### PR TITLE
CDP-1247-1249: update type resolvers to accept args; add createdAt & updatedAt

### DIFF
--- a/prisma/datamodel.prisma
+++ b/prisma/datamodel.prisma
@@ -198,6 +198,7 @@ type ImageFile {
   caption: String
   filename: String
   filetype: String
+  use: ImageUse
   md5: String
   url: String
 }

--- a/prisma/datamodel.prisma
+++ b/prisma/datamodel.prisma
@@ -161,18 +161,18 @@ type Dimensions {
 # Full video,promotional teaser, etc
 type VideoUse {
   id: ID! @unique
-  name: String!
+  name: String! @unique
 }
 
 # thumbnail/cover image, email graphic etc
 type ImageUse {
   id: ID! @unique
-  name: String!
+  name: String! @unique
 }
 
 type SupportFileUse {
   id: ID! @unique
-  name: String!
+  name: String! @unique
 }
 
 type VideoFile {

--- a/prisma/datamodel.prisma
+++ b/prisma/datamodel.prisma
@@ -184,7 +184,7 @@ type VideoFile {
   bitrate: Float
   filesize: Float
   dimensions: Dimensions
-  stream: VideoStream
+  stream: [VideoStream]
 }
 
 type ImageFile {

--- a/prisma/datamodel.prisma
+++ b/prisma/datamodel.prisma
@@ -124,6 +124,7 @@ type VideoProject {
   team: Team
   status: ProjectPublishStatus @default(value: DRAFT)
   visibility: ProjectVisibility # what is default?
+  protectImages: Boolean
   units: [VideoUnit]
   supportFiles: [SupportFile]
   thumbnails: [ImageFile]

--- a/prisma/datamodel.prisma
+++ b/prisma/datamodel.prisma
@@ -134,6 +134,8 @@ type VideoProject {
 
 type VideoUnit {
   id: ID! @unique
+  createdAt: DateTime!
+  updatedAt: DateTime!
   language: Language
   title: String!
   descPublic: String

--- a/prisma/datamodel.prisma
+++ b/prisma/datamodel.prisma
@@ -114,6 +114,8 @@ type Thumbnail {
 
 type VideoProject {
   id: ID! @unique
+  createdAt: DateTime!
+  updatedAt: DateTime!
   projectType: String! # How are the units related? LANGUAGE_TRANSLATION, SERIES, etc
   projectTitle: String!
   descPublic: String
@@ -167,6 +169,8 @@ type ImageUse {
 
 type VideoFile {
   id: ID! @unique
+  createdAt: DateTime!
+  updatedAt: DateTime!
   language: Language
   filetype: String
   filename: String
@@ -184,6 +188,8 @@ type VideoFile {
 
 type ImageFile {
   id: ID! @unique
+  createdAt: DateTime!
+  updatedAt: DateTime!
   language: Language
   dimensions: Dimensions
   alt: String
@@ -197,6 +203,8 @@ type ImageFile {
 
 type SupportFile {
   id: ID! @unique
+  createdAt: DateTime!
+  updatedAt: DateTime!
   language: Language!
   url: String
   md5: String

--- a/prisma/datamodel.prisma
+++ b/prisma/datamodel.prisma
@@ -168,6 +168,11 @@ type ImageUse {
   name: String!
 }
 
+type SupportFileUse {
+  id: ID! @unique
+  name: String!
+}
+
 type VideoFile {
   id: ID! @unique
   createdAt: DateTime!
@@ -213,4 +218,5 @@ type SupportFile {
   filename: String
   filetype: String # srt, pdf
   filesize: Float
+  use: SupportFileUse
 }

--- a/src/resolvers/Video.js
+++ b/src/resolvers/Video.js
@@ -472,89 +472,127 @@ export default {
 
   VideoProject: {
     team( parent, args, ctx ) {
-      return ctx.prisma.videoProject( { id: parent.id } ).team();
+      return ctx.prisma
+        .videoProject( { id: parent.id } )
+        .team( { ...args } );
     },
 
     tags( parent, args, ctx ) {
-      return ctx.prisma.videoProject( { id: parent.id } ).tags();
+      return ctx.prisma
+        .videoProject( { id: parent.id } )
+        .tags( { ...args } );
     },
 
     categories( parent, args, ctx ) {
-      return ctx.prisma.videoProject( { id: parent.id } ).categories();
+      return ctx.prisma
+        .videoProject( { id: parent.id } )
+        .categories( { ...args } );
     },
 
     units( parent, args, ctx ) {
-      return ctx.prisma.videoProject( { id: parent.id } ).units();
+      return ctx.prisma
+        .videoProject( { id: parent.id } )
+        .units( { ...args } );
     },
 
     supportFiles( parent, args, ctx ) {
-      return ctx.prisma.videoProject( { id: parent.id } ).supportFiles();
+      return ctx.prisma
+        .videoProject( { id: parent.id } )
+        .supportFiles( { ...args } );
     },
 
     thumbnails( parent, args, ctx ) {
-      return ctx.prisma.videoProject( { id: parent.id } ).thumbnails();
+      return ctx.prisma
+        .videoProject( { id: parent.id } )
+        .thumbnails( { ...args } );
     },
   },
 
   VideoUnit: {
     language( parent, args, ctx ) {
-      return ctx.prisma.videoUnit( { id: parent.id } ).language();
+      return ctx.prisma
+        .videoUnit( { id: parent.id } )
+        .language( { ...args } );
     },
 
     files( parent, args, ctx ) {
-      return ctx.prisma.videoUnit( { id: parent.id } ).files();
+      return ctx.prisma
+        .videoUnit( { id: parent.id } )
+        .files( { ...args } );
     },
 
     tags( parent, args, ctx ) {
-      return ctx.prisma.videoUnit( { id: parent.id } ).tags();
+      return ctx.prisma
+        .videoUnit( { id: parent.id } )
+        .tags( { ...args } );
     },
 
     categories( parent, args, ctx ) {
-      return ctx.prisma.videoUnit( { id: parent.id } ).categories();
+      return ctx.prisma
+        .videoUnit( { id: parent.id } )
+        .categories( { ...args } );
     },
 
     thumbnails( parent, args, ctx ) {
-      return ctx.prisma.videoUnit( { id: parent.id } ).thumbnails();
+      return ctx.prisma
+        .videoUnit( { id: parent.id } )
+        .thumbnails( { ...args } );
     },
   },
 
   VideoFile: {
     language( parent, args, ctx ) {
-      return ctx.prisma.videoFile( { id: parent.id } ).language();
+      return ctx.prisma
+        .videoFile( { id: parent.id } )
+        .language( { ...args } );
     },
 
     use( parent, args, ctx ) {
-      return ctx.prisma.videoFile( { id: parent.id } ).use();
+      return ctx.prisma
+        .videoFile( { id: parent.id } )
+        .use( { ...args } );
     },
 
     dimensions( parent, args, ctx ) {
-      return ctx.prisma.videoFile( { id: parent.id } ).dimensions();
+      return ctx.prisma
+        .videoFile( { id: parent.id } )
+        .dimensions( { ...args } );
     },
 
     stream( parent, args, ctx ) {
-      return ctx.prisma.videoFile( { id: parent.id } ).stream();
+      return ctx.prisma
+        .videoFile( { id: parent.id } )
+        .stream( { ...args } );
     }
   },
 
   SupportFile: {
     language( parent, args, ctx ) {
-      return ctx.prisma.supportFile( { id: parent.id } ).language();
+      return ctx.prisma
+        .supportFile( { id: parent.id } )
+        .language( { ...args } );
     }
   },
 
   ImageFile: {
     language( parent, args, ctx ) {
-      return ctx.prisma.imageFile( { id: parent.id } ).language();
+      return ctx.prisma
+        .imageFile( { id: parent.id } )
+        .language( { ...args } );
     },
 
     dimensions( parent, args, ctx ) {
-      return ctx.prisma.imageFile( { id: parent.id } ).dimensions();
+      return ctx.prisma
+        .imageFile( { id: parent.id } )
+        .dimensions( { ...args } );
     }
   },
 
   Thumbnail: {
     image( parent, args, ctx ) {
-      return ctx.prisma.thumbnail( { id: parent.id } ).image();
+      return ctx.prisma
+        .thumbnail( { id: parent.id } )
+        .image( { ...args } );
     }
   },
 

--- a/src/schema/generated/prisma-client/index.d.ts
+++ b/src/schema/generated/prisma-client/index.d.ts
@@ -699,6 +699,10 @@ export type VideoQuality = "WEB" | "BROADCAST";
 export type ImageFileOrderByInput =
   | "id_ASC"
   | "id_DESC"
+  | "createdAt_ASC"
+  | "createdAt_DESC"
+  | "updatedAt_ASC"
+  | "updatedAt_DESC"
   | "alt_ASC"
   | "alt_DESC"
   | "longdesc_ASC"
@@ -712,11 +716,7 @@ export type ImageFileOrderByInput =
   | "md5_ASC"
   | "md5_DESC"
   | "url_ASC"
-  | "url_DESC"
-  | "createdAt_ASC"
-  | "createdAt_DESC"
-  | "updatedAt_ASC"
-  | "updatedAt_DESC";
+  | "url_DESC";
 
 export type ThumbnailOrderByInput =
   | "id_ASC"
@@ -743,6 +743,10 @@ export type ThumbnailSize = "SMALL" | "MEDIUM" | "LARGE" | "FULL";
 export type VideoProjectOrderByInput =
   | "id_ASC"
   | "id_DESC"
+  | "createdAt_ASC"
+  | "createdAt_DESC"
+  | "updatedAt_ASC"
+  | "updatedAt_DESC"
   | "projectType_ASC"
   | "projectType_DESC"
   | "projectTitle_ASC"
@@ -756,11 +760,7 @@ export type VideoProjectOrderByInput =
   | "status_ASC"
   | "status_DESC"
   | "visibility_ASC"
-  | "visibility_DESC"
-  | "createdAt_ASC"
-  | "createdAt_DESC"
-  | "updatedAt_ASC"
-  | "updatedAt_DESC";
+  | "visibility_DESC";
 
 export type TeamOrderByInput =
   | "id_ASC"
@@ -897,6 +897,10 @@ export type LanguageOrderByInput =
 export type SupportFileOrderByInput =
   | "id_ASC"
   | "id_DESC"
+  | "createdAt_ASC"
+  | "createdAt_DESC"
+  | "updatedAt_ASC"
+  | "updatedAt_DESC"
   | "url_ASC"
   | "url_DESC"
   | "md5_ASC"
@@ -906,11 +910,7 @@ export type SupportFileOrderByInput =
   | "filetype_ASC"
   | "filetype_DESC"
   | "filesize_ASC"
-  | "filesize_DESC"
-  | "createdAt_ASC"
-  | "createdAt_DESC"
-  | "updatedAt_ASC"
-  | "updatedAt_DESC";
+  | "filesize_DESC";
 
 export type TagOrderByInput =
   | "id_ASC"
@@ -941,6 +941,10 @@ export type VideoBurnedInStatus = "SUBTITLED" | "CAPTIONED" | "CLEAN";
 export type VideoFileOrderByInput =
   | "id_ASC"
   | "id_DESC"
+  | "createdAt_ASC"
+  | "createdAt_DESC"
+  | "updatedAt_ASC"
+  | "updatedAt_DESC"
   | "filetype_ASC"
   | "filetype_DESC"
   | "filename_ASC"
@@ -958,11 +962,7 @@ export type VideoFileOrderByInput =
   | "bitrate_ASC"
   | "bitrate_DESC"
   | "filesize_ASC"
-  | "filesize_DESC"
-  | "createdAt_ASC"
-  | "createdAt_DESC"
-  | "updatedAt_ASC"
-  | "updatedAt_DESC";
+  | "filesize_DESC";
 
 export interface SupportFileCreateInput {
   language: LanguageCreateOneInput;
@@ -976,6 +976,33 @@ export interface SupportFileCreateInput {
 export type CategoryWhereUniqueInput = AtLeastOne<{
   id: ID_Input;
 }>;
+
+export interface VideoUnitUpdateManyInput {
+  create?: VideoUnitCreateInput[] | VideoUnitCreateInput;
+  update?:
+    | VideoUnitUpdateWithWhereUniqueNestedInput[]
+    | VideoUnitUpdateWithWhereUniqueNestedInput;
+  upsert?:
+    | VideoUnitUpsertWithWhereUniqueNestedInput[]
+    | VideoUnitUpsertWithWhereUniqueNestedInput;
+  delete?: VideoUnitWhereUniqueInput[] | VideoUnitWhereUniqueInput;
+  connect?: VideoUnitWhereUniqueInput[] | VideoUnitWhereUniqueInput;
+  disconnect?: VideoUnitWhereUniqueInput[] | VideoUnitWhereUniqueInput;
+  deleteMany?: VideoUnitScalarWhereInput[] | VideoUnitScalarWhereInput;
+  updateMany?:
+    | VideoUnitUpdateManyWithWhereNestedInput[]
+    | VideoUnitUpdateManyWithWhereNestedInput;
+}
+
+export interface ImageFileCreateManyInput {
+  create?: ImageFileCreateInput[] | ImageFileCreateInput;
+  connect?: ImageFileWhereUniqueInput[] | ImageFileWhereUniqueInput;
+}
+
+export interface TeamUpsertNestedInput {
+  update: TeamUpdateDataInput;
+  create: TeamCreateInput;
+}
 
 export interface UserUpdateWithoutTeamDataInput {
   firstName?: String;
@@ -992,214 +1019,36 @@ export interface UserUpdateWithoutTeamDataInput {
   isConfirmed?: Boolean;
 }
 
-export interface ImageFileWhereInput {
-  id?: ID_Input;
-  id_not?: ID_Input;
-  id_in?: ID_Input[] | ID_Input;
-  id_not_in?: ID_Input[] | ID_Input;
-  id_lt?: ID_Input;
-  id_lte?: ID_Input;
-  id_gt?: ID_Input;
-  id_gte?: ID_Input;
-  id_contains?: ID_Input;
-  id_not_contains?: ID_Input;
-  id_starts_with?: ID_Input;
-  id_not_starts_with?: ID_Input;
-  id_ends_with?: ID_Input;
-  id_not_ends_with?: ID_Input;
-  language?: LanguageWhereInput;
-  dimensions?: DimensionsWhereInput;
-  alt?: String;
-  alt_not?: String;
-  alt_in?: String[] | String;
-  alt_not_in?: String[] | String;
-  alt_lt?: String;
-  alt_lte?: String;
-  alt_gt?: String;
-  alt_gte?: String;
-  alt_contains?: String;
-  alt_not_contains?: String;
-  alt_starts_with?: String;
-  alt_not_starts_with?: String;
-  alt_ends_with?: String;
-  alt_not_ends_with?: String;
-  longdesc?: String;
-  longdesc_not?: String;
-  longdesc_in?: String[] | String;
-  longdesc_not_in?: String[] | String;
-  longdesc_lt?: String;
-  longdesc_lte?: String;
-  longdesc_gt?: String;
-  longdesc_gte?: String;
-  longdesc_contains?: String;
-  longdesc_not_contains?: String;
-  longdesc_starts_with?: String;
-  longdesc_not_starts_with?: String;
-  longdesc_ends_with?: String;
-  longdesc_not_ends_with?: String;
-  caption?: String;
-  caption_not?: String;
-  caption_in?: String[] | String;
-  caption_not_in?: String[] | String;
-  caption_lt?: String;
-  caption_lte?: String;
-  caption_gt?: String;
-  caption_gte?: String;
-  caption_contains?: String;
-  caption_not_contains?: String;
-  caption_starts_with?: String;
-  caption_not_starts_with?: String;
-  caption_ends_with?: String;
-  caption_not_ends_with?: String;
-  filename?: String;
-  filename_not?: String;
-  filename_in?: String[] | String;
-  filename_not_in?: String[] | String;
-  filename_lt?: String;
-  filename_lte?: String;
-  filename_gt?: String;
-  filename_gte?: String;
-  filename_contains?: String;
-  filename_not_contains?: String;
-  filename_starts_with?: String;
-  filename_not_starts_with?: String;
-  filename_ends_with?: String;
-  filename_not_ends_with?: String;
-  filetype?: String;
-  filetype_not?: String;
-  filetype_in?: String[] | String;
-  filetype_not_in?: String[] | String;
-  filetype_lt?: String;
-  filetype_lte?: String;
-  filetype_gt?: String;
-  filetype_gte?: String;
-  filetype_contains?: String;
-  filetype_not_contains?: String;
-  filetype_starts_with?: String;
-  filetype_not_starts_with?: String;
-  filetype_ends_with?: String;
-  filetype_not_ends_with?: String;
-  md5?: String;
-  md5_not?: String;
-  md5_in?: String[] | String;
-  md5_not_in?: String[] | String;
-  md5_lt?: String;
-  md5_lte?: String;
-  md5_gt?: String;
-  md5_gte?: String;
-  md5_contains?: String;
-  md5_not_contains?: String;
-  md5_starts_with?: String;
-  md5_not_starts_with?: String;
-  md5_ends_with?: String;
-  md5_not_ends_with?: String;
-  url?: String;
-  url_not?: String;
-  url_in?: String[] | String;
-  url_not_in?: String[] | String;
-  url_lt?: String;
-  url_lte?: String;
-  url_gt?: String;
-  url_gte?: String;
-  url_contains?: String;
-  url_not_contains?: String;
-  url_starts_with?: String;
-  url_not_starts_with?: String;
-  url_ends_with?: String;
-  url_not_ends_with?: String;
-  AND?: ImageFileWhereInput[] | ImageFileWhereInput;
-  OR?: ImageFileWhereInput[] | ImageFileWhereInput;
-  NOT?: ImageFileWhereInput[] | ImageFileWhereInput;
-}
-
-export interface VideoProjectUpdateInput {
-  projectType?: String;
-  projectTitle?: String;
-  descPublic?: String;
-  descInternal?: String;
-  author?: String;
-  team?: TeamUpdateOneInput;
-  status?: ProjectPublishStatus;
-  visibility?: ProjectVisibility;
-  units?: VideoUnitUpdateManyInput;
-  supportFiles?: SupportFileUpdateManyInput;
-  thumbnails?: ImageFileUpdateManyInput;
-  categories?: CategoryUpdateManyInput;
-  tags?: TagUpdateManyInput;
-}
-
-export interface UserUpdatepermissionsInput {
-  set?: Permission[] | Permission;
-}
-
-export interface CategoryCreateInput {
-  translations?: LanguageTranslationCreateManyInput;
-}
-
-export type ImageUseWhereUniqueInput = AtLeastOne<{
-  id: ID_Input;
-}>;
-
-export interface LanguageTranslationCreateManyInput {
-  create?: LanguageTranslationCreateInput[] | LanguageTranslationCreateInput;
-  connect?:
-    | LanguageTranslationWhereUniqueInput[]
-    | LanguageTranslationWhereUniqueInput;
-}
-
-export interface ImageUseWhereInput {
-  id?: ID_Input;
-  id_not?: ID_Input;
-  id_in?: ID_Input[] | ID_Input;
-  id_not_in?: ID_Input[] | ID_Input;
-  id_lt?: ID_Input;
-  id_lte?: ID_Input;
-  id_gt?: ID_Input;
-  id_gte?: ID_Input;
-  id_contains?: ID_Input;
-  id_not_contains?: ID_Input;
-  id_starts_with?: ID_Input;
-  id_not_starts_with?: ID_Input;
-  id_ends_with?: ID_Input;
-  id_not_ends_with?: ID_Input;
-  name?: String;
-  name_not?: String;
-  name_in?: String[] | String;
-  name_not_in?: String[] | String;
-  name_lt?: String;
-  name_lte?: String;
-  name_gt?: String;
-  name_gte?: String;
-  name_contains?: String;
-  name_not_contains?: String;
-  name_starts_with?: String;
-  name_not_starts_with?: String;
-  name_ends_with?: String;
-  name_not_ends_with?: String;
-  AND?: ImageUseWhereInput[] | ImageUseWhereInput;
-  OR?: ImageUseWhereInput[] | ImageUseWhereInput;
-  NOT?: ImageUseWhereInput[] | ImageUseWhereInput;
-}
-
-export interface LanguageTranslationCreateInput {
-  name: String;
-  language: LanguageCreateOneInput;
-}
-
-export interface VideoStreamSubscriptionWhereInput {
+export interface VideoUnitSubscriptionWhereInput {
   mutation_in?: MutationType[] | MutationType;
   updatedFields_contains?: String;
   updatedFields_contains_every?: String[] | String;
   updatedFields_contains_some?: String[] | String;
-  node?: VideoStreamWhereInput;
-  AND?: VideoStreamSubscriptionWhereInput[] | VideoStreamSubscriptionWhereInput;
-  OR?: VideoStreamSubscriptionWhereInput[] | VideoStreamSubscriptionWhereInput;
-  NOT?: VideoStreamSubscriptionWhereInput[] | VideoStreamSubscriptionWhereInput;
+  node?: VideoUnitWhereInput;
+  AND?: VideoUnitSubscriptionWhereInput[] | VideoUnitSubscriptionWhereInput;
+  OR?: VideoUnitSubscriptionWhereInput[] | VideoUnitSubscriptionWhereInput;
+  NOT?: VideoUnitSubscriptionWhereInput[] | VideoUnitSubscriptionWhereInput;
 }
 
-export interface LanguageCreateOneInput {
-  create?: LanguageCreateInput;
-  connect?: LanguageWhereUniqueInput;
+export interface VideoProjectSubscriptionWhereInput {
+  mutation_in?: MutationType[] | MutationType;
+  updatedFields_contains?: String;
+  updatedFields_contains_every?: String[] | String;
+  updatedFields_contains_some?: String[] | String;
+  node?: VideoProjectWhereInput;
+  AND?:
+    | VideoProjectSubscriptionWhereInput[]
+    | VideoProjectSubscriptionWhereInput;
+  OR?:
+    | VideoProjectSubscriptionWhereInput[]
+    | VideoProjectSubscriptionWhereInput;
+  NOT?:
+    | VideoProjectSubscriptionWhereInput[]
+    | VideoProjectSubscriptionWhereInput;
+}
+
+export interface CategoryCreateInput {
+  translations?: LanguageTranslationCreateManyInput;
 }
 
 export interface VideoFileSubscriptionWhereInput {
@@ -1213,6 +1062,43 @@ export interface VideoFileSubscriptionWhereInput {
   NOT?: VideoFileSubscriptionWhereInput[] | VideoFileSubscriptionWhereInput;
 }
 
+export interface LanguageTranslationCreateManyInput {
+  create?: LanguageTranslationCreateInput[] | LanguageTranslationCreateInput;
+  connect?:
+    | LanguageTranslationWhereUniqueInput[]
+    | LanguageTranslationWhereUniqueInput;
+}
+
+export type ImageFileWhereUniqueInput = AtLeastOne<{
+  id: ID_Input;
+}>;
+
+export interface LanguageTranslationCreateInput {
+  name: String;
+  language: LanguageCreateOneInput;
+}
+
+export interface ThumbnailSubscriptionWhereInput {
+  mutation_in?: MutationType[] | MutationType;
+  updatedFields_contains?: String;
+  updatedFields_contains_every?: String[] | String;
+  updatedFields_contains_some?: String[] | String;
+  node?: ThumbnailWhereInput;
+  AND?: ThumbnailSubscriptionWhereInput[] | ThumbnailSubscriptionWhereInput;
+  OR?: ThumbnailSubscriptionWhereInput[] | ThumbnailSubscriptionWhereInput;
+  NOT?: ThumbnailSubscriptionWhereInput[] | ThumbnailSubscriptionWhereInput;
+}
+
+export interface LanguageCreateOneInput {
+  create?: LanguageCreateInput;
+  connect?: LanguageWhereUniqueInput;
+}
+
+export type LanguageWhereUniqueInput = AtLeastOne<{
+  id: ID_Input;
+  locale?: String;
+}>;
+
 export interface LanguageCreateInput {
   languageCode: String;
   locale: String;
@@ -1221,30 +1107,30 @@ export interface LanguageCreateInput {
   nativeName: String;
 }
 
-export interface UserSubscriptionWhereInput {
+export interface SupportFileSubscriptionWhereInput {
   mutation_in?: MutationType[] | MutationType;
   updatedFields_contains?: String;
   updatedFields_contains_every?: String[] | String;
   updatedFields_contains_some?: String[] | String;
-  node?: UserWhereInput;
-  AND?: UserSubscriptionWhereInput[] | UserSubscriptionWhereInput;
-  OR?: UserSubscriptionWhereInput[] | UserSubscriptionWhereInput;
-  NOT?: UserSubscriptionWhereInput[] | UserSubscriptionWhereInput;
+  node?: SupportFileWhereInput;
+  AND?: SupportFileSubscriptionWhereInput[] | SupportFileSubscriptionWhereInput;
+  OR?: SupportFileSubscriptionWhereInput[] | SupportFileSubscriptionWhereInput;
+  NOT?: SupportFileSubscriptionWhereInput[] | SupportFileSubscriptionWhereInput;
 }
 
 export interface CategoryUpdateInput {
   translations?: LanguageTranslationUpdateManyInput;
 }
 
-export interface TeamSubscriptionWhereInput {
+export interface LanguageSubscriptionWhereInput {
   mutation_in?: MutationType[] | MutationType;
   updatedFields_contains?: String;
   updatedFields_contains_every?: String[] | String;
   updatedFields_contains_some?: String[] | String;
-  node?: TeamWhereInput;
-  AND?: TeamSubscriptionWhereInput[] | TeamSubscriptionWhereInput;
-  OR?: TeamSubscriptionWhereInput[] | TeamSubscriptionWhereInput;
-  NOT?: TeamSubscriptionWhereInput[] | TeamSubscriptionWhereInput;
+  node?: LanguageWhereInput;
+  AND?: LanguageSubscriptionWhereInput[] | LanguageSubscriptionWhereInput;
+  OR?: LanguageSubscriptionWhereInput[] | LanguageSubscriptionWhereInput;
+  NOT?: LanguageSubscriptionWhereInput[] | LanguageSubscriptionWhereInput;
 }
 
 export interface LanguageTranslationUpdateManyInput {
@@ -1272,65 +1158,20 @@ export interface LanguageTranslationUpdateManyInput {
     | LanguageTranslationUpdateManyWithWhereNestedInput;
 }
 
-export type LanguageTranslationWhereUniqueInput = AtLeastOne<{
-  id: ID_Input;
-}>;
+export interface ImageUseSubscriptionWhereInput {
+  mutation_in?: MutationType[] | MutationType;
+  updatedFields_contains?: String;
+  updatedFields_contains_every?: String[] | String;
+  updatedFields_contains_some?: String[] | String;
+  node?: ImageUseWhereInput;
+  AND?: ImageUseSubscriptionWhereInput[] | ImageUseSubscriptionWhereInput;
+  OR?: ImageUseSubscriptionWhereInput[] | ImageUseSubscriptionWhereInput;
+  NOT?: ImageUseSubscriptionWhereInput[] | ImageUseSubscriptionWhereInput;
+}
 
 export interface LanguageTranslationUpdateWithWhereUniqueNestedInput {
   where: LanguageTranslationWhereUniqueInput;
   data: LanguageTranslationUpdateDataInput;
-}
-
-export interface LanguageTranslationSubscriptionWhereInput {
-  mutation_in?: MutationType[] | MutationType;
-  updatedFields_contains?: String;
-  updatedFields_contains_every?: String[] | String;
-  updatedFields_contains_some?: String[] | String;
-  node?: LanguageTranslationWhereInput;
-  AND?:
-    | LanguageTranslationSubscriptionWhereInput[]
-    | LanguageTranslationSubscriptionWhereInput;
-  OR?:
-    | LanguageTranslationSubscriptionWhereInput[]
-    | LanguageTranslationSubscriptionWhereInput;
-  NOT?:
-    | LanguageTranslationSubscriptionWhereInput[]
-    | LanguageTranslationSubscriptionWhereInput;
-}
-
-export interface LanguageTranslationUpdateDataInput {
-  name?: String;
-  language?: LanguageUpdateOneRequiredInput;
-}
-
-export type SupportFileWhereUniqueInput = AtLeastOne<{
-  id: ID_Input;
-}>;
-
-export interface LanguageUpdateOneRequiredInput {
-  create?: LanguageCreateInput;
-  update?: LanguageUpdateDataInput;
-  upsert?: LanguageUpsertNestedInput;
-  connect?: LanguageWhereUniqueInput;
-}
-
-export interface ImageFileSubscriptionWhereInput {
-  mutation_in?: MutationType[] | MutationType;
-  updatedFields_contains?: String;
-  updatedFields_contains_every?: String[] | String;
-  updatedFields_contains_some?: String[] | String;
-  node?: ImageFileWhereInput;
-  AND?: ImageFileSubscriptionWhereInput[] | ImageFileSubscriptionWhereInput;
-  OR?: ImageFileSubscriptionWhereInput[] | ImageFileSubscriptionWhereInput;
-  NOT?: ImageFileSubscriptionWhereInput[] | ImageFileSubscriptionWhereInput;
-}
-
-export interface LanguageUpdateDataInput {
-  languageCode?: String;
-  locale?: String;
-  textDirection?: String;
-  displayName?: String;
-  nativeName?: String;
 }
 
 export interface DimensionsSubscriptionWhereInput {
@@ -1344,1222 +1185,27 @@ export interface DimensionsSubscriptionWhereInput {
   NOT?: DimensionsSubscriptionWhereInput[] | DimensionsSubscriptionWhereInput;
 }
 
-export interface LanguageUpsertNestedInput {
-  update: LanguageUpdateDataInput;
-  create: LanguageCreateInput;
-}
-
-export interface VideoUseUpdateManyMutationInput {
+export interface LanguageTranslationUpdateDataInput {
   name?: String;
+  language?: LanguageUpdateOneRequiredInput;
 }
 
-export interface LanguageTranslationUpsertWithWhereUniqueNestedInput {
-  where: LanguageTranslationWhereUniqueInput;
-  update: LanguageTranslationUpdateDataInput;
-  create: LanguageTranslationCreateInput;
+export interface CategorySubscriptionWhereInput {
+  mutation_in?: MutationType[] | MutationType;
+  updatedFields_contains?: String;
+  updatedFields_contains_every?: String[] | String;
+  updatedFields_contains_some?: String[] | String;
+  node?: CategoryWhereInput;
+  AND?: CategorySubscriptionWhereInput[] | CategorySubscriptionWhereInput;
+  OR?: CategorySubscriptionWhereInput[] | CategorySubscriptionWhereInput;
+  NOT?: CategorySubscriptionWhereInput[] | CategorySubscriptionWhereInput;
 }
 
-export type TagWhereUniqueInput = AtLeastOne<{
-  id: ID_Input;
-}>;
-
-export interface LanguageTranslationScalarWhereInput {
-  id?: ID_Input;
-  id_not?: ID_Input;
-  id_in?: ID_Input[] | ID_Input;
-  id_not_in?: ID_Input[] | ID_Input;
-  id_lt?: ID_Input;
-  id_lte?: ID_Input;
-  id_gt?: ID_Input;
-  id_gte?: ID_Input;
-  id_contains?: ID_Input;
-  id_not_contains?: ID_Input;
-  id_starts_with?: ID_Input;
-  id_not_starts_with?: ID_Input;
-  id_ends_with?: ID_Input;
-  id_not_ends_with?: ID_Input;
-  name?: String;
-  name_not?: String;
-  name_in?: String[] | String;
-  name_not_in?: String[] | String;
-  name_lt?: String;
-  name_lte?: String;
-  name_gt?: String;
-  name_gte?: String;
-  name_contains?: String;
-  name_not_contains?: String;
-  name_starts_with?: String;
-  name_not_starts_with?: String;
-  name_ends_with?: String;
-  name_not_ends_with?: String;
-  AND?:
-    | LanguageTranslationScalarWhereInput[]
-    | LanguageTranslationScalarWhereInput;
-  OR?:
-    | LanguageTranslationScalarWhereInput[]
-    | LanguageTranslationScalarWhereInput;
-  NOT?:
-    | LanguageTranslationScalarWhereInput[]
-    | LanguageTranslationScalarWhereInput;
-}
-
-export interface TagWhereInput {
-  id?: ID_Input;
-  id_not?: ID_Input;
-  id_in?: ID_Input[] | ID_Input;
-  id_not_in?: ID_Input[] | ID_Input;
-  id_lt?: ID_Input;
-  id_lte?: ID_Input;
-  id_gt?: ID_Input;
-  id_gte?: ID_Input;
-  id_contains?: ID_Input;
-  id_not_contains?: ID_Input;
-  id_starts_with?: ID_Input;
-  id_not_starts_with?: ID_Input;
-  id_ends_with?: ID_Input;
-  id_not_ends_with?: ID_Input;
-  translations_every?: LanguageTranslationWhereInput;
-  translations_some?: LanguageTranslationWhereInput;
-  translations_none?: LanguageTranslationWhereInput;
-  AND?: TagWhereInput[] | TagWhereInput;
-  OR?: TagWhereInput[] | TagWhereInput;
-  NOT?: TagWhereInput[] | TagWhereInput;
-}
-
-export interface LanguageTranslationUpdateManyWithWhereNestedInput {
-  where: LanguageTranslationScalarWhereInput;
-  data: LanguageTranslationUpdateManyDataInput;
-}
-
-export interface VideoStreamUpdateManyMutationInput {
-  site?: String;
-  url?: String;
-  embedUrl?: String;
-}
-
-export interface LanguageTranslationUpdateManyDataInput {
-  name?: String;
-}
-
-export interface VideoProjectUpdateManyMutationInput {
-  projectType?: String;
-  projectTitle?: String;
-  descPublic?: String;
-  descInternal?: String;
-  author?: String;
-  status?: ProjectPublishStatus;
-  visibility?: ProjectVisibility;
-}
-
-export interface VideoUnitUpdateWithWhereUniqueNestedInput {
-  where: VideoUnitWhereUniqueInput;
-  data: VideoUnitUpdateDataInput;
-}
-
-export interface ImageFileUpdateManyDataInput {
-  alt?: String;
-  longdesc?: String;
-  caption?: String;
-  filename?: String;
-  filetype?: String;
-  md5?: String;
-  url?: String;
-}
-
-export interface VideoUnitUpdateManyInput {
-  create?: VideoUnitCreateInput[] | VideoUnitCreateInput;
-  update?:
-    | VideoUnitUpdateWithWhereUniqueNestedInput[]
-    | VideoUnitUpdateWithWhereUniqueNestedInput;
-  upsert?:
-    | VideoUnitUpsertWithWhereUniqueNestedInput[]
-    | VideoUnitUpsertWithWhereUniqueNestedInput;
-  delete?: VideoUnitWhereUniqueInput[] | VideoUnitWhereUniqueInput;
-  connect?: VideoUnitWhereUniqueInput[] | VideoUnitWhereUniqueInput;
-  disconnect?: VideoUnitWhereUniqueInput[] | VideoUnitWhereUniqueInput;
-  deleteMany?: VideoUnitScalarWhereInput[] | VideoUnitScalarWhereInput;
-  updateMany?:
-    | VideoUnitUpdateManyWithWhereNestedInput[]
-    | VideoUnitUpdateManyWithWhereNestedInput;
-}
-
-export interface TeamWhereInput {
-  id?: ID_Input;
-  id_not?: ID_Input;
-  id_in?: ID_Input[] | ID_Input;
-  id_not_in?: ID_Input[] | ID_Input;
-  id_lt?: ID_Input;
-  id_lte?: ID_Input;
-  id_gt?: ID_Input;
-  id_gte?: ID_Input;
-  id_contains?: ID_Input;
-  id_not_contains?: ID_Input;
-  id_starts_with?: ID_Input;
-  id_not_starts_with?: ID_Input;
-  id_ends_with?: ID_Input;
-  id_not_ends_with?: ID_Input;
-  name?: String;
-  name_not?: String;
-  name_in?: String[] | String;
-  name_not_in?: String[] | String;
-  name_lt?: String;
-  name_lte?: String;
-  name_gt?: String;
-  name_gte?: String;
-  name_contains?: String;
-  name_not_contains?: String;
-  name_starts_with?: String;
-  name_not_starts_with?: String;
-  name_ends_with?: String;
-  name_not_ends_with?: String;
-  organization?: String;
-  organization_not?: String;
-  organization_in?: String[] | String;
-  organization_not_in?: String[] | String;
-  organization_lt?: String;
-  organization_lte?: String;
-  organization_gt?: String;
-  organization_gte?: String;
-  organization_contains?: String;
-  organization_not_contains?: String;
-  organization_starts_with?: String;
-  organization_not_starts_with?: String;
-  organization_ends_with?: String;
-  organization_not_ends_with?: String;
-  members_every?: UserWhereInput;
-  members_some?: UserWhereInput;
-  members_none?: UserWhereInput;
-  isConfirmed?: Boolean;
-  isConfirmed_not?: Boolean;
-  AND?: TeamWhereInput[] | TeamWhereInput;
-  OR?: TeamWhereInput[] | TeamWhereInput;
-  NOT?: TeamWhereInput[] | TeamWhereInput;
-}
-
-export interface DimensionsCreateInput {
-  width?: Int;
-  height?: Int;
-}
-
-export interface ImageFileUpdateManyWithWhereNestedInput {
-  where: ImageFileScalarWhereInput;
-  data: ImageFileUpdateManyDataInput;
-}
-
-export interface DimensionsUpdateInput {
-  width?: Int;
-  height?: Int;
-}
-
-export type DimensionsWhereUniqueInput = AtLeastOne<{
-  id: ID_Input;
-}>;
-
-export interface DimensionsUpdateManyMutationInput {
-  width?: Int;
-  height?: Int;
-}
-
-export interface ImageFileUpdateWithWhereUniqueNestedInput {
-  where: ImageFileWhereUniqueInput;
-  data: ImageFileUpdateDataInput;
-}
-
-export interface ImageFileCreateInput {
-  language?: LanguageCreateOneInput;
-  dimensions?: DimensionsCreateOneInput;
-  alt?: String;
-  longdesc?: String;
-  caption?: String;
-  filename?: String;
-  filetype?: String;
-  md5?: String;
-  url?: String;
-}
-
-export interface SupportFileUpdateManyDataInput {
-  url?: String;
-  md5?: String;
-  filename?: String;
-  filetype?: String;
-  filesize?: Float;
-}
-
-export interface DimensionsCreateOneInput {
-  create?: DimensionsCreateInput;
-  connect?: DimensionsWhereUniqueInput;
-}
-
-export interface SupportFileUpdateManyWithWhereNestedInput {
-  where: SupportFileScalarWhereInput;
-  data: SupportFileUpdateManyDataInput;
-}
-
-export interface ImageFileUpdateInput {
-  language?: LanguageUpdateOneInput;
-  dimensions?: DimensionsUpdateOneInput;
-  alt?: String;
-  longdesc?: String;
-  caption?: String;
-  filename?: String;
-  filetype?: String;
-  md5?: String;
-  url?: String;
-}
-
-export interface ThumbnailWhereInput {
-  id?: ID_Input;
-  id_not?: ID_Input;
-  id_in?: ID_Input[] | ID_Input;
-  id_not_in?: ID_Input[] | ID_Input;
-  id_lt?: ID_Input;
-  id_lte?: ID_Input;
-  id_gt?: ID_Input;
-  id_gte?: ID_Input;
-  id_contains?: ID_Input;
-  id_not_contains?: ID_Input;
-  id_starts_with?: ID_Input;
-  id_not_starts_with?: ID_Input;
-  id_ends_with?: ID_Input;
-  id_not_ends_with?: ID_Input;
-  size?: ThumbnailSize;
-  size_not?: ThumbnailSize;
-  size_in?: ThumbnailSize[] | ThumbnailSize;
-  size_not_in?: ThumbnailSize[] | ThumbnailSize;
-  image?: ImageFileWhereInput;
-  AND?: ThumbnailWhereInput[] | ThumbnailWhereInput;
-  OR?: ThumbnailWhereInput[] | ThumbnailWhereInput;
-  NOT?: ThumbnailWhereInput[] | ThumbnailWhereInput;
-}
-
-export interface LanguageUpdateOneInput {
+export interface LanguageUpdateOneRequiredInput {
   create?: LanguageCreateInput;
   update?: LanguageUpdateDataInput;
   upsert?: LanguageUpsertNestedInput;
-  delete?: Boolean;
-  disconnect?: Boolean;
   connect?: LanguageWhereUniqueInput;
-}
-
-export interface SupportFileUpdateDataInput {
-  language?: LanguageUpdateOneRequiredInput;
-  url?: String;
-  md5?: String;
-  filename?: String;
-  filetype?: String;
-  filesize?: Float;
-}
-
-export interface DimensionsUpdateOneInput {
-  create?: DimensionsCreateInput;
-  update?: DimensionsUpdateDataInput;
-  upsert?: DimensionsUpsertNestedInput;
-  delete?: Boolean;
-  disconnect?: Boolean;
-  connect?: DimensionsWhereUniqueInput;
-}
-
-export interface SupportFileUpdateManyInput {
-  create?: SupportFileCreateInput[] | SupportFileCreateInput;
-  update?:
-    | SupportFileUpdateWithWhereUniqueNestedInput[]
-    | SupportFileUpdateWithWhereUniqueNestedInput;
-  upsert?:
-    | SupportFileUpsertWithWhereUniqueNestedInput[]
-    | SupportFileUpsertWithWhereUniqueNestedInput;
-  delete?: SupportFileWhereUniqueInput[] | SupportFileWhereUniqueInput;
-  connect?: SupportFileWhereUniqueInput[] | SupportFileWhereUniqueInput;
-  disconnect?: SupportFileWhereUniqueInput[] | SupportFileWhereUniqueInput;
-  deleteMany?: SupportFileScalarWhereInput[] | SupportFileScalarWhereInput;
-  updateMany?:
-    | SupportFileUpdateManyWithWhereNestedInput[]
-    | SupportFileUpdateManyWithWhereNestedInput;
-}
-
-export interface DimensionsUpdateDataInput {
-  width?: Int;
-  height?: Int;
-}
-
-export interface VideoUnitUpdateManyDataInput {
-  title?: String;
-  descPublic?: String;
-}
-
-export interface DimensionsUpsertNestedInput {
-  update: DimensionsUpdateDataInput;
-  create: DimensionsCreateInput;
-}
-
-export interface VideoUnitScalarWhereInput {
-  id?: ID_Input;
-  id_not?: ID_Input;
-  id_in?: ID_Input[] | ID_Input;
-  id_not_in?: ID_Input[] | ID_Input;
-  id_lt?: ID_Input;
-  id_lte?: ID_Input;
-  id_gt?: ID_Input;
-  id_gte?: ID_Input;
-  id_contains?: ID_Input;
-  id_not_contains?: ID_Input;
-  id_starts_with?: ID_Input;
-  id_not_starts_with?: ID_Input;
-  id_ends_with?: ID_Input;
-  id_not_ends_with?: ID_Input;
-  title?: String;
-  title_not?: String;
-  title_in?: String[] | String;
-  title_not_in?: String[] | String;
-  title_lt?: String;
-  title_lte?: String;
-  title_gt?: String;
-  title_gte?: String;
-  title_contains?: String;
-  title_not_contains?: String;
-  title_starts_with?: String;
-  title_not_starts_with?: String;
-  title_ends_with?: String;
-  title_not_ends_with?: String;
-  descPublic?: String;
-  descPublic_not?: String;
-  descPublic_in?: String[] | String;
-  descPublic_not_in?: String[] | String;
-  descPublic_lt?: String;
-  descPublic_lte?: String;
-  descPublic_gt?: String;
-  descPublic_gte?: String;
-  descPublic_contains?: String;
-  descPublic_not_contains?: String;
-  descPublic_starts_with?: String;
-  descPublic_not_starts_with?: String;
-  descPublic_ends_with?: String;
-  descPublic_not_ends_with?: String;
-  AND?: VideoUnitScalarWhereInput[] | VideoUnitScalarWhereInput;
-  OR?: VideoUnitScalarWhereInput[] | VideoUnitScalarWhereInput;
-  NOT?: VideoUnitScalarWhereInput[] | VideoUnitScalarWhereInput;
-}
-
-export interface ImageFileUpdateManyMutationInput {
-  alt?: String;
-  longdesc?: String;
-  caption?: String;
-  filename?: String;
-  filetype?: String;
-  md5?: String;
-  url?: String;
-}
-
-export interface VideoUnitUpsertWithWhereUniqueNestedInput {
-  where: VideoUnitWhereUniqueInput;
-  update: VideoUnitUpdateDataInput;
-  create: VideoUnitCreateInput;
-}
-
-export interface ImageUseCreateInput {
-  name: String;
-}
-
-export interface ThumbnailUpdateManyWithWhereNestedInput {
-  where: ThumbnailScalarWhereInput;
-  data: ThumbnailUpdateManyDataInput;
-}
-
-export interface ImageUseUpdateInput {
-  name?: String;
-}
-
-export interface ThumbnailUpsertWithWhereUniqueNestedInput {
-  where: ThumbnailWhereUniqueInput;
-  update: ThumbnailUpdateDataInput;
-  create: ThumbnailCreateInput;
-}
-
-export interface ImageUseUpdateManyMutationInput {
-  name?: String;
-}
-
-export interface VideoUseWhereInput {
-  id?: ID_Input;
-  id_not?: ID_Input;
-  id_in?: ID_Input[] | ID_Input;
-  id_not_in?: ID_Input[] | ID_Input;
-  id_lt?: ID_Input;
-  id_lte?: ID_Input;
-  id_gt?: ID_Input;
-  id_gte?: ID_Input;
-  id_contains?: ID_Input;
-  id_not_contains?: ID_Input;
-  id_starts_with?: ID_Input;
-  id_not_starts_with?: ID_Input;
-  id_ends_with?: ID_Input;
-  id_not_ends_with?: ID_Input;
-  name?: String;
-  name_not?: String;
-  name_in?: String[] | String;
-  name_not_in?: String[] | String;
-  name_lt?: String;
-  name_lte?: String;
-  name_gt?: String;
-  name_gte?: String;
-  name_contains?: String;
-  name_not_contains?: String;
-  name_starts_with?: String;
-  name_not_starts_with?: String;
-  name_ends_with?: String;
-  name_not_ends_with?: String;
-  AND?: VideoUseWhereInput[] | VideoUseWhereInput;
-  OR?: VideoUseWhereInput[] | VideoUseWhereInput;
-  NOT?: VideoUseWhereInput[] | VideoUseWhereInput;
-}
-
-export interface LanguageUpdateInput {
-  languageCode?: String;
-  locale?: String;
-  textDirection?: String;
-  displayName?: String;
-  nativeName?: String;
-}
-
-export interface CategoryWhereInput {
-  id?: ID_Input;
-  id_not?: ID_Input;
-  id_in?: ID_Input[] | ID_Input;
-  id_not_in?: ID_Input[] | ID_Input;
-  id_lt?: ID_Input;
-  id_lte?: ID_Input;
-  id_gt?: ID_Input;
-  id_gte?: ID_Input;
-  id_contains?: ID_Input;
-  id_not_contains?: ID_Input;
-  id_starts_with?: ID_Input;
-  id_not_starts_with?: ID_Input;
-  id_ends_with?: ID_Input;
-  id_not_ends_with?: ID_Input;
-  translations_every?: LanguageTranslationWhereInput;
-  translations_some?: LanguageTranslationWhereInput;
-  translations_none?: LanguageTranslationWhereInput;
-  AND?: CategoryWhereInput[] | CategoryWhereInput;
-  OR?: CategoryWhereInput[] | CategoryWhereInput;
-  NOT?: CategoryWhereInput[] | CategoryWhereInput;
-}
-
-export interface LanguageUpdateManyMutationInput {
-  languageCode?: String;
-  locale?: String;
-  textDirection?: String;
-  displayName?: String;
-  nativeName?: String;
-}
-
-export interface ThumbnailUpdateWithWhereUniqueNestedInput {
-  where: ThumbnailWhereUniqueInput;
-  data: ThumbnailUpdateDataInput;
-}
-
-export interface LanguageTranslationUpdateInput {
-  name?: String;
-  language?: LanguageUpdateOneRequiredInput;
-}
-
-export type VideoProjectWhereUniqueInput = AtLeastOne<{
-  id: ID_Input;
-}>;
-
-export interface LanguageTranslationUpdateManyMutationInput {
-  name?: String;
-}
-
-export interface CategoryUpsertWithWhereUniqueNestedInput {
-  where: CategoryWhereUniqueInput;
-  update: CategoryUpdateDataInput;
-  create: CategoryCreateInput;
-}
-
-export interface TeamUpsertNestedInput {
-  update: TeamUpdateDataInput;
-  create: TeamCreateInput;
-}
-
-export interface VideoUnitWhereInput {
-  id?: ID_Input;
-  id_not?: ID_Input;
-  id_in?: ID_Input[] | ID_Input;
-  id_not_in?: ID_Input[] | ID_Input;
-  id_lt?: ID_Input;
-  id_lte?: ID_Input;
-  id_gt?: ID_Input;
-  id_gte?: ID_Input;
-  id_contains?: ID_Input;
-  id_not_contains?: ID_Input;
-  id_starts_with?: ID_Input;
-  id_not_starts_with?: ID_Input;
-  id_ends_with?: ID_Input;
-  id_not_ends_with?: ID_Input;
-  language?: LanguageWhereInput;
-  title?: String;
-  title_not?: String;
-  title_in?: String[] | String;
-  title_not_in?: String[] | String;
-  title_lt?: String;
-  title_lte?: String;
-  title_gt?: String;
-  title_gte?: String;
-  title_contains?: String;
-  title_not_contains?: String;
-  title_starts_with?: String;
-  title_not_starts_with?: String;
-  title_ends_with?: String;
-  title_not_ends_with?: String;
-  descPublic?: String;
-  descPublic_not?: String;
-  descPublic_in?: String[] | String;
-  descPublic_not_in?: String[] | String;
-  descPublic_lt?: String;
-  descPublic_lte?: String;
-  descPublic_gt?: String;
-  descPublic_gte?: String;
-  descPublic_contains?: String;
-  descPublic_not_contains?: String;
-  descPublic_starts_with?: String;
-  descPublic_not_starts_with?: String;
-  descPublic_ends_with?: String;
-  descPublic_not_ends_with?: String;
-  files_every?: VideoFileWhereInput;
-  files_some?: VideoFileWhereInput;
-  files_none?: VideoFileWhereInput;
-  tags_every?: TagWhereInput;
-  tags_some?: TagWhereInput;
-  tags_none?: TagWhereInput;
-  categories_every?: CategoryWhereInput;
-  categories_some?: CategoryWhereInput;
-  categories_none?: CategoryWhereInput;
-  thumbnails_every?: ThumbnailWhereInput;
-  thumbnails_some?: ThumbnailWhereInput;
-  thumbnails_none?: ThumbnailWhereInput;
-  AND?: VideoUnitWhereInput[] | VideoUnitWhereInput;
-  OR?: VideoUnitWhereInput[] | VideoUnitWhereInput;
-  NOT?: VideoUnitWhereInput[] | VideoUnitWhereInput;
-}
-
-export interface SupportFileUpdateInput {
-  language?: LanguageUpdateOneRequiredInput;
-  url?: String;
-  md5?: String;
-  filename?: String;
-  filetype?: String;
-  filesize?: Float;
-}
-
-export interface CategoryUpdateManyInput {
-  create?: CategoryCreateInput[] | CategoryCreateInput;
-  update?:
-    | CategoryUpdateWithWhereUniqueNestedInput[]
-    | CategoryUpdateWithWhereUniqueNestedInput;
-  upsert?:
-    | CategoryUpsertWithWhereUniqueNestedInput[]
-    | CategoryUpsertWithWhereUniqueNestedInput;
-  delete?: CategoryWhereUniqueInput[] | CategoryWhereUniqueInput;
-  connect?: CategoryWhereUniqueInput[] | CategoryWhereUniqueInput;
-  disconnect?: CategoryWhereUniqueInput[] | CategoryWhereUniqueInput;
-  deleteMany?: CategoryScalarWhereInput[] | CategoryScalarWhereInput;
-}
-
-export interface SupportFileUpdateManyMutationInput {
-  url?: String;
-  md5?: String;
-  filename?: String;
-  filetype?: String;
-  filesize?: Float;
-}
-
-export interface LanguageWhereInput {
-  id?: ID_Input;
-  id_not?: ID_Input;
-  id_in?: ID_Input[] | ID_Input;
-  id_not_in?: ID_Input[] | ID_Input;
-  id_lt?: ID_Input;
-  id_lte?: ID_Input;
-  id_gt?: ID_Input;
-  id_gte?: ID_Input;
-  id_contains?: ID_Input;
-  id_not_contains?: ID_Input;
-  id_starts_with?: ID_Input;
-  id_not_starts_with?: ID_Input;
-  id_ends_with?: ID_Input;
-  id_not_ends_with?: ID_Input;
-  languageCode?: String;
-  languageCode_not?: String;
-  languageCode_in?: String[] | String;
-  languageCode_not_in?: String[] | String;
-  languageCode_lt?: String;
-  languageCode_lte?: String;
-  languageCode_gt?: String;
-  languageCode_gte?: String;
-  languageCode_contains?: String;
-  languageCode_not_contains?: String;
-  languageCode_starts_with?: String;
-  languageCode_not_starts_with?: String;
-  languageCode_ends_with?: String;
-  languageCode_not_ends_with?: String;
-  locale?: String;
-  locale_not?: String;
-  locale_in?: String[] | String;
-  locale_not_in?: String[] | String;
-  locale_lt?: String;
-  locale_lte?: String;
-  locale_gt?: String;
-  locale_gte?: String;
-  locale_contains?: String;
-  locale_not_contains?: String;
-  locale_starts_with?: String;
-  locale_not_starts_with?: String;
-  locale_ends_with?: String;
-  locale_not_ends_with?: String;
-  textDirection?: String;
-  textDirection_not?: String;
-  textDirection_in?: String[] | String;
-  textDirection_not_in?: String[] | String;
-  textDirection_lt?: String;
-  textDirection_lte?: String;
-  textDirection_gt?: String;
-  textDirection_gte?: String;
-  textDirection_contains?: String;
-  textDirection_not_contains?: String;
-  textDirection_starts_with?: String;
-  textDirection_not_starts_with?: String;
-  textDirection_ends_with?: String;
-  textDirection_not_ends_with?: String;
-  displayName?: String;
-  displayName_not?: String;
-  displayName_in?: String[] | String;
-  displayName_not_in?: String[] | String;
-  displayName_lt?: String;
-  displayName_lte?: String;
-  displayName_gt?: String;
-  displayName_gte?: String;
-  displayName_contains?: String;
-  displayName_not_contains?: String;
-  displayName_starts_with?: String;
-  displayName_not_starts_with?: String;
-  displayName_ends_with?: String;
-  displayName_not_ends_with?: String;
-  nativeName?: String;
-  nativeName_not?: String;
-  nativeName_in?: String[] | String;
-  nativeName_not_in?: String[] | String;
-  nativeName_lt?: String;
-  nativeName_lte?: String;
-  nativeName_gt?: String;
-  nativeName_gte?: String;
-  nativeName_contains?: String;
-  nativeName_not_contains?: String;
-  nativeName_starts_with?: String;
-  nativeName_not_starts_with?: String;
-  nativeName_ends_with?: String;
-  nativeName_not_ends_with?: String;
-  AND?: LanguageWhereInput[] | LanguageWhereInput;
-  OR?: LanguageWhereInput[] | LanguageWhereInput;
-  NOT?: LanguageWhereInput[] | LanguageWhereInput;
-}
-
-export interface TagCreateInput {
-  translations?: LanguageTranslationCreateManyInput;
-}
-
-export interface TagUpsertWithWhereUniqueNestedInput {
-  where: TagWhereUniqueInput;
-  update: TagUpdateDataInput;
-  create: TagCreateInput;
-}
-
-export interface TagUpdateInput {
-  translations?: LanguageTranslationUpdateManyInput;
-}
-
-export type VideoStreamWhereUniqueInput = AtLeastOne<{
-  id: ID_Input;
-}>;
-
-export interface TeamCreateInput {
-  name: String;
-  organization: String;
-  members?: UserCreateManyWithoutTeamInput;
-  contentTypes?: TeamCreatecontentTypesInput;
-  isConfirmed?: Boolean;
-}
-
-export interface TagUpdateManyInput {
-  create?: TagCreateInput[] | TagCreateInput;
-  update?:
-    | TagUpdateWithWhereUniqueNestedInput[]
-    | TagUpdateWithWhereUniqueNestedInput;
-  upsert?:
-    | TagUpsertWithWhereUniqueNestedInput[]
-    | TagUpsertWithWhereUniqueNestedInput;
-  delete?: TagWhereUniqueInput[] | TagWhereUniqueInput;
-  connect?: TagWhereUniqueInput[] | TagWhereUniqueInput;
-  disconnect?: TagWhereUniqueInput[] | TagWhereUniqueInput;
-  deleteMany?: TagScalarWhereInput[] | TagScalarWhereInput;
-}
-
-export interface UserCreateManyWithoutTeamInput {
-  create?: UserCreateWithoutTeamInput[] | UserCreateWithoutTeamInput;
-  connect?: UserWhereUniqueInput[] | UserWhereUniqueInput;
-}
-
-export interface VideoFileUpdateManyWithWhereNestedInput {
-  where: VideoFileScalarWhereInput;
-  data: VideoFileUpdateManyDataInput;
-}
-
-export interface UserCreateWithoutTeamInput {
-  firstName: String;
-  lastName: String;
-  email: String;
-  password?: String;
-  tempToken?: String;
-  tempTokenExpiry?: Float;
-  jobTitle?: String;
-  country?: String;
-  city?: String;
-  howHeard?: String;
-  permissions?: UserCreatepermissionsInput;
-  isConfirmed?: Boolean;
-}
-
-export interface VideoFileScalarWhereInput {
-  id?: ID_Input;
-  id_not?: ID_Input;
-  id_in?: ID_Input[] | ID_Input;
-  id_not_in?: ID_Input[] | ID_Input;
-  id_lt?: ID_Input;
-  id_lte?: ID_Input;
-  id_gt?: ID_Input;
-  id_gte?: ID_Input;
-  id_contains?: ID_Input;
-  id_not_contains?: ID_Input;
-  id_starts_with?: ID_Input;
-  id_not_starts_with?: ID_Input;
-  id_ends_with?: ID_Input;
-  id_not_ends_with?: ID_Input;
-  filetype?: String;
-  filetype_not?: String;
-  filetype_in?: String[] | String;
-  filetype_not_in?: String[] | String;
-  filetype_lt?: String;
-  filetype_lte?: String;
-  filetype_gt?: String;
-  filetype_gte?: String;
-  filetype_contains?: String;
-  filetype_not_contains?: String;
-  filetype_starts_with?: String;
-  filetype_not_starts_with?: String;
-  filetype_ends_with?: String;
-  filetype_not_ends_with?: String;
-  filename?: String;
-  filename_not?: String;
-  filename_in?: String[] | String;
-  filename_not_in?: String[] | String;
-  filename_lt?: String;
-  filename_lte?: String;
-  filename_gt?: String;
-  filename_gte?: String;
-  filename_contains?: String;
-  filename_not_contains?: String;
-  filename_starts_with?: String;
-  filename_not_starts_with?: String;
-  filename_ends_with?: String;
-  filename_not_ends_with?: String;
-  quality?: VideoQuality;
-  quality_not?: VideoQuality;
-  quality_in?: VideoQuality[] | VideoQuality;
-  quality_not_in?: VideoQuality[] | VideoQuality;
-  videoBurnedInStatus?: VideoBurnedInStatus;
-  videoBurnedInStatus_not?: VideoBurnedInStatus;
-  videoBurnedInStatus_in?: VideoBurnedInStatus[] | VideoBurnedInStatus;
-  videoBurnedInStatus_not_in?: VideoBurnedInStatus[] | VideoBurnedInStatus;
-  url?: String;
-  url_not?: String;
-  url_in?: String[] | String;
-  url_not_in?: String[] | String;
-  url_lt?: String;
-  url_lte?: String;
-  url_gt?: String;
-  url_gte?: String;
-  url_contains?: String;
-  url_not_contains?: String;
-  url_starts_with?: String;
-  url_not_starts_with?: String;
-  url_ends_with?: String;
-  url_not_ends_with?: String;
-  md5?: String;
-  md5_not?: String;
-  md5_in?: String[] | String;
-  md5_not_in?: String[] | String;
-  md5_lt?: String;
-  md5_lte?: String;
-  md5_gt?: String;
-  md5_gte?: String;
-  md5_contains?: String;
-  md5_not_contains?: String;
-  md5_starts_with?: String;
-  md5_not_starts_with?: String;
-  md5_ends_with?: String;
-  md5_not_ends_with?: String;
-  duration?: Float;
-  duration_not?: Float;
-  duration_in?: Float[] | Float;
-  duration_not_in?: Float[] | Float;
-  duration_lt?: Float;
-  duration_lte?: Float;
-  duration_gt?: Float;
-  duration_gte?: Float;
-  bitrate?: Float;
-  bitrate_not?: Float;
-  bitrate_in?: Float[] | Float;
-  bitrate_not_in?: Float[] | Float;
-  bitrate_lt?: Float;
-  bitrate_lte?: Float;
-  bitrate_gt?: Float;
-  bitrate_gte?: Float;
-  filesize?: Float;
-  filesize_not?: Float;
-  filesize_in?: Float[] | Float;
-  filesize_not_in?: Float[] | Float;
-  filesize_lt?: Float;
-  filesize_lte?: Float;
-  filesize_gt?: Float;
-  filesize_gte?: Float;
-  AND?: VideoFileScalarWhereInput[] | VideoFileScalarWhereInput;
-  OR?: VideoFileScalarWhereInput[] | VideoFileScalarWhereInput;
-  NOT?: VideoFileScalarWhereInput[] | VideoFileScalarWhereInput;
-}
-
-export interface UserCreatepermissionsInput {
-  set?: Permission[] | Permission;
-}
-
-export interface VideoFileUpdateDataInput {
-  language?: LanguageUpdateOneInput;
-  filetype?: String;
-  filename?: String;
-  use?: VideoUseUpdateOneInput;
-  quality?: VideoQuality;
-  videoBurnedInStatus?: VideoBurnedInStatus;
-  url?: String;
-  md5?: String;
-  duration?: Float;
-  bitrate?: Float;
-  filesize?: Float;
-  dimensions?: DimensionsUpdateOneInput;
-  stream?: VideoStreamUpdateOneInput;
-}
-
-export interface TeamCreatecontentTypesInput {
-  set?: ContentType[] | ContentType;
-}
-
-export interface LanguageTranslationWhereInput {
-  id?: ID_Input;
-  id_not?: ID_Input;
-  id_in?: ID_Input[] | ID_Input;
-  id_not_in?: ID_Input[] | ID_Input;
-  id_lt?: ID_Input;
-  id_lte?: ID_Input;
-  id_gt?: ID_Input;
-  id_gte?: ID_Input;
-  id_contains?: ID_Input;
-  id_not_contains?: ID_Input;
-  id_starts_with?: ID_Input;
-  id_not_starts_with?: ID_Input;
-  id_ends_with?: ID_Input;
-  id_not_ends_with?: ID_Input;
-  name?: String;
-  name_not?: String;
-  name_in?: String[] | String;
-  name_not_in?: String[] | String;
-  name_lt?: String;
-  name_lte?: String;
-  name_gt?: String;
-  name_gte?: String;
-  name_contains?: String;
-  name_not_contains?: String;
-  name_starts_with?: String;
-  name_not_starts_with?: String;
-  name_ends_with?: String;
-  name_not_ends_with?: String;
-  language?: LanguageWhereInput;
-  AND?: LanguageTranslationWhereInput[] | LanguageTranslationWhereInput;
-  OR?: LanguageTranslationWhereInput[] | LanguageTranslationWhereInput;
-  NOT?: LanguageTranslationWhereInput[] | LanguageTranslationWhereInput;
-}
-
-export interface TeamUpdateInput {
-  name?: String;
-  organization?: String;
-  members?: UserUpdateManyWithoutTeamInput;
-  contentTypes?: TeamUpdatecontentTypesInput;
-  isConfirmed?: Boolean;
-}
-
-export interface VideoFileUpdateManyInput {
-  create?: VideoFileCreateInput[] | VideoFileCreateInput;
-  update?:
-    | VideoFileUpdateWithWhereUniqueNestedInput[]
-    | VideoFileUpdateWithWhereUniqueNestedInput;
-  upsert?:
-    | VideoFileUpsertWithWhereUniqueNestedInput[]
-    | VideoFileUpsertWithWhereUniqueNestedInput;
-  delete?: VideoFileWhereUniqueInput[] | VideoFileWhereUniqueInput;
-  connect?: VideoFileWhereUniqueInput[] | VideoFileWhereUniqueInput;
-  disconnect?: VideoFileWhereUniqueInput[] | VideoFileWhereUniqueInput;
-  deleteMany?: VideoFileScalarWhereInput[] | VideoFileScalarWhereInput;
-  updateMany?:
-    | VideoFileUpdateManyWithWhereNestedInput[]
-    | VideoFileUpdateManyWithWhereNestedInput;
-}
-
-export interface UserUpdateManyWithoutTeamInput {
-  create?: UserCreateWithoutTeamInput[] | UserCreateWithoutTeamInput;
-  delete?: UserWhereUniqueInput[] | UserWhereUniqueInput;
-  connect?: UserWhereUniqueInput[] | UserWhereUniqueInput;
-  disconnect?: UserWhereUniqueInput[] | UserWhereUniqueInput;
-  update?:
-    | UserUpdateWithWhereUniqueWithoutTeamInput[]
-    | UserUpdateWithWhereUniqueWithoutTeamInput;
-  upsert?:
-    | UserUpsertWithWhereUniqueWithoutTeamInput[]
-    | UserUpsertWithWhereUniqueWithoutTeamInput;
-  deleteMany?: UserScalarWhereInput[] | UserScalarWhereInput;
-  updateMany?:
-    | UserUpdateManyWithWhereNestedInput[]
-    | UserUpdateManyWithWhereNestedInput;
-}
-
-export interface VideoUseSubscriptionWhereInput {
-  mutation_in?: MutationType[] | MutationType;
-  updatedFields_contains?: String;
-  updatedFields_contains_every?: String[] | String;
-  updatedFields_contains_some?: String[] | String;
-  node?: VideoUseWhereInput;
-  AND?: VideoUseSubscriptionWhereInput[] | VideoUseSubscriptionWhereInput;
-  OR?: VideoUseSubscriptionWhereInput[] | VideoUseSubscriptionWhereInput;
-  NOT?: VideoUseSubscriptionWhereInput[] | VideoUseSubscriptionWhereInput;
-}
-
-export interface UserUpdateWithWhereUniqueWithoutTeamInput {
-  where: UserWhereUniqueInput;
-  data: UserUpdateWithoutTeamDataInput;
-}
-
-export type ImageFileWhereUniqueInput = AtLeastOne<{
-  id: ID_Input;
-}>;
-
-export interface TeamUpdateDataInput {
-  name?: String;
-  organization?: String;
-  members?: UserUpdateManyWithoutTeamInput;
-  contentTypes?: TeamUpdatecontentTypesInput;
-  isConfirmed?: Boolean;
-}
-
-export type LanguageWhereUniqueInput = AtLeastOne<{
-  id: ID_Input;
-  locale?: String;
-}>;
-
-export interface TeamUpdateOneInput {
-  create?: TeamCreateInput;
-  update?: TeamUpdateDataInput;
-  upsert?: TeamUpsertNestedInput;
-  delete?: Boolean;
-  disconnect?: Boolean;
-  connect?: TeamWhereUniqueInput;
-}
-
-export interface TagSubscriptionWhereInput {
-  mutation_in?: MutationType[] | MutationType;
-  updatedFields_contains?: String;
-  updatedFields_contains_every?: String[] | String;
-  updatedFields_contains_some?: String[] | String;
-  node?: TagWhereInput;
-  AND?: TagSubscriptionWhereInput[] | TagSubscriptionWhereInput;
-  OR?: TagSubscriptionWhereInput[] | TagSubscriptionWhereInput;
-  NOT?: TagSubscriptionWhereInput[] | TagSubscriptionWhereInput;
-}
-
-export interface UserUpsertWithWhereUniqueWithoutTeamInput {
-  where: UserWhereUniqueInput;
-  update: UserUpdateWithoutTeamDataInput;
-  create: UserCreateWithoutTeamInput;
-}
-
-export interface LanguageSubscriptionWhereInput {
-  mutation_in?: MutationType[] | MutationType;
-  updatedFields_contains?: String;
-  updatedFields_contains_every?: String[] | String;
-  updatedFields_contains_some?: String[] | String;
-  node?: LanguageWhereInput;
-  AND?: LanguageSubscriptionWhereInput[] | LanguageSubscriptionWhereInput;
-  OR?: LanguageSubscriptionWhereInput[] | LanguageSubscriptionWhereInput;
-  NOT?: LanguageSubscriptionWhereInput[] | LanguageSubscriptionWhereInput;
-}
-
-export interface UserScalarWhereInput {
-  id?: ID_Input;
-  id_not?: ID_Input;
-  id_in?: ID_Input[] | ID_Input;
-  id_not_in?: ID_Input[] | ID_Input;
-  id_lt?: ID_Input;
-  id_lte?: ID_Input;
-  id_gt?: ID_Input;
-  id_gte?: ID_Input;
-  id_contains?: ID_Input;
-  id_not_contains?: ID_Input;
-  id_starts_with?: ID_Input;
-  id_not_starts_with?: ID_Input;
-  id_ends_with?: ID_Input;
-  id_not_ends_with?: ID_Input;
-  firstName?: String;
-  firstName_not?: String;
-  firstName_in?: String[] | String;
-  firstName_not_in?: String[] | String;
-  firstName_lt?: String;
-  firstName_lte?: String;
-  firstName_gt?: String;
-  firstName_gte?: String;
-  firstName_contains?: String;
-  firstName_not_contains?: String;
-  firstName_starts_with?: String;
-  firstName_not_starts_with?: String;
-  firstName_ends_with?: String;
-  firstName_not_ends_with?: String;
-  lastName?: String;
-  lastName_not?: String;
-  lastName_in?: String[] | String;
-  lastName_not_in?: String[] | String;
-  lastName_lt?: String;
-  lastName_lte?: String;
-  lastName_gt?: String;
-  lastName_gte?: String;
-  lastName_contains?: String;
-  lastName_not_contains?: String;
-  lastName_starts_with?: String;
-  lastName_not_starts_with?: String;
-  lastName_ends_with?: String;
-  lastName_not_ends_with?: String;
-  email?: String;
-  email_not?: String;
-  email_in?: String[] | String;
-  email_not_in?: String[] | String;
-  email_lt?: String;
-  email_lte?: String;
-  email_gt?: String;
-  email_gte?: String;
-  email_contains?: String;
-  email_not_contains?: String;
-  email_starts_with?: String;
-  email_not_starts_with?: String;
-  email_ends_with?: String;
-  email_not_ends_with?: String;
-  password?: String;
-  password_not?: String;
-  password_in?: String[] | String;
-  password_not_in?: String[] | String;
-  password_lt?: String;
-  password_lte?: String;
-  password_gt?: String;
-  password_gte?: String;
-  password_contains?: String;
-  password_not_contains?: String;
-  password_starts_with?: String;
-  password_not_starts_with?: String;
-  password_ends_with?: String;
-  password_not_ends_with?: String;
-  tempToken?: String;
-  tempToken_not?: String;
-  tempToken_in?: String[] | String;
-  tempToken_not_in?: String[] | String;
-  tempToken_lt?: String;
-  tempToken_lte?: String;
-  tempToken_gt?: String;
-  tempToken_gte?: String;
-  tempToken_contains?: String;
-  tempToken_not_contains?: String;
-  tempToken_starts_with?: String;
-  tempToken_not_starts_with?: String;
-  tempToken_ends_with?: String;
-  tempToken_not_ends_with?: String;
-  tempTokenExpiry?: Float;
-  tempTokenExpiry_not?: Float;
-  tempTokenExpiry_in?: Float[] | Float;
-  tempTokenExpiry_not_in?: Float[] | Float;
-  tempTokenExpiry_lt?: Float;
-  tempTokenExpiry_lte?: Float;
-  tempTokenExpiry_gt?: Float;
-  tempTokenExpiry_gte?: Float;
-  jobTitle?: String;
-  jobTitle_not?: String;
-  jobTitle_in?: String[] | String;
-  jobTitle_not_in?: String[] | String;
-  jobTitle_lt?: String;
-  jobTitle_lte?: String;
-  jobTitle_gt?: String;
-  jobTitle_gte?: String;
-  jobTitle_contains?: String;
-  jobTitle_not_contains?: String;
-  jobTitle_starts_with?: String;
-  jobTitle_not_starts_with?: String;
-  jobTitle_ends_with?: String;
-  jobTitle_not_ends_with?: String;
-  country?: String;
-  country_not?: String;
-  country_in?: String[] | String;
-  country_not_in?: String[] | String;
-  country_lt?: String;
-  country_lte?: String;
-  country_gt?: String;
-  country_gte?: String;
-  country_contains?: String;
-  country_not_contains?: String;
-  country_starts_with?: String;
-  country_not_starts_with?: String;
-  country_ends_with?: String;
-  country_not_ends_with?: String;
-  city?: String;
-  city_not?: String;
-  city_in?: String[] | String;
-  city_not_in?: String[] | String;
-  city_lt?: String;
-  city_lte?: String;
-  city_gt?: String;
-  city_gte?: String;
-  city_contains?: String;
-  city_not_contains?: String;
-  city_starts_with?: String;
-  city_not_starts_with?: String;
-  city_ends_with?: String;
-  city_not_ends_with?: String;
-  howHeard?: String;
-  howHeard_not?: String;
-  howHeard_in?: String[] | String;
-  howHeard_not_in?: String[] | String;
-  howHeard_lt?: String;
-  howHeard_lte?: String;
-  howHeard_gt?: String;
-  howHeard_gte?: String;
-  howHeard_contains?: String;
-  howHeard_not_contains?: String;
-  howHeard_starts_with?: String;
-  howHeard_not_starts_with?: String;
-  howHeard_ends_with?: String;
-  howHeard_not_ends_with?: String;
-  isConfirmed?: Boolean;
-  isConfirmed_not?: Boolean;
-  AND?: UserScalarWhereInput[] | UserScalarWhereInput;
-  OR?: UserScalarWhereInput[] | UserScalarWhereInput;
-  NOT?: UserScalarWhereInput[] | UserScalarWhereInput;
 }
 
 export interface SupportFileWhereInput {
@@ -2577,6 +1223,22 @@ export interface SupportFileWhereInput {
   id_not_starts_with?: ID_Input;
   id_ends_with?: ID_Input;
   id_not_ends_with?: ID_Input;
+  createdAt?: DateTimeInput;
+  createdAt_not?: DateTimeInput;
+  createdAt_in?: DateTimeInput[] | DateTimeInput;
+  createdAt_not_in?: DateTimeInput[] | DateTimeInput;
+  createdAt_lt?: DateTimeInput;
+  createdAt_lte?: DateTimeInput;
+  createdAt_gt?: DateTimeInput;
+  createdAt_gte?: DateTimeInput;
+  updatedAt?: DateTimeInput;
+  updatedAt_not?: DateTimeInput;
+  updatedAt_in?: DateTimeInput[] | DateTimeInput;
+  updatedAt_not_in?: DateTimeInput[] | DateTimeInput;
+  updatedAt_lt?: DateTimeInput;
+  updatedAt_lte?: DateTimeInput;
+  updatedAt_gt?: DateTimeInput;
+  updatedAt_gte?: DateTimeInput;
   language?: LanguageWhereInput;
   url?: String;
   url_not?: String;
@@ -2647,546 +1309,12 @@ export interface SupportFileWhereInput {
   NOT?: SupportFileWhereInput[] | SupportFileWhereInput;
 }
 
-export interface UserUpdateManyWithWhereNestedInput {
-  where: UserScalarWhereInput;
-  data: UserUpdateManyDataInput;
-}
-
-export interface VideoUseUpdateInput {
-  name?: String;
-}
-
-export interface UserUpdateManyDataInput {
-  firstName?: String;
-  lastName?: String;
-  email?: String;
-  password?: String;
-  tempToken?: String;
-  tempTokenExpiry?: Float;
-  jobTitle?: String;
-  country?: String;
-  city?: String;
-  howHeard?: String;
-  permissions?: UserUpdatepermissionsInput;
-  isConfirmed?: Boolean;
-}
-
-export interface VideoUnitUpdateInput {
-  language?: LanguageUpdateOneInput;
-  title?: String;
-  descPublic?: String;
-  files?: VideoFileUpdateManyInput;
-  tags?: TagUpdateManyInput;
-  categories?: CategoryUpdateManyInput;
-  thumbnails?: ThumbnailUpdateManyInput;
-}
-
-export interface TeamUpdatecontentTypesInput {
-  set?: ContentType[] | ContentType;
-}
-
-export type TeamWhereUniqueInput = AtLeastOne<{
-  id: ID_Input;
-  name?: String;
-}>;
-
-export interface TeamUpdateManyMutationInput {
-  name?: String;
-  organization?: String;
-  contentTypes?: TeamUpdatecontentTypesInput;
-  isConfirmed?: Boolean;
-}
-
-export interface DimensionsWhereInput {
-  id?: ID_Input;
-  id_not?: ID_Input;
-  id_in?: ID_Input[] | ID_Input;
-  id_not_in?: ID_Input[] | ID_Input;
-  id_lt?: ID_Input;
-  id_lte?: ID_Input;
-  id_gt?: ID_Input;
-  id_gte?: ID_Input;
-  id_contains?: ID_Input;
-  id_not_contains?: ID_Input;
-  id_starts_with?: ID_Input;
-  id_not_starts_with?: ID_Input;
-  id_ends_with?: ID_Input;
-  id_not_ends_with?: ID_Input;
-  width?: Int;
-  width_not?: Int;
-  width_in?: Int[] | Int;
-  width_not_in?: Int[] | Int;
-  width_lt?: Int;
-  width_lte?: Int;
-  width_gt?: Int;
-  width_gte?: Int;
-  height?: Int;
-  height_not?: Int;
-  height_in?: Int[] | Int;
-  height_not_in?: Int[] | Int;
-  height_lt?: Int;
-  height_lte?: Int;
-  height_gt?: Int;
-  height_gte?: Int;
-  AND?: DimensionsWhereInput[] | DimensionsWhereInput;
-  OR?: DimensionsWhereInput[] | DimensionsWhereInput;
-  NOT?: DimensionsWhereInput[] | DimensionsWhereInput;
-}
-
-export interface ThumbnailCreateInput {
-  size?: ThumbnailSize;
-  image?: ImageFileCreateOneInput;
-}
-
-export interface ImageFileUpsertWithWhereUniqueNestedInput {
-  where: ImageFileWhereUniqueInput;
-  update: ImageFileUpdateDataInput;
-  create: ImageFileCreateInput;
-}
-
-export interface ImageFileCreateOneInput {
-  create?: ImageFileCreateInput;
-  connect?: ImageFileWhereUniqueInput;
-}
-
-export type ThumbnailWhereUniqueInput = AtLeastOne<{
-  id: ID_Input;
-}>;
-
-export interface ThumbnailUpdateInput {
-  size?: ThumbnailSize;
-  image?: ImageFileUpdateOneInput;
-}
-
-export interface SupportFileUpsertWithWhereUniqueNestedInput {
-  where: SupportFileWhereUniqueInput;
-  update: SupportFileUpdateDataInput;
-  create: SupportFileCreateInput;
-}
-
-export interface ImageFileUpdateOneInput {
-  create?: ImageFileCreateInput;
-  update?: ImageFileUpdateDataInput;
-  upsert?: ImageFileUpsertNestedInput;
-  delete?: Boolean;
-  disconnect?: Boolean;
-  connect?: ImageFileWhereUniqueInput;
-}
-
-export type UserWhereUniqueInput = AtLeastOne<{
-  id: ID_Input;
-  email?: String;
-}>;
-
-export interface ImageFileUpdateDataInput {
-  language?: LanguageUpdateOneInput;
-  dimensions?: DimensionsUpdateOneInput;
-  alt?: String;
-  longdesc?: String;
-  caption?: String;
-  filename?: String;
-  filetype?: String;
-  md5?: String;
-  url?: String;
-}
-
-export type VideoFileWhereUniqueInput = AtLeastOne<{
-  id: ID_Input;
-}>;
-
-export interface ImageFileUpsertNestedInput {
-  update: ImageFileUpdateDataInput;
-  create: ImageFileCreateInput;
-}
-
-export interface ThumbnailScalarWhereInput {
-  id?: ID_Input;
-  id_not?: ID_Input;
-  id_in?: ID_Input[] | ID_Input;
-  id_not_in?: ID_Input[] | ID_Input;
-  id_lt?: ID_Input;
-  id_lte?: ID_Input;
-  id_gt?: ID_Input;
-  id_gte?: ID_Input;
-  id_contains?: ID_Input;
-  id_not_contains?: ID_Input;
-  id_starts_with?: ID_Input;
-  id_not_starts_with?: ID_Input;
-  id_ends_with?: ID_Input;
-  id_not_ends_with?: ID_Input;
-  size?: ThumbnailSize;
-  size_not?: ThumbnailSize;
-  size_in?: ThumbnailSize[] | ThumbnailSize;
-  size_not_in?: ThumbnailSize[] | ThumbnailSize;
-  AND?: ThumbnailScalarWhereInput[] | ThumbnailScalarWhereInput;
-  OR?: ThumbnailScalarWhereInput[] | ThumbnailScalarWhereInput;
-  NOT?: ThumbnailScalarWhereInput[] | ThumbnailScalarWhereInput;
-}
-
-export interface ThumbnailUpdateManyMutationInput {
-  size?: ThumbnailSize;
-}
-
-export interface VideoStreamWhereInput {
-  id?: ID_Input;
-  id_not?: ID_Input;
-  id_in?: ID_Input[] | ID_Input;
-  id_not_in?: ID_Input[] | ID_Input;
-  id_lt?: ID_Input;
-  id_lte?: ID_Input;
-  id_gt?: ID_Input;
-  id_gte?: ID_Input;
-  id_contains?: ID_Input;
-  id_not_contains?: ID_Input;
-  id_starts_with?: ID_Input;
-  id_not_starts_with?: ID_Input;
-  id_ends_with?: ID_Input;
-  id_not_ends_with?: ID_Input;
-  site?: String;
-  site_not?: String;
-  site_in?: String[] | String;
-  site_not_in?: String[] | String;
-  site_lt?: String;
-  site_lte?: String;
-  site_gt?: String;
-  site_gte?: String;
-  site_contains?: String;
-  site_not_contains?: String;
-  site_starts_with?: String;
-  site_not_starts_with?: String;
-  site_ends_with?: String;
-  site_not_ends_with?: String;
-  url?: String;
-  url_not?: String;
-  url_in?: String[] | String;
-  url_not_in?: String[] | String;
-  url_lt?: String;
-  url_lte?: String;
-  url_gt?: String;
-  url_gte?: String;
-  url_contains?: String;
-  url_not_contains?: String;
-  url_starts_with?: String;
-  url_not_starts_with?: String;
-  url_ends_with?: String;
-  url_not_ends_with?: String;
-  embedUrl?: String;
-  embedUrl_not?: String;
-  embedUrl_in?: String[] | String;
-  embedUrl_not_in?: String[] | String;
-  embedUrl_lt?: String;
-  embedUrl_lte?: String;
-  embedUrl_gt?: String;
-  embedUrl_gte?: String;
-  embedUrl_contains?: String;
-  embedUrl_not_contains?: String;
-  embedUrl_starts_with?: String;
-  embedUrl_not_starts_with?: String;
-  embedUrl_ends_with?: String;
-  embedUrl_not_ends_with?: String;
-  AND?: VideoStreamWhereInput[] | VideoStreamWhereInput;
-  OR?: VideoStreamWhereInput[] | VideoStreamWhereInput;
-  NOT?: VideoStreamWhereInput[] | VideoStreamWhereInput;
-}
-
-export interface UserCreateInput {
-  firstName: String;
-  lastName: String;
-  email: String;
-  password?: String;
-  tempToken?: String;
-  tempTokenExpiry?: Float;
-  jobTitle?: String;
-  country?: String;
-  city?: String;
-  howHeard?: String;
-  permissions?: UserCreatepermissionsInput;
-  team?: TeamCreateOneWithoutMembersInput;
-  isConfirmed?: Boolean;
-}
-
-export interface ThumbnailUpdateManyInput {
-  create?: ThumbnailCreateInput[] | ThumbnailCreateInput;
-  update?:
-    | ThumbnailUpdateWithWhereUniqueNestedInput[]
-    | ThumbnailUpdateWithWhereUniqueNestedInput;
-  upsert?:
-    | ThumbnailUpsertWithWhereUniqueNestedInput[]
-    | ThumbnailUpsertWithWhereUniqueNestedInput;
-  delete?: ThumbnailWhereUniqueInput[] | ThumbnailWhereUniqueInput;
-  connect?: ThumbnailWhereUniqueInput[] | ThumbnailWhereUniqueInput;
-  disconnect?: ThumbnailWhereUniqueInput[] | ThumbnailWhereUniqueInput;
-  deleteMany?: ThumbnailScalarWhereInput[] | ThumbnailScalarWhereInput;
-  updateMany?:
-    | ThumbnailUpdateManyWithWhereNestedInput[]
-    | ThumbnailUpdateManyWithWhereNestedInput;
-}
-
-export interface TeamCreateOneWithoutMembersInput {
-  create?: TeamCreateWithoutMembersInput;
-  connect?: TeamWhereUniqueInput;
-}
-
-export interface CategoryUpdateDataInput {
-  translations?: LanguageTranslationUpdateManyInput;
-}
-
-export interface TeamCreateWithoutMembersInput {
-  name: String;
-  organization: String;
-  contentTypes?: TeamCreatecontentTypesInput;
-  isConfirmed?: Boolean;
-}
-
-export interface VideoProjectWhereInput {
-  id?: ID_Input;
-  id_not?: ID_Input;
-  id_in?: ID_Input[] | ID_Input;
-  id_not_in?: ID_Input[] | ID_Input;
-  id_lt?: ID_Input;
-  id_lte?: ID_Input;
-  id_gt?: ID_Input;
-  id_gte?: ID_Input;
-  id_contains?: ID_Input;
-  id_not_contains?: ID_Input;
-  id_starts_with?: ID_Input;
-  id_not_starts_with?: ID_Input;
-  id_ends_with?: ID_Input;
-  id_not_ends_with?: ID_Input;
-  projectType?: String;
-  projectType_not?: String;
-  projectType_in?: String[] | String;
-  projectType_not_in?: String[] | String;
-  projectType_lt?: String;
-  projectType_lte?: String;
-  projectType_gt?: String;
-  projectType_gte?: String;
-  projectType_contains?: String;
-  projectType_not_contains?: String;
-  projectType_starts_with?: String;
-  projectType_not_starts_with?: String;
-  projectType_ends_with?: String;
-  projectType_not_ends_with?: String;
-  projectTitle?: String;
-  projectTitle_not?: String;
-  projectTitle_in?: String[] | String;
-  projectTitle_not_in?: String[] | String;
-  projectTitle_lt?: String;
-  projectTitle_lte?: String;
-  projectTitle_gt?: String;
-  projectTitle_gte?: String;
-  projectTitle_contains?: String;
-  projectTitle_not_contains?: String;
-  projectTitle_starts_with?: String;
-  projectTitle_not_starts_with?: String;
-  projectTitle_ends_with?: String;
-  projectTitle_not_ends_with?: String;
-  descPublic?: String;
-  descPublic_not?: String;
-  descPublic_in?: String[] | String;
-  descPublic_not_in?: String[] | String;
-  descPublic_lt?: String;
-  descPublic_lte?: String;
-  descPublic_gt?: String;
-  descPublic_gte?: String;
-  descPublic_contains?: String;
-  descPublic_not_contains?: String;
-  descPublic_starts_with?: String;
-  descPublic_not_starts_with?: String;
-  descPublic_ends_with?: String;
-  descPublic_not_ends_with?: String;
-  descInternal?: String;
-  descInternal_not?: String;
-  descInternal_in?: String[] | String;
-  descInternal_not_in?: String[] | String;
-  descInternal_lt?: String;
-  descInternal_lte?: String;
-  descInternal_gt?: String;
-  descInternal_gte?: String;
-  descInternal_contains?: String;
-  descInternal_not_contains?: String;
-  descInternal_starts_with?: String;
-  descInternal_not_starts_with?: String;
-  descInternal_ends_with?: String;
-  descInternal_not_ends_with?: String;
-  author?: String;
-  author_not?: String;
-  author_in?: String[] | String;
-  author_not_in?: String[] | String;
-  author_lt?: String;
-  author_lte?: String;
-  author_gt?: String;
-  author_gte?: String;
-  author_contains?: String;
-  author_not_contains?: String;
-  author_starts_with?: String;
-  author_not_starts_with?: String;
-  author_ends_with?: String;
-  author_not_ends_with?: String;
-  team?: TeamWhereInput;
-  status?: ProjectPublishStatus;
-  status_not?: ProjectPublishStatus;
-  status_in?: ProjectPublishStatus[] | ProjectPublishStatus;
-  status_not_in?: ProjectPublishStatus[] | ProjectPublishStatus;
-  visibility?: ProjectVisibility;
-  visibility_not?: ProjectVisibility;
-  visibility_in?: ProjectVisibility[] | ProjectVisibility;
-  visibility_not_in?: ProjectVisibility[] | ProjectVisibility;
-  units_every?: VideoUnitWhereInput;
-  units_some?: VideoUnitWhereInput;
-  units_none?: VideoUnitWhereInput;
-  supportFiles_every?: SupportFileWhereInput;
-  supportFiles_some?: SupportFileWhereInput;
-  supportFiles_none?: SupportFileWhereInput;
-  thumbnails_every?: ImageFileWhereInput;
-  thumbnails_some?: ImageFileWhereInput;
-  thumbnails_none?: ImageFileWhereInput;
-  categories_every?: CategoryWhereInput;
-  categories_some?: CategoryWhereInput;
-  categories_none?: CategoryWhereInput;
-  tags_every?: TagWhereInput;
-  tags_some?: TagWhereInput;
-  tags_none?: TagWhereInput;
-  AND?: VideoProjectWhereInput[] | VideoProjectWhereInput;
-  OR?: VideoProjectWhereInput[] | VideoProjectWhereInput;
-  NOT?: VideoProjectWhereInput[] | VideoProjectWhereInput;
-}
-
-export interface UserUpdateInput {
-  firstName?: String;
-  lastName?: String;
-  email?: String;
-  password?: String;
-  tempToken?: String;
-  tempTokenExpiry?: Float;
-  jobTitle?: String;
-  country?: String;
-  city?: String;
-  howHeard?: String;
-  permissions?: UserUpdatepermissionsInput;
-  team?: TeamUpdateOneWithoutMembersInput;
-  isConfirmed?: Boolean;
-}
-
-export interface TagUpdateDataInput {
-  translations?: LanguageTranslationUpdateManyInput;
-}
-
-export interface TeamUpdateOneWithoutMembersInput {
-  create?: TeamCreateWithoutMembersInput;
-  update?: TeamUpdateWithoutMembersDataInput;
-  upsert?: TeamUpsertWithoutMembersInput;
-  delete?: Boolean;
-  disconnect?: Boolean;
-  connect?: TeamWhereUniqueInput;
-}
-
-export interface VideoFileUpdateManyDataInput {
-  filetype?: String;
-  filename?: String;
-  quality?: VideoQuality;
-  videoBurnedInStatus?: VideoBurnedInStatus;
-  url?: String;
-  md5?: String;
-  duration?: Float;
-  bitrate?: Float;
-  filesize?: Float;
-}
-
-export interface TeamUpdateWithoutMembersDataInput {
-  name?: String;
-  organization?: String;
-  contentTypes?: TeamUpdatecontentTypesInput;
-  isConfirmed?: Boolean;
-}
-
-export interface VideoFileUpsertWithWhereUniqueNestedInput {
-  where: VideoFileWhereUniqueInput;
-  update: VideoFileUpdateDataInput;
-  create: VideoFileCreateInput;
-}
-
-export interface TeamUpsertWithoutMembersInput {
-  update: TeamUpdateWithoutMembersDataInput;
-  create: TeamCreateWithoutMembersInput;
-}
-
-export interface VideoFileUpdateWithWhereUniqueNestedInput {
-  where: VideoFileWhereUniqueInput;
-  data: VideoFileUpdateDataInput;
-}
-
-export interface UserUpdateManyMutationInput {
-  firstName?: String;
-  lastName?: String;
-  email?: String;
-  password?: String;
-  tempToken?: String;
-  tempTokenExpiry?: Float;
-  jobTitle?: String;
-  country?: String;
-  city?: String;
-  howHeard?: String;
-  permissions?: UserUpdatepermissionsInput;
-  isConfirmed?: Boolean;
-}
-
-export interface VideoUnitSubscriptionWhereInput {
-  mutation_in?: MutationType[] | MutationType;
-  updatedFields_contains?: String;
-  updatedFields_contains_every?: String[] | String;
-  updatedFields_contains_some?: String[] | String;
-  node?: VideoUnitWhereInput;
-  AND?: VideoUnitSubscriptionWhereInput[] | VideoUnitSubscriptionWhereInput;
-  OR?: VideoUnitSubscriptionWhereInput[] | VideoUnitSubscriptionWhereInput;
-  NOT?: VideoUnitSubscriptionWhereInput[] | VideoUnitSubscriptionWhereInput;
-}
-
-export interface VideoFileCreateInput {
-  language?: LanguageCreateOneInput;
-  filetype?: String;
-  filename?: String;
-  use?: VideoUseCreateOneInput;
-  quality?: VideoQuality;
-  videoBurnedInStatus?: VideoBurnedInStatus;
-  url?: String;
-  md5?: String;
-  duration?: Float;
-  bitrate?: Float;
-  filesize?: Float;
-  dimensions?: DimensionsCreateOneInput;
-  stream?: VideoStreamCreateOneInput;
-}
-
-export interface ThumbnailSubscriptionWhereInput {
-  mutation_in?: MutationType[] | MutationType;
-  updatedFields_contains?: String;
-  updatedFields_contains_every?: String[] | String;
-  updatedFields_contains_some?: String[] | String;
-  node?: ThumbnailWhereInput;
-  AND?: ThumbnailSubscriptionWhereInput[] | ThumbnailSubscriptionWhereInput;
-  OR?: ThumbnailSubscriptionWhereInput[] | ThumbnailSubscriptionWhereInput;
-  NOT?: ThumbnailSubscriptionWhereInput[] | ThumbnailSubscriptionWhereInput;
-}
-
-export interface VideoUseCreateOneInput {
-  create?: VideoUseCreateInput;
-  connect?: VideoUseWhereUniqueInput;
-}
-
-export interface ImageUseSubscriptionWhereInput {
-  mutation_in?: MutationType[] | MutationType;
-  updatedFields_contains?: String;
-  updatedFields_contains_every?: String[] | String;
-  updatedFields_contains_some?: String[] | String;
-  node?: ImageUseWhereInput;
-  AND?: ImageUseSubscriptionWhereInput[] | ImageUseSubscriptionWhereInput;
-  OR?: ImageUseSubscriptionWhereInput[] | ImageUseSubscriptionWhereInput;
-  NOT?: ImageUseSubscriptionWhereInput[] | ImageUseSubscriptionWhereInput;
-}
-
-export interface VideoUseCreateInput {
-  name: String;
+export interface LanguageUpdateDataInput {
+  languageCode?: String;
+  locale?: String;
+  textDirection?: String;
+  displayName?: String;
+  nativeName?: String;
 }
 
 export interface VideoUnitUpdateManyMutationInput {
@@ -3194,9 +1322,104 @@ export interface VideoUnitUpdateManyMutationInput {
   descPublic?: String;
 }
 
-export interface VideoStreamCreateOneInput {
-  create?: VideoStreamCreateInput;
-  connect?: VideoStreamWhereUniqueInput;
+export interface LanguageUpsertNestedInput {
+  update: LanguageUpdateDataInput;
+  create: LanguageCreateInput;
+}
+
+export interface VideoStreamUpdateManyMutationInput {
+  site?: String;
+  url?: String;
+  embedUrl?: String;
+}
+
+export interface LanguageTranslationUpsertWithWhereUniqueNestedInput {
+  where: LanguageTranslationWhereUniqueInput;
+  update: LanguageTranslationUpdateDataInput;
+  create: LanguageTranslationCreateInput;
+}
+
+export interface VideoStreamUpdateInput {
+  site?: String;
+  url?: String;
+  embedUrl?: String;
+}
+
+export interface LanguageTranslationScalarWhereInput {
+  id?: ID_Input;
+  id_not?: ID_Input;
+  id_in?: ID_Input[] | ID_Input;
+  id_not_in?: ID_Input[] | ID_Input;
+  id_lt?: ID_Input;
+  id_lte?: ID_Input;
+  id_gt?: ID_Input;
+  id_gte?: ID_Input;
+  id_contains?: ID_Input;
+  id_not_contains?: ID_Input;
+  id_starts_with?: ID_Input;
+  id_not_starts_with?: ID_Input;
+  id_ends_with?: ID_Input;
+  id_not_ends_with?: ID_Input;
+  name?: String;
+  name_not?: String;
+  name_in?: String[] | String;
+  name_not_in?: String[] | String;
+  name_lt?: String;
+  name_lte?: String;
+  name_gt?: String;
+  name_gte?: String;
+  name_contains?: String;
+  name_not_contains?: String;
+  name_starts_with?: String;
+  name_not_starts_with?: String;
+  name_ends_with?: String;
+  name_not_ends_with?: String;
+  AND?:
+    | LanguageTranslationScalarWhereInput[]
+    | LanguageTranslationScalarWhereInput;
+  OR?:
+    | LanguageTranslationScalarWhereInput[]
+    | LanguageTranslationScalarWhereInput;
+  NOT?:
+    | LanguageTranslationScalarWhereInput[]
+    | LanguageTranslationScalarWhereInput;
+}
+
+export interface VideoProjectUpdateManyMutationInput {
+  projectType?: String;
+  projectTitle?: String;
+  descPublic?: String;
+  descInternal?: String;
+  author?: String;
+  status?: ProjectPublishStatus;
+  visibility?: ProjectVisibility;
+}
+
+export interface LanguageTranslationUpdateManyWithWhereNestedInput {
+  where: LanguageTranslationScalarWhereInput;
+  data: LanguageTranslationUpdateManyDataInput;
+}
+
+export interface ImageFileUpdateManyWithWhereNestedInput {
+  where: ImageFileScalarWhereInput;
+  data: ImageFileUpdateManyDataInput;
+}
+
+export interface LanguageTranslationUpdateManyDataInput {
+  name?: String;
+}
+
+export type TeamWhereUniqueInput = AtLeastOne<{
+  id: ID_Input;
+  name?: String;
+}>;
+
+export interface TeamUpdateDataInput {
+  name?: String;
+  organization?: String;
+  members?: UserUpdateManyWithoutTeamInput;
+  contentTypes?: TeamUpdatecontentTypesInput;
+  isConfirmed?: Boolean;
 }
 
 export interface UserWhereInput {
@@ -3356,10 +1579,54 @@ export interface UserWhereInput {
   NOT?: UserWhereInput[] | UserWhereInput;
 }
 
-export interface VideoStreamCreateInput {
-  site?: String;
-  url?: String;
-  embedUrl?: String;
+export interface TeamUpdateOneInput {
+  create?: TeamCreateInput;
+  update?: TeamUpdateDataInput;
+  upsert?: TeamUpsertNestedInput;
+  delete?: Boolean;
+  disconnect?: Boolean;
+  connect?: TeamWhereUniqueInput;
+}
+
+export interface DimensionsWhereInput {
+  id?: ID_Input;
+  id_not?: ID_Input;
+  id_in?: ID_Input[] | ID_Input;
+  id_not_in?: ID_Input[] | ID_Input;
+  id_lt?: ID_Input;
+  id_lte?: ID_Input;
+  id_gt?: ID_Input;
+  id_gte?: ID_Input;
+  id_contains?: ID_Input;
+  id_not_contains?: ID_Input;
+  id_starts_with?: ID_Input;
+  id_not_starts_with?: ID_Input;
+  id_ends_with?: ID_Input;
+  id_not_ends_with?: ID_Input;
+  width?: Int;
+  width_not?: Int;
+  width_in?: Int[] | Int;
+  width_not_in?: Int[] | Int;
+  width_lt?: Int;
+  width_lte?: Int;
+  width_gt?: Int;
+  width_gte?: Int;
+  height?: Int;
+  height_not?: Int;
+  height_in?: Int[] | Int;
+  height_not_in?: Int[] | Int;
+  height_lt?: Int;
+  height_lte?: Int;
+  height_gt?: Int;
+  height_gte?: Int;
+  AND?: DimensionsWhereInput[] | DimensionsWhereInput;
+  OR?: DimensionsWhereInput[] | DimensionsWhereInput;
+  NOT?: DimensionsWhereInput[] | DimensionsWhereInput;
+}
+
+export interface DimensionsCreateInput {
+  width?: Int;
+  height?: Int;
 }
 
 export interface ImageFileUpdateManyInput {
@@ -3379,20 +1646,143 @@ export interface ImageFileUpdateManyInput {
     | ImageFileUpdateManyWithWhereNestedInput;
 }
 
-export interface VideoFileUpdateInput {
-  language?: LanguageUpdateOneInput;
-  filetype?: String;
-  filename?: String;
-  use?: VideoUseUpdateOneInput;
-  quality?: VideoQuality;
-  videoBurnedInStatus?: VideoBurnedInStatus;
+export interface DimensionsUpdateInput {
+  width?: Int;
+  height?: Int;
+}
+
+export interface SupportFileUpdateManyDataInput {
   url?: String;
   md5?: String;
-  duration?: Float;
-  bitrate?: Float;
+  filename?: String;
+  filetype?: String;
   filesize?: Float;
-  dimensions?: DimensionsUpdateOneInput;
-  stream?: VideoStreamUpdateOneInput;
+}
+
+export interface DimensionsUpdateManyMutationInput {
+  width?: Int;
+  height?: Int;
+}
+
+export interface SupportFileScalarWhereInput {
+  id?: ID_Input;
+  id_not?: ID_Input;
+  id_in?: ID_Input[] | ID_Input;
+  id_not_in?: ID_Input[] | ID_Input;
+  id_lt?: ID_Input;
+  id_lte?: ID_Input;
+  id_gt?: ID_Input;
+  id_gte?: ID_Input;
+  id_contains?: ID_Input;
+  id_not_contains?: ID_Input;
+  id_starts_with?: ID_Input;
+  id_not_starts_with?: ID_Input;
+  id_ends_with?: ID_Input;
+  id_not_ends_with?: ID_Input;
+  createdAt?: DateTimeInput;
+  createdAt_not?: DateTimeInput;
+  createdAt_in?: DateTimeInput[] | DateTimeInput;
+  createdAt_not_in?: DateTimeInput[] | DateTimeInput;
+  createdAt_lt?: DateTimeInput;
+  createdAt_lte?: DateTimeInput;
+  createdAt_gt?: DateTimeInput;
+  createdAt_gte?: DateTimeInput;
+  updatedAt?: DateTimeInput;
+  updatedAt_not?: DateTimeInput;
+  updatedAt_in?: DateTimeInput[] | DateTimeInput;
+  updatedAt_not_in?: DateTimeInput[] | DateTimeInput;
+  updatedAt_lt?: DateTimeInput;
+  updatedAt_lte?: DateTimeInput;
+  updatedAt_gt?: DateTimeInput;
+  updatedAt_gte?: DateTimeInput;
+  url?: String;
+  url_not?: String;
+  url_in?: String[] | String;
+  url_not_in?: String[] | String;
+  url_lt?: String;
+  url_lte?: String;
+  url_gt?: String;
+  url_gte?: String;
+  url_contains?: String;
+  url_not_contains?: String;
+  url_starts_with?: String;
+  url_not_starts_with?: String;
+  url_ends_with?: String;
+  url_not_ends_with?: String;
+  md5?: String;
+  md5_not?: String;
+  md5_in?: String[] | String;
+  md5_not_in?: String[] | String;
+  md5_lt?: String;
+  md5_lte?: String;
+  md5_gt?: String;
+  md5_gte?: String;
+  md5_contains?: String;
+  md5_not_contains?: String;
+  md5_starts_with?: String;
+  md5_not_starts_with?: String;
+  md5_ends_with?: String;
+  md5_not_ends_with?: String;
+  filename?: String;
+  filename_not?: String;
+  filename_in?: String[] | String;
+  filename_not_in?: String[] | String;
+  filename_lt?: String;
+  filename_lte?: String;
+  filename_gt?: String;
+  filename_gte?: String;
+  filename_contains?: String;
+  filename_not_contains?: String;
+  filename_starts_with?: String;
+  filename_not_starts_with?: String;
+  filename_ends_with?: String;
+  filename_not_ends_with?: String;
+  filetype?: String;
+  filetype_not?: String;
+  filetype_in?: String[] | String;
+  filetype_not_in?: String[] | String;
+  filetype_lt?: String;
+  filetype_lte?: String;
+  filetype_gt?: String;
+  filetype_gte?: String;
+  filetype_contains?: String;
+  filetype_not_contains?: String;
+  filetype_starts_with?: String;
+  filetype_not_starts_with?: String;
+  filetype_ends_with?: String;
+  filetype_not_ends_with?: String;
+  filesize?: Float;
+  filesize_not?: Float;
+  filesize_in?: Float[] | Float;
+  filesize_not_in?: Float[] | Float;
+  filesize_lt?: Float;
+  filesize_lte?: Float;
+  filesize_gt?: Float;
+  filesize_gte?: Float;
+  AND?: SupportFileScalarWhereInput[] | SupportFileScalarWhereInput;
+  OR?: SupportFileScalarWhereInput[] | SupportFileScalarWhereInput;
+  NOT?: SupportFileScalarWhereInput[] | SupportFileScalarWhereInput;
+}
+
+export interface ImageFileCreateInput {
+  language?: LanguageCreateOneInput;
+  dimensions?: DimensionsCreateOneInput;
+  alt?: String;
+  longdesc?: String;
+  caption?: String;
+  filename?: String;
+  filetype?: String;
+  md5?: String;
+  url?: String;
+}
+
+export type ThumbnailWhereUniqueInput = AtLeastOne<{
+  id: ID_Input;
+}>;
+
+export interface DimensionsCreateOneInput {
+  create?: DimensionsCreateInput;
+  connect?: DimensionsWhereUniqueInput;
 }
 
 export interface SupportFileUpdateWithWhereUniqueNestedInput {
@@ -3400,31 +1790,347 @@ export interface SupportFileUpdateWithWhereUniqueNestedInput {
   data: SupportFileUpdateDataInput;
 }
 
-export interface VideoUseUpdateOneInput {
-  create?: VideoUseCreateInput;
-  update?: VideoUseUpdateDataInput;
-  upsert?: VideoUseUpsertNestedInput;
+export interface ImageFileUpdateInput {
+  language?: LanguageUpdateOneInput;
+  dimensions?: DimensionsUpdateOneInput;
+  alt?: String;
+  longdesc?: String;
+  caption?: String;
+  filename?: String;
+  filetype?: String;
+  md5?: String;
+  url?: String;
+}
+
+export interface SupportFileUpdateManyInput {
+  create?: SupportFileCreateInput[] | SupportFileCreateInput;
+  update?:
+    | SupportFileUpdateWithWhereUniqueNestedInput[]
+    | SupportFileUpdateWithWhereUniqueNestedInput;
+  upsert?:
+    | SupportFileUpsertWithWhereUniqueNestedInput[]
+    | SupportFileUpsertWithWhereUniqueNestedInput;
+  delete?: SupportFileWhereUniqueInput[] | SupportFileWhereUniqueInput;
+  connect?: SupportFileWhereUniqueInput[] | SupportFileWhereUniqueInput;
+  disconnect?: SupportFileWhereUniqueInput[] | SupportFileWhereUniqueInput;
+  deleteMany?: SupportFileScalarWhereInput[] | SupportFileScalarWhereInput;
+  updateMany?:
+    | SupportFileUpdateManyWithWhereNestedInput[]
+    | SupportFileUpdateManyWithWhereNestedInput;
+}
+
+export interface LanguageUpdateOneInput {
+  create?: LanguageCreateInput;
+  update?: LanguageUpdateDataInput;
+  upsert?: LanguageUpsertNestedInput;
   delete?: Boolean;
   disconnect?: Boolean;
-  connect?: VideoUseWhereUniqueInput;
+  connect?: LanguageWhereUniqueInput;
+}
+
+export interface VideoUnitUpdateManyWithWhereNestedInput {
+  where: VideoUnitScalarWhereInput;
+  data: VideoUnitUpdateManyDataInput;
+}
+
+export interface DimensionsUpdateOneInput {
+  create?: DimensionsCreateInput;
+  update?: DimensionsUpdateDataInput;
+  upsert?: DimensionsUpsertNestedInput;
+  delete?: Boolean;
+  disconnect?: Boolean;
+  connect?: DimensionsWhereUniqueInput;
+}
+
+export type UserWhereUniqueInput = AtLeastOne<{
+  id: ID_Input;
+  email?: String;
+}>;
+
+export interface DimensionsUpdateDataInput {
+  width?: Int;
+  height?: Int;
 }
 
 export interface ThumbnailUpdateManyDataInput {
   size?: ThumbnailSize;
 }
 
-export interface VideoUseUpdateDataInput {
+export interface DimensionsUpsertNestedInput {
+  update: DimensionsUpdateDataInput;
+  create: DimensionsCreateInput;
+}
+
+export type VideoFileWhereUniqueInput = AtLeastOne<{
+  id: ID_Input;
+}>;
+
+export interface ImageFileUpdateManyMutationInput {
+  alt?: String;
+  longdesc?: String;
+  caption?: String;
+  filename?: String;
+  filetype?: String;
+  md5?: String;
+  url?: String;
+}
+
+export interface ThumbnailUpsertWithWhereUniqueNestedInput {
+  where: ThumbnailWhereUniqueInput;
+  update: ThumbnailUpdateDataInput;
+  create: ThumbnailCreateInput;
+}
+
+export interface ImageUseCreateInput {
+  name: String;
+}
+
+export interface ThumbnailUpdateWithWhereUniqueNestedInput {
+  where: ThumbnailWhereUniqueInput;
+  data: ThumbnailUpdateDataInput;
+}
+
+export interface ImageUseUpdateInput {
   name?: String;
 }
 
-export interface ThumbnailUpdateDataInput {
-  size?: ThumbnailSize;
-  image?: ImageFileUpdateOneInput;
+export interface VideoFileWhereInput {
+  id?: ID_Input;
+  id_not?: ID_Input;
+  id_in?: ID_Input[] | ID_Input;
+  id_not_in?: ID_Input[] | ID_Input;
+  id_lt?: ID_Input;
+  id_lte?: ID_Input;
+  id_gt?: ID_Input;
+  id_gte?: ID_Input;
+  id_contains?: ID_Input;
+  id_not_contains?: ID_Input;
+  id_starts_with?: ID_Input;
+  id_not_starts_with?: ID_Input;
+  id_ends_with?: ID_Input;
+  id_not_ends_with?: ID_Input;
+  createdAt?: DateTimeInput;
+  createdAt_not?: DateTimeInput;
+  createdAt_in?: DateTimeInput[] | DateTimeInput;
+  createdAt_not_in?: DateTimeInput[] | DateTimeInput;
+  createdAt_lt?: DateTimeInput;
+  createdAt_lte?: DateTimeInput;
+  createdAt_gt?: DateTimeInput;
+  createdAt_gte?: DateTimeInput;
+  updatedAt?: DateTimeInput;
+  updatedAt_not?: DateTimeInput;
+  updatedAt_in?: DateTimeInput[] | DateTimeInput;
+  updatedAt_not_in?: DateTimeInput[] | DateTimeInput;
+  updatedAt_lt?: DateTimeInput;
+  updatedAt_lte?: DateTimeInput;
+  updatedAt_gt?: DateTimeInput;
+  updatedAt_gte?: DateTimeInput;
+  language?: LanguageWhereInput;
+  filetype?: String;
+  filetype_not?: String;
+  filetype_in?: String[] | String;
+  filetype_not_in?: String[] | String;
+  filetype_lt?: String;
+  filetype_lte?: String;
+  filetype_gt?: String;
+  filetype_gte?: String;
+  filetype_contains?: String;
+  filetype_not_contains?: String;
+  filetype_starts_with?: String;
+  filetype_not_starts_with?: String;
+  filetype_ends_with?: String;
+  filetype_not_ends_with?: String;
+  filename?: String;
+  filename_not?: String;
+  filename_in?: String[] | String;
+  filename_not_in?: String[] | String;
+  filename_lt?: String;
+  filename_lte?: String;
+  filename_gt?: String;
+  filename_gte?: String;
+  filename_contains?: String;
+  filename_not_contains?: String;
+  filename_starts_with?: String;
+  filename_not_starts_with?: String;
+  filename_ends_with?: String;
+  filename_not_ends_with?: String;
+  use?: VideoUseWhereInput;
+  quality?: VideoQuality;
+  quality_not?: VideoQuality;
+  quality_in?: VideoQuality[] | VideoQuality;
+  quality_not_in?: VideoQuality[] | VideoQuality;
+  videoBurnedInStatus?: VideoBurnedInStatus;
+  videoBurnedInStatus_not?: VideoBurnedInStatus;
+  videoBurnedInStatus_in?: VideoBurnedInStatus[] | VideoBurnedInStatus;
+  videoBurnedInStatus_not_in?: VideoBurnedInStatus[] | VideoBurnedInStatus;
+  url?: String;
+  url_not?: String;
+  url_in?: String[] | String;
+  url_not_in?: String[] | String;
+  url_lt?: String;
+  url_lte?: String;
+  url_gt?: String;
+  url_gte?: String;
+  url_contains?: String;
+  url_not_contains?: String;
+  url_starts_with?: String;
+  url_not_starts_with?: String;
+  url_ends_with?: String;
+  url_not_ends_with?: String;
+  md5?: String;
+  md5_not?: String;
+  md5_in?: String[] | String;
+  md5_not_in?: String[] | String;
+  md5_lt?: String;
+  md5_lte?: String;
+  md5_gt?: String;
+  md5_gte?: String;
+  md5_contains?: String;
+  md5_not_contains?: String;
+  md5_starts_with?: String;
+  md5_not_starts_with?: String;
+  md5_ends_with?: String;
+  md5_not_ends_with?: String;
+  duration?: Float;
+  duration_not?: Float;
+  duration_in?: Float[] | Float;
+  duration_not_in?: Float[] | Float;
+  duration_lt?: Float;
+  duration_lte?: Float;
+  duration_gt?: Float;
+  duration_gte?: Float;
+  bitrate?: Float;
+  bitrate_not?: Float;
+  bitrate_in?: Float[] | Float;
+  bitrate_not_in?: Float[] | Float;
+  bitrate_lt?: Float;
+  bitrate_lte?: Float;
+  bitrate_gt?: Float;
+  bitrate_gte?: Float;
+  filesize?: Float;
+  filesize_not?: Float;
+  filesize_in?: Float[] | Float;
+  filesize_not_in?: Float[] | Float;
+  filesize_lt?: Float;
+  filesize_lte?: Float;
+  filesize_gt?: Float;
+  filesize_gte?: Float;
+  dimensions?: DimensionsWhereInput;
+  stream?: VideoStreamWhereInput;
+  AND?: VideoFileWhereInput[] | VideoFileWhereInput;
+  OR?: VideoFileWhereInput[] | VideoFileWhereInput;
+  NOT?: VideoFileWhereInput[] | VideoFileWhereInput;
 }
 
-export interface VideoUseUpsertNestedInput {
-  update: VideoUseUpdateDataInput;
-  create: VideoUseCreateInput;
+export interface ImageUseUpdateManyMutationInput {
+  name?: String;
+}
+
+export interface VideoStreamWhereInput {
+  id?: ID_Input;
+  id_not?: ID_Input;
+  id_in?: ID_Input[] | ID_Input;
+  id_not_in?: ID_Input[] | ID_Input;
+  id_lt?: ID_Input;
+  id_lte?: ID_Input;
+  id_gt?: ID_Input;
+  id_gte?: ID_Input;
+  id_contains?: ID_Input;
+  id_not_contains?: ID_Input;
+  id_starts_with?: ID_Input;
+  id_not_starts_with?: ID_Input;
+  id_ends_with?: ID_Input;
+  id_not_ends_with?: ID_Input;
+  site?: String;
+  site_not?: String;
+  site_in?: String[] | String;
+  site_not_in?: String[] | String;
+  site_lt?: String;
+  site_lte?: String;
+  site_gt?: String;
+  site_gte?: String;
+  site_contains?: String;
+  site_not_contains?: String;
+  site_starts_with?: String;
+  site_not_starts_with?: String;
+  site_ends_with?: String;
+  site_not_ends_with?: String;
+  url?: String;
+  url_not?: String;
+  url_in?: String[] | String;
+  url_not_in?: String[] | String;
+  url_lt?: String;
+  url_lte?: String;
+  url_gt?: String;
+  url_gte?: String;
+  url_contains?: String;
+  url_not_contains?: String;
+  url_starts_with?: String;
+  url_not_starts_with?: String;
+  url_ends_with?: String;
+  url_not_ends_with?: String;
+  embedUrl?: String;
+  embedUrl_not?: String;
+  embedUrl_in?: String[] | String;
+  embedUrl_not_in?: String[] | String;
+  embedUrl_lt?: String;
+  embedUrl_lte?: String;
+  embedUrl_gt?: String;
+  embedUrl_gte?: String;
+  embedUrl_contains?: String;
+  embedUrl_not_contains?: String;
+  embedUrl_starts_with?: String;
+  embedUrl_not_starts_with?: String;
+  embedUrl_ends_with?: String;
+  embedUrl_not_ends_with?: String;
+  AND?: VideoStreamWhereInput[] | VideoStreamWhereInput;
+  OR?: VideoStreamWhereInput[] | VideoStreamWhereInput;
+  NOT?: VideoStreamWhereInput[] | VideoStreamWhereInput;
+}
+
+export interface LanguageUpdateInput {
+  languageCode?: String;
+  locale?: String;
+  textDirection?: String;
+  displayName?: String;
+  nativeName?: String;
+}
+
+export interface CategoryScalarWhereInput {
+  id?: ID_Input;
+  id_not?: ID_Input;
+  id_in?: ID_Input[] | ID_Input;
+  id_not_in?: ID_Input[] | ID_Input;
+  id_lt?: ID_Input;
+  id_lte?: ID_Input;
+  id_gt?: ID_Input;
+  id_gte?: ID_Input;
+  id_contains?: ID_Input;
+  id_not_contains?: ID_Input;
+  id_starts_with?: ID_Input;
+  id_not_starts_with?: ID_Input;
+  id_ends_with?: ID_Input;
+  id_not_ends_with?: ID_Input;
+  AND?: CategoryScalarWhereInput[] | CategoryScalarWhereInput;
+  OR?: CategoryScalarWhereInput[] | CategoryScalarWhereInput;
+  NOT?: CategoryScalarWhereInput[] | CategoryScalarWhereInput;
+}
+
+export interface LanguageUpdateManyMutationInput {
+  languageCode?: String;
+  locale?: String;
+  textDirection?: String;
+  displayName?: String;
+  nativeName?: String;
+}
+
+export interface CategoryUpdateDataInput {
+  translations?: LanguageTranslationUpdateManyInput;
+}
+
+export interface LanguageTranslationUpdateInput {
+  name?: String;
+  language?: LanguageUpdateOneRequiredInput;
 }
 
 export interface CategoryUpdateWithWhereUniqueNestedInput {
@@ -3432,13 +2138,197 @@ export interface CategoryUpdateWithWhereUniqueNestedInput {
   data: CategoryUpdateDataInput;
 }
 
-export interface VideoStreamUpdateOneInput {
-  create?: VideoStreamCreateInput;
-  update?: VideoStreamUpdateDataInput;
-  upsert?: VideoStreamUpsertNestedInput;
-  delete?: Boolean;
-  disconnect?: Boolean;
-  connect?: VideoStreamWhereUniqueInput;
+export interface LanguageTranslationUpdateManyMutationInput {
+  name?: String;
+}
+
+export interface TagScalarWhereInput {
+  id?: ID_Input;
+  id_not?: ID_Input;
+  id_in?: ID_Input[] | ID_Input;
+  id_not_in?: ID_Input[] | ID_Input;
+  id_lt?: ID_Input;
+  id_lte?: ID_Input;
+  id_gt?: ID_Input;
+  id_gte?: ID_Input;
+  id_contains?: ID_Input;
+  id_not_contains?: ID_Input;
+  id_starts_with?: ID_Input;
+  id_not_starts_with?: ID_Input;
+  id_ends_with?: ID_Input;
+  id_not_ends_with?: ID_Input;
+  AND?: TagScalarWhereInput[] | TagScalarWhereInput;
+  OR?: TagScalarWhereInput[] | TagScalarWhereInput;
+  NOT?: TagScalarWhereInput[] | TagScalarWhereInput;
+}
+
+export interface VideoProjectUpdateInput {
+  projectType?: String;
+  projectTitle?: String;
+  descPublic?: String;
+  descInternal?: String;
+  author?: String;
+  team?: TeamUpdateOneInput;
+  status?: ProjectPublishStatus;
+  visibility?: ProjectVisibility;
+  units?: VideoUnitUpdateManyInput;
+  supportFiles?: SupportFileUpdateManyInput;
+  thumbnails?: ImageFileUpdateManyInput;
+  categories?: CategoryUpdateManyInput;
+  tags?: TagUpdateManyInput;
+}
+
+export interface TagUpsertWithWhereUniqueNestedInput {
+  where: TagWhereUniqueInput;
+  update: TagUpdateDataInput;
+  create: TagCreateInput;
+}
+
+export interface SupportFileUpdateInput {
+  language?: LanguageUpdateOneRequiredInput;
+  url?: String;
+  md5?: String;
+  filename?: String;
+  filetype?: String;
+  filesize?: Float;
+}
+
+export interface VideoProjectWhereInput {
+  id?: ID_Input;
+  id_not?: ID_Input;
+  id_in?: ID_Input[] | ID_Input;
+  id_not_in?: ID_Input[] | ID_Input;
+  id_lt?: ID_Input;
+  id_lte?: ID_Input;
+  id_gt?: ID_Input;
+  id_gte?: ID_Input;
+  id_contains?: ID_Input;
+  id_not_contains?: ID_Input;
+  id_starts_with?: ID_Input;
+  id_not_starts_with?: ID_Input;
+  id_ends_with?: ID_Input;
+  id_not_ends_with?: ID_Input;
+  createdAt?: DateTimeInput;
+  createdAt_not?: DateTimeInput;
+  createdAt_in?: DateTimeInput[] | DateTimeInput;
+  createdAt_not_in?: DateTimeInput[] | DateTimeInput;
+  createdAt_lt?: DateTimeInput;
+  createdAt_lte?: DateTimeInput;
+  createdAt_gt?: DateTimeInput;
+  createdAt_gte?: DateTimeInput;
+  updatedAt?: DateTimeInput;
+  updatedAt_not?: DateTimeInput;
+  updatedAt_in?: DateTimeInput[] | DateTimeInput;
+  updatedAt_not_in?: DateTimeInput[] | DateTimeInput;
+  updatedAt_lt?: DateTimeInput;
+  updatedAt_lte?: DateTimeInput;
+  updatedAt_gt?: DateTimeInput;
+  updatedAt_gte?: DateTimeInput;
+  projectType?: String;
+  projectType_not?: String;
+  projectType_in?: String[] | String;
+  projectType_not_in?: String[] | String;
+  projectType_lt?: String;
+  projectType_lte?: String;
+  projectType_gt?: String;
+  projectType_gte?: String;
+  projectType_contains?: String;
+  projectType_not_contains?: String;
+  projectType_starts_with?: String;
+  projectType_not_starts_with?: String;
+  projectType_ends_with?: String;
+  projectType_not_ends_with?: String;
+  projectTitle?: String;
+  projectTitle_not?: String;
+  projectTitle_in?: String[] | String;
+  projectTitle_not_in?: String[] | String;
+  projectTitle_lt?: String;
+  projectTitle_lte?: String;
+  projectTitle_gt?: String;
+  projectTitle_gte?: String;
+  projectTitle_contains?: String;
+  projectTitle_not_contains?: String;
+  projectTitle_starts_with?: String;
+  projectTitle_not_starts_with?: String;
+  projectTitle_ends_with?: String;
+  projectTitle_not_ends_with?: String;
+  descPublic?: String;
+  descPublic_not?: String;
+  descPublic_in?: String[] | String;
+  descPublic_not_in?: String[] | String;
+  descPublic_lt?: String;
+  descPublic_lte?: String;
+  descPublic_gt?: String;
+  descPublic_gte?: String;
+  descPublic_contains?: String;
+  descPublic_not_contains?: String;
+  descPublic_starts_with?: String;
+  descPublic_not_starts_with?: String;
+  descPublic_ends_with?: String;
+  descPublic_not_ends_with?: String;
+  descInternal?: String;
+  descInternal_not?: String;
+  descInternal_in?: String[] | String;
+  descInternal_not_in?: String[] | String;
+  descInternal_lt?: String;
+  descInternal_lte?: String;
+  descInternal_gt?: String;
+  descInternal_gte?: String;
+  descInternal_contains?: String;
+  descInternal_not_contains?: String;
+  descInternal_starts_with?: String;
+  descInternal_not_starts_with?: String;
+  descInternal_ends_with?: String;
+  descInternal_not_ends_with?: String;
+  author?: String;
+  author_not?: String;
+  author_in?: String[] | String;
+  author_not_in?: String[] | String;
+  author_lt?: String;
+  author_lte?: String;
+  author_gt?: String;
+  author_gte?: String;
+  author_contains?: String;
+  author_not_contains?: String;
+  author_starts_with?: String;
+  author_not_starts_with?: String;
+  author_ends_with?: String;
+  author_not_ends_with?: String;
+  team?: TeamWhereInput;
+  status?: ProjectPublishStatus;
+  status_not?: ProjectPublishStatus;
+  status_in?: ProjectPublishStatus[] | ProjectPublishStatus;
+  status_not_in?: ProjectPublishStatus[] | ProjectPublishStatus;
+  visibility?: ProjectVisibility;
+  visibility_not?: ProjectVisibility;
+  visibility_in?: ProjectVisibility[] | ProjectVisibility;
+  visibility_not_in?: ProjectVisibility[] | ProjectVisibility;
+  units_every?: VideoUnitWhereInput;
+  units_some?: VideoUnitWhereInput;
+  units_none?: VideoUnitWhereInput;
+  supportFiles_every?: SupportFileWhereInput;
+  supportFiles_some?: SupportFileWhereInput;
+  supportFiles_none?: SupportFileWhereInput;
+  thumbnails_every?: ImageFileWhereInput;
+  thumbnails_some?: ImageFileWhereInput;
+  thumbnails_none?: ImageFileWhereInput;
+  categories_every?: CategoryWhereInput;
+  categories_some?: CategoryWhereInput;
+  categories_none?: CategoryWhereInput;
+  tags_every?: TagWhereInput;
+  tags_some?: TagWhereInput;
+  tags_none?: TagWhereInput;
+  AND?: VideoProjectWhereInput[] | VideoProjectWhereInput;
+  OR?: VideoProjectWhereInput[] | VideoProjectWhereInput;
+  NOT?: VideoProjectWhereInput[] | VideoProjectWhereInput;
+}
+
+export interface SupportFileUpdateManyMutationInput {
+  url?: String;
+  md5?: String;
+  filename?: String;
+  filetype?: String;
+  filesize?: Float;
 }
 
 export interface TagUpdateWithWhereUniqueNestedInput {
@@ -3446,39 +2336,11 @@ export interface TagUpdateWithWhereUniqueNestedInput {
   data: TagUpdateDataInput;
 }
 
-export interface VideoStreamUpdateDataInput {
-  site?: String;
-  url?: String;
-  embedUrl?: String;
+export interface TagCreateInput {
+  translations?: LanguageTranslationCreateManyInput;
 }
 
-export type VideoUseWhereUniqueInput = AtLeastOne<{
-  id: ID_Input;
-}>;
-
-export interface VideoStreamUpsertNestedInput {
-  update: VideoStreamUpdateDataInput;
-  create: VideoStreamCreateInput;
-}
-
-export interface VideoProjectSubscriptionWhereInput {
-  mutation_in?: MutationType[] | MutationType;
-  updatedFields_contains?: String;
-  updatedFields_contains_every?: String[] | String;
-  updatedFields_contains_some?: String[] | String;
-  node?: VideoProjectWhereInput;
-  AND?:
-    | VideoProjectSubscriptionWhereInput[]
-    | VideoProjectSubscriptionWhereInput;
-  OR?:
-    | VideoProjectSubscriptionWhereInput[]
-    | VideoProjectSubscriptionWhereInput;
-  NOT?:
-    | VideoProjectSubscriptionWhereInput[]
-    | VideoProjectSubscriptionWhereInput;
-}
-
-export interface VideoFileUpdateManyMutationInput {
+export interface VideoFileUpdateManyDataInput {
   filetype?: String;
   filename?: String;
   quality?: VideoQuality;
@@ -3490,31 +2352,558 @@ export interface VideoFileUpdateManyMutationInput {
   filesize?: Float;
 }
 
-export interface CategorySubscriptionWhereInput {
+export interface TagUpdateInput {
+  translations?: LanguageTranslationUpdateManyInput;
+}
+
+export interface VideoFileUpdateManyWithWhereNestedInput {
+  where: VideoFileScalarWhereInput;
+  data: VideoFileUpdateManyDataInput;
+}
+
+export interface TeamCreateInput {
+  name: String;
+  organization: String;
+  members?: UserCreateManyWithoutTeamInput;
+  contentTypes?: TeamCreatecontentTypesInput;
+  isConfirmed?: Boolean;
+}
+
+export interface VideoFileUpsertWithWhereUniqueNestedInput {
+  where: VideoFileWhereUniqueInput;
+  update: VideoFileUpdateDataInput;
+  create: VideoFileCreateInput;
+}
+
+export interface UserCreateManyWithoutTeamInput {
+  create?: UserCreateWithoutTeamInput[] | UserCreateWithoutTeamInput;
+  connect?: UserWhereUniqueInput[] | UserWhereUniqueInput;
+}
+
+export type VideoUnitWhereUniqueInput = AtLeastOne<{
+  id: ID_Input;
+}>;
+
+export interface UserCreateWithoutTeamInput {
+  firstName: String;
+  lastName: String;
+  email: String;
+  password?: String;
+  tempToken?: String;
+  tempTokenExpiry?: Float;
+  jobTitle?: String;
+  country?: String;
+  city?: String;
+  howHeard?: String;
+  permissions?: UserCreatepermissionsInput;
+  isConfirmed?: Boolean;
+}
+
+export interface VideoFileUpdateManyInput {
+  create?: VideoFileCreateInput[] | VideoFileCreateInput;
+  update?:
+    | VideoFileUpdateWithWhereUniqueNestedInput[]
+    | VideoFileUpdateWithWhereUniqueNestedInput;
+  upsert?:
+    | VideoFileUpsertWithWhereUniqueNestedInput[]
+    | VideoFileUpsertWithWhereUniqueNestedInput;
+  delete?: VideoFileWhereUniqueInput[] | VideoFileWhereUniqueInput;
+  connect?: VideoFileWhereUniqueInput[] | VideoFileWhereUniqueInput;
+  disconnect?: VideoFileWhereUniqueInput[] | VideoFileWhereUniqueInput;
+  deleteMany?: VideoFileScalarWhereInput[] | VideoFileScalarWhereInput;
+  updateMany?:
+    | VideoFileUpdateManyWithWhereNestedInput[]
+    | VideoFileUpdateManyWithWhereNestedInput;
+}
+
+export interface UserCreatepermissionsInput {
+  set?: Permission[] | Permission;
+}
+
+export type VideoUseWhereUniqueInput = AtLeastOne<{
+  id: ID_Input;
+}>;
+
+export interface TeamCreatecontentTypesInput {
+  set?: ContentType[] | ContentType;
+}
+
+export interface VideoUnitUpdateWithWhereUniqueNestedInput {
+  where: VideoUnitWhereUniqueInput;
+  data: VideoUnitUpdateDataInput;
+}
+
+export interface TeamUpdateInput {
+  name?: String;
+  organization?: String;
+  members?: UserUpdateManyWithoutTeamInput;
+  contentTypes?: TeamUpdatecontentTypesInput;
+  isConfirmed?: Boolean;
+}
+
+export interface VideoStreamSubscriptionWhereInput {
   mutation_in?: MutationType[] | MutationType;
   updatedFields_contains?: String;
   updatedFields_contains_every?: String[] | String;
   updatedFields_contains_some?: String[] | String;
-  node?: CategoryWhereInput;
-  AND?: CategorySubscriptionWhereInput[] | CategorySubscriptionWhereInput;
-  OR?: CategorySubscriptionWhereInput[] | CategorySubscriptionWhereInput;
-  NOT?: CategorySubscriptionWhereInput[] | CategorySubscriptionWhereInput;
+  node?: VideoStreamWhereInput;
+  AND?: VideoStreamSubscriptionWhereInput[] | VideoStreamSubscriptionWhereInput;
+  OR?: VideoStreamSubscriptionWhereInput[] | VideoStreamSubscriptionWhereInput;
+  NOT?: VideoStreamSubscriptionWhereInput[] | VideoStreamSubscriptionWhereInput;
 }
 
-export interface VideoProjectCreateInput {
-  projectType: String;
-  projectTitle: String;
+export interface UserUpdateManyWithoutTeamInput {
+  create?: UserCreateWithoutTeamInput[] | UserCreateWithoutTeamInput;
+  delete?: UserWhereUniqueInput[] | UserWhereUniqueInput;
+  connect?: UserWhereUniqueInput[] | UserWhereUniqueInput;
+  disconnect?: UserWhereUniqueInput[] | UserWhereUniqueInput;
+  update?:
+    | UserUpdateWithWhereUniqueWithoutTeamInput[]
+    | UserUpdateWithWhereUniqueWithoutTeamInput;
+  upsert?:
+    | UserUpsertWithWhereUniqueWithoutTeamInput[]
+    | UserUpsertWithWhereUniqueWithoutTeamInput;
+  deleteMany?: UserScalarWhereInput[] | UserScalarWhereInput;
+  updateMany?:
+    | UserUpdateManyWithWhereNestedInput[]
+    | UserUpdateManyWithWhereNestedInput;
+}
+
+export interface ImageUseWhereInput {
+  id?: ID_Input;
+  id_not?: ID_Input;
+  id_in?: ID_Input[] | ID_Input;
+  id_not_in?: ID_Input[] | ID_Input;
+  id_lt?: ID_Input;
+  id_lte?: ID_Input;
+  id_gt?: ID_Input;
+  id_gte?: ID_Input;
+  id_contains?: ID_Input;
+  id_not_contains?: ID_Input;
+  id_starts_with?: ID_Input;
+  id_not_starts_with?: ID_Input;
+  id_ends_with?: ID_Input;
+  id_not_ends_with?: ID_Input;
+  name?: String;
+  name_not?: String;
+  name_in?: String[] | String;
+  name_not_in?: String[] | String;
+  name_lt?: String;
+  name_lte?: String;
+  name_gt?: String;
+  name_gte?: String;
+  name_contains?: String;
+  name_not_contains?: String;
+  name_starts_with?: String;
+  name_not_starts_with?: String;
+  name_ends_with?: String;
+  name_not_ends_with?: String;
+  AND?: ImageUseWhereInput[] | ImageUseWhereInput;
+  OR?: ImageUseWhereInput[] | ImageUseWhereInput;
+  NOT?: ImageUseWhereInput[] | ImageUseWhereInput;
+}
+
+export interface UserUpdateWithWhereUniqueWithoutTeamInput {
+  where: UserWhereUniqueInput;
+  data: UserUpdateWithoutTeamDataInput;
+}
+
+export interface TeamSubscriptionWhereInput {
+  mutation_in?: MutationType[] | MutationType;
+  updatedFields_contains?: String;
+  updatedFields_contains_every?: String[] | String;
+  updatedFields_contains_some?: String[] | String;
+  node?: TeamWhereInput;
+  AND?: TeamSubscriptionWhereInput[] | TeamSubscriptionWhereInput;
+  OR?: TeamSubscriptionWhereInput[] | TeamSubscriptionWhereInput;
+  NOT?: TeamSubscriptionWhereInput[] | TeamSubscriptionWhereInput;
+}
+
+export interface ImageFileWhereInput {
+  id?: ID_Input;
+  id_not?: ID_Input;
+  id_in?: ID_Input[] | ID_Input;
+  id_not_in?: ID_Input[] | ID_Input;
+  id_lt?: ID_Input;
+  id_lte?: ID_Input;
+  id_gt?: ID_Input;
+  id_gte?: ID_Input;
+  id_contains?: ID_Input;
+  id_not_contains?: ID_Input;
+  id_starts_with?: ID_Input;
+  id_not_starts_with?: ID_Input;
+  id_ends_with?: ID_Input;
+  id_not_ends_with?: ID_Input;
+  createdAt?: DateTimeInput;
+  createdAt_not?: DateTimeInput;
+  createdAt_in?: DateTimeInput[] | DateTimeInput;
+  createdAt_not_in?: DateTimeInput[] | DateTimeInput;
+  createdAt_lt?: DateTimeInput;
+  createdAt_lte?: DateTimeInput;
+  createdAt_gt?: DateTimeInput;
+  createdAt_gte?: DateTimeInput;
+  updatedAt?: DateTimeInput;
+  updatedAt_not?: DateTimeInput;
+  updatedAt_in?: DateTimeInput[] | DateTimeInput;
+  updatedAt_not_in?: DateTimeInput[] | DateTimeInput;
+  updatedAt_lt?: DateTimeInput;
+  updatedAt_lte?: DateTimeInput;
+  updatedAt_gt?: DateTimeInput;
+  updatedAt_gte?: DateTimeInput;
+  language?: LanguageWhereInput;
+  dimensions?: DimensionsWhereInput;
+  alt?: String;
+  alt_not?: String;
+  alt_in?: String[] | String;
+  alt_not_in?: String[] | String;
+  alt_lt?: String;
+  alt_lte?: String;
+  alt_gt?: String;
+  alt_gte?: String;
+  alt_contains?: String;
+  alt_not_contains?: String;
+  alt_starts_with?: String;
+  alt_not_starts_with?: String;
+  alt_ends_with?: String;
+  alt_not_ends_with?: String;
+  longdesc?: String;
+  longdesc_not?: String;
+  longdesc_in?: String[] | String;
+  longdesc_not_in?: String[] | String;
+  longdesc_lt?: String;
+  longdesc_lte?: String;
+  longdesc_gt?: String;
+  longdesc_gte?: String;
+  longdesc_contains?: String;
+  longdesc_not_contains?: String;
+  longdesc_starts_with?: String;
+  longdesc_not_starts_with?: String;
+  longdesc_ends_with?: String;
+  longdesc_not_ends_with?: String;
+  caption?: String;
+  caption_not?: String;
+  caption_in?: String[] | String;
+  caption_not_in?: String[] | String;
+  caption_lt?: String;
+  caption_lte?: String;
+  caption_gt?: String;
+  caption_gte?: String;
+  caption_contains?: String;
+  caption_not_contains?: String;
+  caption_starts_with?: String;
+  caption_not_starts_with?: String;
+  caption_ends_with?: String;
+  caption_not_ends_with?: String;
+  filename?: String;
+  filename_not?: String;
+  filename_in?: String[] | String;
+  filename_not_in?: String[] | String;
+  filename_lt?: String;
+  filename_lte?: String;
+  filename_gt?: String;
+  filename_gte?: String;
+  filename_contains?: String;
+  filename_not_contains?: String;
+  filename_starts_with?: String;
+  filename_not_starts_with?: String;
+  filename_ends_with?: String;
+  filename_not_ends_with?: String;
+  filetype?: String;
+  filetype_not?: String;
+  filetype_in?: String[] | String;
+  filetype_not_in?: String[] | String;
+  filetype_lt?: String;
+  filetype_lte?: String;
+  filetype_gt?: String;
+  filetype_gte?: String;
+  filetype_contains?: String;
+  filetype_not_contains?: String;
+  filetype_starts_with?: String;
+  filetype_not_starts_with?: String;
+  filetype_ends_with?: String;
+  filetype_not_ends_with?: String;
+  md5?: String;
+  md5_not?: String;
+  md5_in?: String[] | String;
+  md5_not_in?: String[] | String;
+  md5_lt?: String;
+  md5_lte?: String;
+  md5_gt?: String;
+  md5_gte?: String;
+  md5_contains?: String;
+  md5_not_contains?: String;
+  md5_starts_with?: String;
+  md5_not_starts_with?: String;
+  md5_ends_with?: String;
+  md5_not_ends_with?: String;
+  url?: String;
+  url_not?: String;
+  url_in?: String[] | String;
+  url_not_in?: String[] | String;
+  url_lt?: String;
+  url_lte?: String;
+  url_gt?: String;
+  url_gte?: String;
+  url_contains?: String;
+  url_not_contains?: String;
+  url_starts_with?: String;
+  url_not_starts_with?: String;
+  url_ends_with?: String;
+  url_not_ends_with?: String;
+  AND?: ImageFileWhereInput[] | ImageFileWhereInput;
+  OR?: ImageFileWhereInput[] | ImageFileWhereInput;
+  NOT?: ImageFileWhereInput[] | ImageFileWhereInput;
+}
+
+export interface LanguageTranslationSubscriptionWhereInput {
+  mutation_in?: MutationType[] | MutationType;
+  updatedFields_contains?: String;
+  updatedFields_contains_every?: String[] | String;
+  updatedFields_contains_some?: String[] | String;
+  node?: LanguageTranslationWhereInput;
+  AND?:
+    | LanguageTranslationSubscriptionWhereInput[]
+    | LanguageTranslationSubscriptionWhereInput;
+  OR?:
+    | LanguageTranslationSubscriptionWhereInput[]
+    | LanguageTranslationSubscriptionWhereInput;
+  NOT?:
+    | LanguageTranslationSubscriptionWhereInput[]
+    | LanguageTranslationSubscriptionWhereInput;
+}
+
+export interface UserUpdatepermissionsInput {
+  set?: Permission[] | Permission;
+}
+
+export interface ImageFileSubscriptionWhereInput {
+  mutation_in?: MutationType[] | MutationType;
+  updatedFields_contains?: String;
+  updatedFields_contains_every?: String[] | String;
+  updatedFields_contains_some?: String[] | String;
+  node?: ImageFileWhereInput;
+  AND?: ImageFileSubscriptionWhereInput[] | ImageFileSubscriptionWhereInput;
+  OR?: ImageFileSubscriptionWhereInput[] | ImageFileSubscriptionWhereInput;
+  NOT?: ImageFileSubscriptionWhereInput[] | ImageFileSubscriptionWhereInput;
+}
+
+export interface UserUpsertWithWhereUniqueWithoutTeamInput {
+  where: UserWhereUniqueInput;
+  update: UserUpdateWithoutTeamDataInput;
+  create: UserCreateWithoutTeamInput;
+}
+
+export interface VideoUseUpdateManyMutationInput {
+  name?: String;
+}
+
+export interface UserScalarWhereInput {
+  id?: ID_Input;
+  id_not?: ID_Input;
+  id_in?: ID_Input[] | ID_Input;
+  id_not_in?: ID_Input[] | ID_Input;
+  id_lt?: ID_Input;
+  id_lte?: ID_Input;
+  id_gt?: ID_Input;
+  id_gte?: ID_Input;
+  id_contains?: ID_Input;
+  id_not_contains?: ID_Input;
+  id_starts_with?: ID_Input;
+  id_not_starts_with?: ID_Input;
+  id_ends_with?: ID_Input;
+  id_not_ends_with?: ID_Input;
+  firstName?: String;
+  firstName_not?: String;
+  firstName_in?: String[] | String;
+  firstName_not_in?: String[] | String;
+  firstName_lt?: String;
+  firstName_lte?: String;
+  firstName_gt?: String;
+  firstName_gte?: String;
+  firstName_contains?: String;
+  firstName_not_contains?: String;
+  firstName_starts_with?: String;
+  firstName_not_starts_with?: String;
+  firstName_ends_with?: String;
+  firstName_not_ends_with?: String;
+  lastName?: String;
+  lastName_not?: String;
+  lastName_in?: String[] | String;
+  lastName_not_in?: String[] | String;
+  lastName_lt?: String;
+  lastName_lte?: String;
+  lastName_gt?: String;
+  lastName_gte?: String;
+  lastName_contains?: String;
+  lastName_not_contains?: String;
+  lastName_starts_with?: String;
+  lastName_not_starts_with?: String;
+  lastName_ends_with?: String;
+  lastName_not_ends_with?: String;
+  email?: String;
+  email_not?: String;
+  email_in?: String[] | String;
+  email_not_in?: String[] | String;
+  email_lt?: String;
+  email_lte?: String;
+  email_gt?: String;
+  email_gte?: String;
+  email_contains?: String;
+  email_not_contains?: String;
+  email_starts_with?: String;
+  email_not_starts_with?: String;
+  email_ends_with?: String;
+  email_not_ends_with?: String;
+  password?: String;
+  password_not?: String;
+  password_in?: String[] | String;
+  password_not_in?: String[] | String;
+  password_lt?: String;
+  password_lte?: String;
+  password_gt?: String;
+  password_gte?: String;
+  password_contains?: String;
+  password_not_contains?: String;
+  password_starts_with?: String;
+  password_not_starts_with?: String;
+  password_ends_with?: String;
+  password_not_ends_with?: String;
+  tempToken?: String;
+  tempToken_not?: String;
+  tempToken_in?: String[] | String;
+  tempToken_not_in?: String[] | String;
+  tempToken_lt?: String;
+  tempToken_lte?: String;
+  tempToken_gt?: String;
+  tempToken_gte?: String;
+  tempToken_contains?: String;
+  tempToken_not_contains?: String;
+  tempToken_starts_with?: String;
+  tempToken_not_starts_with?: String;
+  tempToken_ends_with?: String;
+  tempToken_not_ends_with?: String;
+  tempTokenExpiry?: Float;
+  tempTokenExpiry_not?: Float;
+  tempTokenExpiry_in?: Float[] | Float;
+  tempTokenExpiry_not_in?: Float[] | Float;
+  tempTokenExpiry_lt?: Float;
+  tempTokenExpiry_lte?: Float;
+  tempTokenExpiry_gt?: Float;
+  tempTokenExpiry_gte?: Float;
+  jobTitle?: String;
+  jobTitle_not?: String;
+  jobTitle_in?: String[] | String;
+  jobTitle_not_in?: String[] | String;
+  jobTitle_lt?: String;
+  jobTitle_lte?: String;
+  jobTitle_gt?: String;
+  jobTitle_gte?: String;
+  jobTitle_contains?: String;
+  jobTitle_not_contains?: String;
+  jobTitle_starts_with?: String;
+  jobTitle_not_starts_with?: String;
+  jobTitle_ends_with?: String;
+  jobTitle_not_ends_with?: String;
+  country?: String;
+  country_not?: String;
+  country_in?: String[] | String;
+  country_not_in?: String[] | String;
+  country_lt?: String;
+  country_lte?: String;
+  country_gt?: String;
+  country_gte?: String;
+  country_contains?: String;
+  country_not_contains?: String;
+  country_starts_with?: String;
+  country_not_starts_with?: String;
+  country_ends_with?: String;
+  country_not_ends_with?: String;
+  city?: String;
+  city_not?: String;
+  city_in?: String[] | String;
+  city_not_in?: String[] | String;
+  city_lt?: String;
+  city_lte?: String;
+  city_gt?: String;
+  city_gte?: String;
+  city_contains?: String;
+  city_not_contains?: String;
+  city_starts_with?: String;
+  city_not_starts_with?: String;
+  city_ends_with?: String;
+  city_not_ends_with?: String;
+  howHeard?: String;
+  howHeard_not?: String;
+  howHeard_in?: String[] | String;
+  howHeard_not_in?: String[] | String;
+  howHeard_lt?: String;
+  howHeard_lte?: String;
+  howHeard_gt?: String;
+  howHeard_gte?: String;
+  howHeard_contains?: String;
+  howHeard_not_contains?: String;
+  howHeard_starts_with?: String;
+  howHeard_not_starts_with?: String;
+  howHeard_ends_with?: String;
+  howHeard_not_ends_with?: String;
+  isConfirmed?: Boolean;
+  isConfirmed_not?: Boolean;
+  AND?: UserScalarWhereInput[] | UserScalarWhereInput;
+  OR?: UserScalarWhereInput[] | UserScalarWhereInput;
+  NOT?: UserScalarWhereInput[] | UserScalarWhereInput;
+}
+
+export interface VideoUnitUpdateInput {
+  language?: LanguageUpdateOneInput;
+  title?: String;
   descPublic?: String;
-  descInternal?: String;
-  author?: String;
-  team?: TeamCreateOneInput;
-  status?: ProjectPublishStatus;
-  visibility?: ProjectVisibility;
-  units?: VideoUnitCreateManyInput;
-  supportFiles?: SupportFileCreateManyInput;
-  thumbnails?: ImageFileCreateManyInput;
-  categories?: CategoryCreateManyInput;
-  tags?: TagCreateManyInput;
+  files?: VideoFileUpdateManyInput;
+  tags?: TagUpdateManyInput;
+  categories?: CategoryUpdateManyInput;
+  thumbnails?: ThumbnailUpdateManyInput;
+}
+
+export interface UserUpdateManyWithWhereNestedInput {
+  where: UserScalarWhereInput;
+  data: UserUpdateManyDataInput;
+}
+
+export interface TagWhereInput {
+  id?: ID_Input;
+  id_not?: ID_Input;
+  id_in?: ID_Input[] | ID_Input;
+  id_not_in?: ID_Input[] | ID_Input;
+  id_lt?: ID_Input;
+  id_lte?: ID_Input;
+  id_gt?: ID_Input;
+  id_gte?: ID_Input;
+  id_contains?: ID_Input;
+  id_not_contains?: ID_Input;
+  id_starts_with?: ID_Input;
+  id_not_starts_with?: ID_Input;
+  id_ends_with?: ID_Input;
+  id_not_ends_with?: ID_Input;
+  translations_every?: LanguageTranslationWhereInput;
+  translations_some?: LanguageTranslationWhereInput;
+  translations_none?: LanguageTranslationWhereInput;
+  AND?: TagWhereInput[] | TagWhereInput;
+  OR?: TagWhereInput[] | TagWhereInput;
+  NOT?: TagWhereInput[] | TagWhereInput;
+}
+
+export interface UserUpdateManyDataInput {
+  firstName?: String;
+  lastName?: String;
+  email?: String;
+  password?: String;
+  tempToken?: String;
+  tempTokenExpiry?: Float;
+  jobTitle?: String;
+  country?: String;
+  city?: String;
+  howHeard?: String;
+  permissions?: UserUpdatepermissionsInput;
+  isConfirmed?: Boolean;
 }
 
 export interface ImageFileScalarWhereInput {
@@ -3532,6 +2921,22 @@ export interface ImageFileScalarWhereInput {
   id_not_starts_with?: ID_Input;
   id_ends_with?: ID_Input;
   id_not_ends_with?: ID_Input;
+  createdAt?: DateTimeInput;
+  createdAt_not?: DateTimeInput;
+  createdAt_in?: DateTimeInput[] | DateTimeInput;
+  createdAt_not_in?: DateTimeInput[] | DateTimeInput;
+  createdAt_lt?: DateTimeInput;
+  createdAt_lte?: DateTimeInput;
+  createdAt_gt?: DateTimeInput;
+  createdAt_gte?: DateTimeInput;
+  updatedAt?: DateTimeInput;
+  updatedAt_not?: DateTimeInput;
+  updatedAt_in?: DateTimeInput[] | DateTimeInput;
+  updatedAt_not_in?: DateTimeInput[] | DateTimeInput;
+  updatedAt_lt?: DateTimeInput;
+  updatedAt_lte?: DateTimeInput;
+  updatedAt_gt?: DateTimeInput;
+  updatedAt_gte?: DateTimeInput;
   alt?: String;
   alt_not?: String;
   alt_in?: String[] | String;
@@ -3635,22 +3040,11 @@ export interface ImageFileScalarWhereInput {
   NOT?: ImageFileScalarWhereInput[] | ImageFileScalarWhereInput;
 }
 
-export interface TeamCreateOneInput {
-  create?: TeamCreateInput;
-  connect?: TeamWhereUniqueInput;
+export interface TeamUpdatecontentTypesInput {
+  set?: ContentType[] | ContentType;
 }
 
-export interface VideoUnitUpdateManyWithWhereNestedInput {
-  where: VideoUnitScalarWhereInput;
-  data: VideoUnitUpdateManyDataInput;
-}
-
-export interface VideoUnitCreateManyInput {
-  create?: VideoUnitCreateInput[] | VideoUnitCreateInput;
-  connect?: VideoUnitWhereUniqueInput[] | VideoUnitWhereUniqueInput;
-}
-
-export interface CategoryScalarWhereInput {
+export interface TeamWhereInput {
   id?: ID_Input;
   id_not?: ID_Input;
   id_in?: ID_Input[] | ID_Input;
@@ -3665,47 +3059,72 @@ export interface CategoryScalarWhereInput {
   id_not_starts_with?: ID_Input;
   id_ends_with?: ID_Input;
   id_not_ends_with?: ID_Input;
-  AND?: CategoryScalarWhereInput[] | CategoryScalarWhereInput;
-  OR?: CategoryScalarWhereInput[] | CategoryScalarWhereInput;
-  NOT?: CategoryScalarWhereInput[] | CategoryScalarWhereInput;
+  name?: String;
+  name_not?: String;
+  name_in?: String[] | String;
+  name_not_in?: String[] | String;
+  name_lt?: String;
+  name_lte?: String;
+  name_gt?: String;
+  name_gte?: String;
+  name_contains?: String;
+  name_not_contains?: String;
+  name_starts_with?: String;
+  name_not_starts_with?: String;
+  name_ends_with?: String;
+  name_not_ends_with?: String;
+  organization?: String;
+  organization_not?: String;
+  organization_in?: String[] | String;
+  organization_not_in?: String[] | String;
+  organization_lt?: String;
+  organization_lte?: String;
+  organization_gt?: String;
+  organization_gte?: String;
+  organization_contains?: String;
+  organization_not_contains?: String;
+  organization_starts_with?: String;
+  organization_not_starts_with?: String;
+  organization_ends_with?: String;
+  organization_not_ends_with?: String;
+  members_every?: UserWhereInput;
+  members_some?: UserWhereInput;
+  members_none?: UserWhereInput;
+  isConfirmed?: Boolean;
+  isConfirmed_not?: Boolean;
+  AND?: TeamWhereInput[] | TeamWhereInput;
+  OR?: TeamWhereInput[] | TeamWhereInput;
+  NOT?: TeamWhereInput[] | TeamWhereInput;
 }
 
-export interface VideoUnitCreateInput {
-  language?: LanguageCreateOneInput;
-  title: String;
-  descPublic?: String;
-  files?: VideoFileCreateManyInput;
-  tags?: TagCreateManyInput;
-  categories?: CategoryCreateManyInput;
-  thumbnails?: ThumbnailCreateManyInput;
+export interface TeamUpdateManyMutationInput {
+  name?: String;
+  organization?: String;
+  contentTypes?: TeamUpdatecontentTypesInput;
+  isConfirmed?: Boolean;
 }
 
-export type VideoUnitWhereUniqueInput = AtLeastOne<{
+export type DimensionsWhereUniqueInput = AtLeastOne<{
   id: ID_Input;
 }>;
 
-export interface VideoFileCreateManyInput {
-  create?: VideoFileCreateInput[] | VideoFileCreateInput;
-  connect?: VideoFileWhereUniqueInput[] | VideoFileWhereUniqueInput;
+export interface ThumbnailCreateInput {
+  size?: ThumbnailSize;
+  image?: ImageFileCreateOneInput;
 }
 
-export interface SupportFileSubscriptionWhereInput {
-  mutation_in?: MutationType[] | MutationType;
-  updatedFields_contains?: String;
-  updatedFields_contains_every?: String[] | String;
-  updatedFields_contains_some?: String[] | String;
-  node?: SupportFileWhereInput;
-  AND?: SupportFileSubscriptionWhereInput[] | SupportFileSubscriptionWhereInput;
-  OR?: SupportFileSubscriptionWhereInput[] | SupportFileSubscriptionWhereInput;
-  NOT?: SupportFileSubscriptionWhereInput[] | SupportFileSubscriptionWhereInput;
+export interface SupportFileUpsertWithWhereUniqueNestedInput {
+  where: SupportFileWhereUniqueInput;
+  update: SupportFileUpdateDataInput;
+  create: SupportFileCreateInput;
 }
 
-export interface TagCreateManyInput {
-  create?: TagCreateInput[] | TagCreateInput;
-  connect?: TagWhereUniqueInput[] | TagWhereUniqueInput;
+export interface ImageFileCreateOneInput {
+  create?: ImageFileCreateInput;
+  connect?: ImageFileWhereUniqueInput;
 }
 
-export interface SupportFileScalarWhereInput {
+export interface ThumbnailWhereInput {
   id?: ID_Input;
   id_not?: ID_Input;
   id_in?: ID_Input[] | ID_Input;
@@ -3720,96 +3139,106 @@ export interface SupportFileScalarWhereInput {
   id_not_starts_with?: ID_Input;
   id_ends_with?: ID_Input;
   id_not_ends_with?: ID_Input;
-  url?: String;
-  url_not?: String;
-  url_in?: String[] | String;
-  url_not_in?: String[] | String;
-  url_lt?: String;
-  url_lte?: String;
-  url_gt?: String;
-  url_gte?: String;
-  url_contains?: String;
-  url_not_contains?: String;
-  url_starts_with?: String;
-  url_not_starts_with?: String;
-  url_ends_with?: String;
-  url_not_ends_with?: String;
+  size?: ThumbnailSize;
+  size_not?: ThumbnailSize;
+  size_in?: ThumbnailSize[] | ThumbnailSize;
+  size_not_in?: ThumbnailSize[] | ThumbnailSize;
+  image?: ImageFileWhereInput;
+  AND?: ThumbnailWhereInput[] | ThumbnailWhereInput;
+  OR?: ThumbnailWhereInput[] | ThumbnailWhereInput;
+  NOT?: ThumbnailWhereInput[] | ThumbnailWhereInput;
+}
+
+export interface ThumbnailUpdateInput {
+  size?: ThumbnailSize;
+  image?: ImageFileUpdateOneInput;
+}
+
+export interface VideoUnitScalarWhereInput {
+  id?: ID_Input;
+  id_not?: ID_Input;
+  id_in?: ID_Input[] | ID_Input;
+  id_not_in?: ID_Input[] | ID_Input;
+  id_lt?: ID_Input;
+  id_lte?: ID_Input;
+  id_gt?: ID_Input;
+  id_gte?: ID_Input;
+  id_contains?: ID_Input;
+  id_not_contains?: ID_Input;
+  id_starts_with?: ID_Input;
+  id_not_starts_with?: ID_Input;
+  id_ends_with?: ID_Input;
+  id_not_ends_with?: ID_Input;
+  title?: String;
+  title_not?: String;
+  title_in?: String[] | String;
+  title_not_in?: String[] | String;
+  title_lt?: String;
+  title_lte?: String;
+  title_gt?: String;
+  title_gte?: String;
+  title_contains?: String;
+  title_not_contains?: String;
+  title_starts_with?: String;
+  title_not_starts_with?: String;
+  title_ends_with?: String;
+  title_not_ends_with?: String;
+  descPublic?: String;
+  descPublic_not?: String;
+  descPublic_in?: String[] | String;
+  descPublic_not_in?: String[] | String;
+  descPublic_lt?: String;
+  descPublic_lte?: String;
+  descPublic_gt?: String;
+  descPublic_gte?: String;
+  descPublic_contains?: String;
+  descPublic_not_contains?: String;
+  descPublic_starts_with?: String;
+  descPublic_not_starts_with?: String;
+  descPublic_ends_with?: String;
+  descPublic_not_ends_with?: String;
+  AND?: VideoUnitScalarWhereInput[] | VideoUnitScalarWhereInput;
+  OR?: VideoUnitScalarWhereInput[] | VideoUnitScalarWhereInput;
+  NOT?: VideoUnitScalarWhereInput[] | VideoUnitScalarWhereInput;
+}
+
+export interface ImageFileUpdateOneInput {
+  create?: ImageFileCreateInput;
+  update?: ImageFileUpdateDataInput;
+  upsert?: ImageFileUpsertNestedInput;
+  delete?: Boolean;
+  disconnect?: Boolean;
+  connect?: ImageFileWhereUniqueInput;
+}
+
+export interface ThumbnailUpdateManyWithWhereNestedInput {
+  where: ThumbnailScalarWhereInput;
+  data: ThumbnailUpdateManyDataInput;
+}
+
+export interface ImageFileUpdateDataInput {
+  language?: LanguageUpdateOneInput;
+  dimensions?: DimensionsUpdateOneInput;
+  alt?: String;
+  longdesc?: String;
+  caption?: String;
+  filename?: String;
+  filetype?: String;
   md5?: String;
-  md5_not?: String;
-  md5_in?: String[] | String;
-  md5_not_in?: String[] | String;
-  md5_lt?: String;
-  md5_lte?: String;
-  md5_gt?: String;
-  md5_gte?: String;
-  md5_contains?: String;
-  md5_not_contains?: String;
-  md5_starts_with?: String;
-  md5_not_starts_with?: String;
-  md5_ends_with?: String;
-  md5_not_ends_with?: String;
-  filename?: String;
-  filename_not?: String;
-  filename_in?: String[] | String;
-  filename_not_in?: String[] | String;
-  filename_lt?: String;
-  filename_lte?: String;
-  filename_gt?: String;
-  filename_gte?: String;
-  filename_contains?: String;
-  filename_not_contains?: String;
-  filename_starts_with?: String;
-  filename_not_starts_with?: String;
-  filename_ends_with?: String;
-  filename_not_ends_with?: String;
-  filetype?: String;
-  filetype_not?: String;
-  filetype_in?: String[] | String;
-  filetype_not_in?: String[] | String;
-  filetype_lt?: String;
-  filetype_lte?: String;
-  filetype_gt?: String;
-  filetype_gte?: String;
-  filetype_contains?: String;
-  filetype_not_contains?: String;
-  filetype_starts_with?: String;
-  filetype_not_starts_with?: String;
-  filetype_ends_with?: String;
-  filetype_not_ends_with?: String;
-  filesize?: Float;
-  filesize_not?: Float;
-  filesize_in?: Float[] | Float;
-  filesize_not_in?: Float[] | Float;
-  filesize_lt?: Float;
-  filesize_lte?: Float;
-  filesize_gt?: Float;
-  filesize_gte?: Float;
-  AND?: SupportFileScalarWhereInput[] | SupportFileScalarWhereInput;
-  OR?: SupportFileScalarWhereInput[] | SupportFileScalarWhereInput;
-  NOT?: SupportFileScalarWhereInput[] | SupportFileScalarWhereInput;
+  url?: String;
 }
 
-export interface ImageFileCreateManyInput {
-  create?: ImageFileCreateInput[] | ImageFileCreateInput;
-  connect?: ImageFileWhereUniqueInput[] | ImageFileWhereUniqueInput;
+export interface ThumbnailUpdateDataInput {
+  size?: ThumbnailSize;
+  image?: ImageFileUpdateOneInput;
 }
 
-export interface SupportFileCreateManyInput {
-  create?: SupportFileCreateInput[] | SupportFileCreateInput;
-  connect?: SupportFileWhereUniqueInput[] | SupportFileWhereUniqueInput;
+export interface ImageFileUpsertNestedInput {
+  update: ImageFileUpdateDataInput;
+  create: ImageFileCreateInput;
 }
 
-export interface ThumbnailCreateManyInput {
-  create?: ThumbnailCreateInput[] | ThumbnailCreateInput;
-  connect?: ThumbnailWhereUniqueInput[] | ThumbnailWhereUniqueInput;
-}
-
-export interface CategoryCreateManyInput {
-  create?: CategoryCreateInput[] | CategoryCreateInput;
-  connect?: CategoryWhereUniqueInput[] | CategoryWhereUniqueInput;
-}
-
-export interface VideoFileWhereInput {
+export interface VideoUseWhereInput {
   id?: ID_Input;
   id_not?: ID_Input;
   id_in?: ID_Input[] | ID_Input;
@@ -3824,7 +3253,142 @@ export interface VideoFileWhereInput {
   id_not_starts_with?: ID_Input;
   id_ends_with?: ID_Input;
   id_not_ends_with?: ID_Input;
-  language?: LanguageWhereInput;
+  name?: String;
+  name_not?: String;
+  name_in?: String[] | String;
+  name_not_in?: String[] | String;
+  name_lt?: String;
+  name_lte?: String;
+  name_gt?: String;
+  name_gte?: String;
+  name_contains?: String;
+  name_not_contains?: String;
+  name_starts_with?: String;
+  name_not_starts_with?: String;
+  name_ends_with?: String;
+  name_not_ends_with?: String;
+  AND?: VideoUseWhereInput[] | VideoUseWhereInput;
+  OR?: VideoUseWhereInput[] | VideoUseWhereInput;
+  NOT?: VideoUseWhereInput[] | VideoUseWhereInput;
+}
+
+export interface ThumbnailUpdateManyMutationInput {
+  size?: ThumbnailSize;
+}
+
+export interface CategoryUpsertWithWhereUniqueNestedInput {
+  where: CategoryWhereUniqueInput;
+  update: CategoryUpdateDataInput;
+  create: CategoryCreateInput;
+}
+
+export interface UserCreateInput {
+  firstName: String;
+  lastName: String;
+  email: String;
+  password?: String;
+  tempToken?: String;
+  tempTokenExpiry?: Float;
+  jobTitle?: String;
+  country?: String;
+  city?: String;
+  howHeard?: String;
+  permissions?: UserCreatepermissionsInput;
+  team?: TeamCreateOneWithoutMembersInput;
+  isConfirmed?: Boolean;
+}
+
+export interface CategoryUpdateManyInput {
+  create?: CategoryCreateInput[] | CategoryCreateInput;
+  update?:
+    | CategoryUpdateWithWhereUniqueNestedInput[]
+    | CategoryUpdateWithWhereUniqueNestedInput;
+  upsert?:
+    | CategoryUpsertWithWhereUniqueNestedInput[]
+    | CategoryUpsertWithWhereUniqueNestedInput;
+  delete?: CategoryWhereUniqueInput[] | CategoryWhereUniqueInput;
+  connect?: CategoryWhereUniqueInput[] | CategoryWhereUniqueInput;
+  disconnect?: CategoryWhereUniqueInput[] | CategoryWhereUniqueInput;
+  deleteMany?: CategoryScalarWhereInput[] | CategoryScalarWhereInput;
+}
+
+export interface TeamCreateOneWithoutMembersInput {
+  create?: TeamCreateWithoutMembersInput;
+  connect?: TeamWhereUniqueInput;
+}
+
+export interface TagUpdateDataInput {
+  translations?: LanguageTranslationUpdateManyInput;
+}
+
+export interface TeamCreateWithoutMembersInput {
+  name: String;
+  organization: String;
+  contentTypes?: TeamCreatecontentTypesInput;
+  isConfirmed?: Boolean;
+}
+
+export interface TagUpdateManyInput {
+  create?: TagCreateInput[] | TagCreateInput;
+  update?:
+    | TagUpdateWithWhereUniqueNestedInput[]
+    | TagUpdateWithWhereUniqueNestedInput;
+  upsert?:
+    | TagUpsertWithWhereUniqueNestedInput[]
+    | TagUpsertWithWhereUniqueNestedInput;
+  delete?: TagWhereUniqueInput[] | TagWhereUniqueInput;
+  connect?: TagWhereUniqueInput[] | TagWhereUniqueInput;
+  disconnect?: TagWhereUniqueInput[] | TagWhereUniqueInput;
+  deleteMany?: TagScalarWhereInput[] | TagScalarWhereInput;
+}
+
+export interface UserUpdateInput {
+  firstName?: String;
+  lastName?: String;
+  email?: String;
+  password?: String;
+  tempToken?: String;
+  tempTokenExpiry?: Float;
+  jobTitle?: String;
+  country?: String;
+  city?: String;
+  howHeard?: String;
+  permissions?: UserUpdatepermissionsInput;
+  team?: TeamUpdateOneWithoutMembersInput;
+  isConfirmed?: Boolean;
+}
+
+export interface VideoFileScalarWhereInput {
+  id?: ID_Input;
+  id_not?: ID_Input;
+  id_in?: ID_Input[] | ID_Input;
+  id_not_in?: ID_Input[] | ID_Input;
+  id_lt?: ID_Input;
+  id_lte?: ID_Input;
+  id_gt?: ID_Input;
+  id_gte?: ID_Input;
+  id_contains?: ID_Input;
+  id_not_contains?: ID_Input;
+  id_starts_with?: ID_Input;
+  id_not_starts_with?: ID_Input;
+  id_ends_with?: ID_Input;
+  id_not_ends_with?: ID_Input;
+  createdAt?: DateTimeInput;
+  createdAt_not?: DateTimeInput;
+  createdAt_in?: DateTimeInput[] | DateTimeInput;
+  createdAt_not_in?: DateTimeInput[] | DateTimeInput;
+  createdAt_lt?: DateTimeInput;
+  createdAt_lte?: DateTimeInput;
+  createdAt_gt?: DateTimeInput;
+  createdAt_gte?: DateTimeInput;
+  updatedAt?: DateTimeInput;
+  updatedAt_not?: DateTimeInput;
+  updatedAt_in?: DateTimeInput[] | DateTimeInput;
+  updatedAt_not_in?: DateTimeInput[] | DateTimeInput;
+  updatedAt_lt?: DateTimeInput;
+  updatedAt_lte?: DateTimeInput;
+  updatedAt_gt?: DateTimeInput;
+  updatedAt_gte?: DateTimeInput;
   filetype?: String;
   filetype_not?: String;
   filetype_in?: String[] | String;
@@ -3853,7 +3417,6 @@ export interface VideoFileWhereInput {
   filename_not_starts_with?: String;
   filename_ends_with?: String;
   filename_not_ends_with?: String;
-  use?: VideoUseWhereInput;
   quality?: VideoQuality;
   quality_not?: VideoQuality;
   quality_in?: VideoQuality[] | VideoQuality;
@@ -3914,30 +3477,33 @@ export interface VideoFileWhereInput {
   filesize_lte?: Float;
   filesize_gt?: Float;
   filesize_gte?: Float;
-  dimensions?: DimensionsWhereInput;
-  stream?: VideoStreamWhereInput;
-  AND?: VideoFileWhereInput[] | VideoFileWhereInput;
-  OR?: VideoFileWhereInput[] | VideoFileWhereInput;
-  NOT?: VideoFileWhereInput[] | VideoFileWhereInput;
+  AND?: VideoFileScalarWhereInput[] | VideoFileScalarWhereInput;
+  OR?: VideoFileScalarWhereInput[] | VideoFileScalarWhereInput;
+  NOT?: VideoFileScalarWhereInput[] | VideoFileScalarWhereInput;
 }
 
-export interface VideoStreamUpdateInput {
-  site?: String;
-  url?: String;
-  embedUrl?: String;
+export interface TeamUpdateOneWithoutMembersInput {
+  create?: TeamCreateWithoutMembersInput;
+  update?: TeamUpdateWithoutMembersDataInput;
+  upsert?: TeamUpsertWithoutMembersInput;
+  delete?: Boolean;
+  disconnect?: Boolean;
+  connect?: TeamWhereUniqueInput;
 }
 
-export interface VideoUnitUpdateDataInput {
-  language?: LanguageUpdateOneInput;
-  title?: String;
-  descPublic?: String;
-  files?: VideoFileUpdateManyInput;
-  tags?: TagUpdateManyInput;
-  categories?: CategoryUpdateManyInput;
-  thumbnails?: ThumbnailUpdateManyInput;
+export interface VideoFileUpdateWithWhereUniqueNestedInput {
+  where: VideoFileWhereUniqueInput;
+  data: VideoFileUpdateDataInput;
 }
 
-export interface TagScalarWhereInput {
+export interface TeamUpdateWithoutMembersDataInput {
+  name?: String;
+  organization?: String;
+  contentTypes?: TeamUpdatecontentTypesInput;
+  isConfirmed?: Boolean;
+}
+
+export interface LanguageTranslationWhereInput {
   id?: ID_Input;
   id_not?: ID_Input;
   id_in?: ID_Input[] | ID_Input;
@@ -3952,9 +3518,555 @@ export interface TagScalarWhereInput {
   id_not_starts_with?: ID_Input;
   id_ends_with?: ID_Input;
   id_not_ends_with?: ID_Input;
-  AND?: TagScalarWhereInput[] | TagScalarWhereInput;
-  OR?: TagScalarWhereInput[] | TagScalarWhereInput;
-  NOT?: TagScalarWhereInput[] | TagScalarWhereInput;
+  name?: String;
+  name_not?: String;
+  name_in?: String[] | String;
+  name_not_in?: String[] | String;
+  name_lt?: String;
+  name_lte?: String;
+  name_gt?: String;
+  name_gte?: String;
+  name_contains?: String;
+  name_not_contains?: String;
+  name_starts_with?: String;
+  name_not_starts_with?: String;
+  name_ends_with?: String;
+  name_not_ends_with?: String;
+  language?: LanguageWhereInput;
+  AND?: LanguageTranslationWhereInput[] | LanguageTranslationWhereInput;
+  OR?: LanguageTranslationWhereInput[] | LanguageTranslationWhereInput;
+  NOT?: LanguageTranslationWhereInput[] | LanguageTranslationWhereInput;
+}
+
+export interface TeamUpsertWithoutMembersInput {
+  update: TeamUpdateWithoutMembersDataInput;
+  create: TeamCreateWithoutMembersInput;
+}
+
+export type ImageUseWhereUniqueInput = AtLeastOne<{
+  id: ID_Input;
+}>;
+
+export interface UserUpdateManyMutationInput {
+  firstName?: String;
+  lastName?: String;
+  email?: String;
+  password?: String;
+  tempToken?: String;
+  tempTokenExpiry?: Float;
+  jobTitle?: String;
+  country?: String;
+  city?: String;
+  howHeard?: String;
+  permissions?: UserUpdatepermissionsInput;
+  isConfirmed?: Boolean;
+}
+
+export interface TagSubscriptionWhereInput {
+  mutation_in?: MutationType[] | MutationType;
+  updatedFields_contains?: String;
+  updatedFields_contains_every?: String[] | String;
+  updatedFields_contains_some?: String[] | String;
+  node?: TagWhereInput;
+  AND?: TagSubscriptionWhereInput[] | TagSubscriptionWhereInput;
+  OR?: TagSubscriptionWhereInput[] | TagSubscriptionWhereInput;
+  NOT?: TagSubscriptionWhereInput[] | TagSubscriptionWhereInput;
+}
+
+export interface VideoFileCreateInput {
+  language?: LanguageCreateOneInput;
+  filetype?: String;
+  filename?: String;
+  use?: VideoUseCreateOneInput;
+  quality?: VideoQuality;
+  videoBurnedInStatus?: VideoBurnedInStatus;
+  url?: String;
+  md5?: String;
+  duration?: Float;
+  bitrate?: Float;
+  filesize?: Float;
+  dimensions?: DimensionsCreateOneInput;
+  stream?: VideoStreamCreateOneInput;
+}
+
+export type SupportFileWhereUniqueInput = AtLeastOne<{
+  id: ID_Input;
+}>;
+
+export interface VideoUseCreateOneInput {
+  create?: VideoUseCreateInput;
+  connect?: VideoUseWhereUniqueInput;
+}
+
+export type TagWhereUniqueInput = AtLeastOne<{
+  id: ID_Input;
+}>;
+
+export interface VideoUseCreateInput {
+  name: String;
+}
+
+export interface ImageFileUpsertWithWhereUniqueNestedInput {
+  where: ImageFileWhereUniqueInput;
+  update: ImageFileUpdateDataInput;
+  create: ImageFileCreateInput;
+}
+
+export interface VideoStreamCreateOneInput {
+  create?: VideoStreamCreateInput;
+  connect?: VideoStreamWhereUniqueInput;
+}
+
+export interface SupportFileUpdateManyWithWhereNestedInput {
+  where: SupportFileScalarWhereInput;
+  data: SupportFileUpdateManyDataInput;
+}
+
+export interface VideoStreamCreateInput {
+  site?: String;
+  url?: String;
+  embedUrl?: String;
+}
+
+export interface VideoUnitUpdateManyDataInput {
+  title?: String;
+  descPublic?: String;
+}
+
+export interface VideoFileUpdateInput {
+  language?: LanguageUpdateOneInput;
+  filetype?: String;
+  filename?: String;
+  use?: VideoUseUpdateOneInput;
+  quality?: VideoQuality;
+  videoBurnedInStatus?: VideoBurnedInStatus;
+  url?: String;
+  md5?: String;
+  duration?: Float;
+  bitrate?: Float;
+  filesize?: Float;
+  dimensions?: DimensionsUpdateOneInput;
+  stream?: VideoStreamUpdateOneInput;
+}
+
+export interface ThumbnailScalarWhereInput {
+  id?: ID_Input;
+  id_not?: ID_Input;
+  id_in?: ID_Input[] | ID_Input;
+  id_not_in?: ID_Input[] | ID_Input;
+  id_lt?: ID_Input;
+  id_lte?: ID_Input;
+  id_gt?: ID_Input;
+  id_gte?: ID_Input;
+  id_contains?: ID_Input;
+  id_not_contains?: ID_Input;
+  id_starts_with?: ID_Input;
+  id_not_starts_with?: ID_Input;
+  id_ends_with?: ID_Input;
+  id_not_ends_with?: ID_Input;
+  size?: ThumbnailSize;
+  size_not?: ThumbnailSize;
+  size_in?: ThumbnailSize[] | ThumbnailSize;
+  size_not_in?: ThumbnailSize[] | ThumbnailSize;
+  AND?: ThumbnailScalarWhereInput[] | ThumbnailScalarWhereInput;
+  OR?: ThumbnailScalarWhereInput[] | ThumbnailScalarWhereInput;
+  NOT?: ThumbnailScalarWhereInput[] | ThumbnailScalarWhereInput;
+}
+
+export interface VideoUseUpdateOneInput {
+  create?: VideoUseCreateInput;
+  update?: VideoUseUpdateDataInput;
+  upsert?: VideoUseUpsertNestedInput;
+  delete?: Boolean;
+  disconnect?: Boolean;
+  connect?: VideoUseWhereUniqueInput;
+}
+
+export interface CategoryWhereInput {
+  id?: ID_Input;
+  id_not?: ID_Input;
+  id_in?: ID_Input[] | ID_Input;
+  id_not_in?: ID_Input[] | ID_Input;
+  id_lt?: ID_Input;
+  id_lte?: ID_Input;
+  id_gt?: ID_Input;
+  id_gte?: ID_Input;
+  id_contains?: ID_Input;
+  id_not_contains?: ID_Input;
+  id_starts_with?: ID_Input;
+  id_not_starts_with?: ID_Input;
+  id_ends_with?: ID_Input;
+  id_not_ends_with?: ID_Input;
+  translations_every?: LanguageTranslationWhereInput;
+  translations_some?: LanguageTranslationWhereInput;
+  translations_none?: LanguageTranslationWhereInput;
+  AND?: CategoryWhereInput[] | CategoryWhereInput;
+  OR?: CategoryWhereInput[] | CategoryWhereInput;
+  NOT?: CategoryWhereInput[] | CategoryWhereInput;
+}
+
+export interface VideoUseUpdateDataInput {
+  name?: String;
+}
+
+export interface VideoUnitWhereInput {
+  id?: ID_Input;
+  id_not?: ID_Input;
+  id_in?: ID_Input[] | ID_Input;
+  id_not_in?: ID_Input[] | ID_Input;
+  id_lt?: ID_Input;
+  id_lte?: ID_Input;
+  id_gt?: ID_Input;
+  id_gte?: ID_Input;
+  id_contains?: ID_Input;
+  id_not_contains?: ID_Input;
+  id_starts_with?: ID_Input;
+  id_not_starts_with?: ID_Input;
+  id_ends_with?: ID_Input;
+  id_not_ends_with?: ID_Input;
+  language?: LanguageWhereInput;
+  title?: String;
+  title_not?: String;
+  title_in?: String[] | String;
+  title_not_in?: String[] | String;
+  title_lt?: String;
+  title_lte?: String;
+  title_gt?: String;
+  title_gte?: String;
+  title_contains?: String;
+  title_not_contains?: String;
+  title_starts_with?: String;
+  title_not_starts_with?: String;
+  title_ends_with?: String;
+  title_not_ends_with?: String;
+  descPublic?: String;
+  descPublic_not?: String;
+  descPublic_in?: String[] | String;
+  descPublic_not_in?: String[] | String;
+  descPublic_lt?: String;
+  descPublic_lte?: String;
+  descPublic_gt?: String;
+  descPublic_gte?: String;
+  descPublic_contains?: String;
+  descPublic_not_contains?: String;
+  descPublic_starts_with?: String;
+  descPublic_not_starts_with?: String;
+  descPublic_ends_with?: String;
+  descPublic_not_ends_with?: String;
+  files_every?: VideoFileWhereInput;
+  files_some?: VideoFileWhereInput;
+  files_none?: VideoFileWhereInput;
+  tags_every?: TagWhereInput;
+  tags_some?: TagWhereInput;
+  tags_none?: TagWhereInput;
+  categories_every?: CategoryWhereInput;
+  categories_some?: CategoryWhereInput;
+  categories_none?: CategoryWhereInput;
+  thumbnails_every?: ThumbnailWhereInput;
+  thumbnails_some?: ThumbnailWhereInput;
+  thumbnails_none?: ThumbnailWhereInput;
+  AND?: VideoUnitWhereInput[] | VideoUnitWhereInput;
+  OR?: VideoUnitWhereInput[] | VideoUnitWhereInput;
+  NOT?: VideoUnitWhereInput[] | VideoUnitWhereInput;
+}
+
+export interface VideoUseUpsertNestedInput {
+  update: VideoUseUpdateDataInput;
+  create: VideoUseCreateInput;
+}
+
+export type VideoStreamWhereUniqueInput = AtLeastOne<{
+  id: ID_Input;
+}>;
+
+export interface VideoStreamUpdateOneInput {
+  create?: VideoStreamCreateInput;
+  update?: VideoStreamUpdateDataInput;
+  upsert?: VideoStreamUpsertNestedInput;
+  delete?: Boolean;
+  disconnect?: Boolean;
+  connect?: VideoStreamWhereUniqueInput;
+}
+
+export interface VideoUnitUpdateDataInput {
+  language?: LanguageUpdateOneInput;
+  title?: String;
+  descPublic?: String;
+  files?: VideoFileUpdateManyInput;
+  tags?: TagUpdateManyInput;
+  categories?: CategoryUpdateManyInput;
+  thumbnails?: ThumbnailUpdateManyInput;
+}
+
+export interface VideoStreamUpdateDataInput {
+  site?: String;
+  url?: String;
+  embedUrl?: String;
+}
+
+export interface UserSubscriptionWhereInput {
+  mutation_in?: MutationType[] | MutationType;
+  updatedFields_contains?: String;
+  updatedFields_contains_every?: String[] | String;
+  updatedFields_contains_some?: String[] | String;
+  node?: UserWhereInput;
+  AND?: UserSubscriptionWhereInput[] | UserSubscriptionWhereInput;
+  OR?: UserSubscriptionWhereInput[] | UserSubscriptionWhereInput;
+  NOT?: UserSubscriptionWhereInput[] | UserSubscriptionWhereInput;
+}
+
+export interface VideoStreamUpsertNestedInput {
+  update: VideoStreamUpdateDataInput;
+  create: VideoStreamCreateInput;
+}
+
+export interface VideoUseUpdateInput {
+  name?: String;
+}
+
+export interface VideoFileUpdateManyMutationInput {
+  filetype?: String;
+  filename?: String;
+  quality?: VideoQuality;
+  videoBurnedInStatus?: VideoBurnedInStatus;
+  url?: String;
+  md5?: String;
+  duration?: Float;
+  bitrate?: Float;
+  filesize?: Float;
+}
+
+export interface ImageFileUpdateWithWhereUniqueNestedInput {
+  where: ImageFileWhereUniqueInput;
+  data: ImageFileUpdateDataInput;
+}
+
+export interface VideoProjectCreateInput {
+  projectType: String;
+  projectTitle: String;
+  descPublic?: String;
+  descInternal?: String;
+  author?: String;
+  team?: TeamCreateOneInput;
+  status?: ProjectPublishStatus;
+  visibility?: ProjectVisibility;
+  units?: VideoUnitCreateManyInput;
+  supportFiles?: SupportFileCreateManyInput;
+  thumbnails?: ImageFileCreateManyInput;
+  categories?: CategoryCreateManyInput;
+  tags?: TagCreateManyInput;
+}
+
+export interface VideoUnitUpsertWithWhereUniqueNestedInput {
+  where: VideoUnitWhereUniqueInput;
+  update: VideoUnitUpdateDataInput;
+  create: VideoUnitCreateInput;
+}
+
+export interface TeamCreateOneInput {
+  create?: TeamCreateInput;
+  connect?: TeamWhereUniqueInput;
+}
+
+export type VideoProjectWhereUniqueInput = AtLeastOne<{
+  id: ID_Input;
+}>;
+
+export interface VideoUnitCreateManyInput {
+  create?: VideoUnitCreateInput[] | VideoUnitCreateInput;
+  connect?: VideoUnitWhereUniqueInput[] | VideoUnitWhereUniqueInput;
+}
+
+export interface VideoFileUpdateDataInput {
+  language?: LanguageUpdateOneInput;
+  filetype?: String;
+  filename?: String;
+  use?: VideoUseUpdateOneInput;
+  quality?: VideoQuality;
+  videoBurnedInStatus?: VideoBurnedInStatus;
+  url?: String;
+  md5?: String;
+  duration?: Float;
+  bitrate?: Float;
+  filesize?: Float;
+  dimensions?: DimensionsUpdateOneInput;
+  stream?: VideoStreamUpdateOneInput;
+}
+
+export interface VideoUnitCreateInput {
+  language?: LanguageCreateOneInput;
+  title: String;
+  descPublic?: String;
+  files?: VideoFileCreateManyInput;
+  tags?: TagCreateManyInput;
+  categories?: CategoryCreateManyInput;
+  thumbnails?: ThumbnailCreateManyInput;
+}
+
+export type LanguageTranslationWhereUniqueInput = AtLeastOne<{
+  id: ID_Input;
+}>;
+
+export interface VideoFileCreateManyInput {
+  create?: VideoFileCreateInput[] | VideoFileCreateInput;
+  connect?: VideoFileWhereUniqueInput[] | VideoFileWhereUniqueInput;
+}
+
+export interface SupportFileUpdateDataInput {
+  language?: LanguageUpdateOneRequiredInput;
+  url?: String;
+  md5?: String;
+  filename?: String;
+  filetype?: String;
+  filesize?: Float;
+}
+
+export interface SupportFileCreateManyInput {
+  create?: SupportFileCreateInput[] | SupportFileCreateInput;
+  connect?: SupportFileWhereUniqueInput[] | SupportFileWhereUniqueInput;
+}
+
+export interface ThumbnailCreateManyInput {
+  create?: ThumbnailCreateInput[] | ThumbnailCreateInput;
+  connect?: ThumbnailWhereUniqueInput[] | ThumbnailWhereUniqueInput;
+}
+
+export interface CategoryCreateManyInput {
+  create?: CategoryCreateInput[] | CategoryCreateInput;
+  connect?: CategoryWhereUniqueInput[] | CategoryWhereUniqueInput;
+}
+
+export interface TagCreateManyInput {
+  create?: TagCreateInput[] | TagCreateInput;
+  connect?: TagWhereUniqueInput[] | TagWhereUniqueInput;
+}
+
+export interface ThumbnailUpdateManyInput {
+  create?: ThumbnailCreateInput[] | ThumbnailCreateInput;
+  update?:
+    | ThumbnailUpdateWithWhereUniqueNestedInput[]
+    | ThumbnailUpdateWithWhereUniqueNestedInput;
+  upsert?:
+    | ThumbnailUpsertWithWhereUniqueNestedInput[]
+    | ThumbnailUpsertWithWhereUniqueNestedInput;
+  delete?: ThumbnailWhereUniqueInput[] | ThumbnailWhereUniqueInput;
+  connect?: ThumbnailWhereUniqueInput[] | ThumbnailWhereUniqueInput;
+  disconnect?: ThumbnailWhereUniqueInput[] | ThumbnailWhereUniqueInput;
+  deleteMany?: ThumbnailScalarWhereInput[] | ThumbnailScalarWhereInput;
+  updateMany?:
+    | ThumbnailUpdateManyWithWhereNestedInput[]
+    | ThumbnailUpdateManyWithWhereNestedInput;
+}
+
+export interface ImageFileUpdateManyDataInput {
+  alt?: String;
+  longdesc?: String;
+  caption?: String;
+  filename?: String;
+  filetype?: String;
+  md5?: String;
+  url?: String;
+}
+
+export interface VideoUseSubscriptionWhereInput {
+  mutation_in?: MutationType[] | MutationType;
+  updatedFields_contains?: String;
+  updatedFields_contains_every?: String[] | String;
+  updatedFields_contains_some?: String[] | String;
+  node?: VideoUseWhereInput;
+  AND?: VideoUseSubscriptionWhereInput[] | VideoUseSubscriptionWhereInput;
+  OR?: VideoUseSubscriptionWhereInput[] | VideoUseSubscriptionWhereInput;
+  NOT?: VideoUseSubscriptionWhereInput[] | VideoUseSubscriptionWhereInput;
+}
+
+export interface LanguageWhereInput {
+  id?: ID_Input;
+  id_not?: ID_Input;
+  id_in?: ID_Input[] | ID_Input;
+  id_not_in?: ID_Input[] | ID_Input;
+  id_lt?: ID_Input;
+  id_lte?: ID_Input;
+  id_gt?: ID_Input;
+  id_gte?: ID_Input;
+  id_contains?: ID_Input;
+  id_not_contains?: ID_Input;
+  id_starts_with?: ID_Input;
+  id_not_starts_with?: ID_Input;
+  id_ends_with?: ID_Input;
+  id_not_ends_with?: ID_Input;
+  languageCode?: String;
+  languageCode_not?: String;
+  languageCode_in?: String[] | String;
+  languageCode_not_in?: String[] | String;
+  languageCode_lt?: String;
+  languageCode_lte?: String;
+  languageCode_gt?: String;
+  languageCode_gte?: String;
+  languageCode_contains?: String;
+  languageCode_not_contains?: String;
+  languageCode_starts_with?: String;
+  languageCode_not_starts_with?: String;
+  languageCode_ends_with?: String;
+  languageCode_not_ends_with?: String;
+  locale?: String;
+  locale_not?: String;
+  locale_in?: String[] | String;
+  locale_not_in?: String[] | String;
+  locale_lt?: String;
+  locale_lte?: String;
+  locale_gt?: String;
+  locale_gte?: String;
+  locale_contains?: String;
+  locale_not_contains?: String;
+  locale_starts_with?: String;
+  locale_not_starts_with?: String;
+  locale_ends_with?: String;
+  locale_not_ends_with?: String;
+  textDirection?: String;
+  textDirection_not?: String;
+  textDirection_in?: String[] | String;
+  textDirection_not_in?: String[] | String;
+  textDirection_lt?: String;
+  textDirection_lte?: String;
+  textDirection_gt?: String;
+  textDirection_gte?: String;
+  textDirection_contains?: String;
+  textDirection_not_contains?: String;
+  textDirection_starts_with?: String;
+  textDirection_not_starts_with?: String;
+  textDirection_ends_with?: String;
+  textDirection_not_ends_with?: String;
+  displayName?: String;
+  displayName_not?: String;
+  displayName_in?: String[] | String;
+  displayName_not_in?: String[] | String;
+  displayName_lt?: String;
+  displayName_lte?: String;
+  displayName_gt?: String;
+  displayName_gte?: String;
+  displayName_contains?: String;
+  displayName_not_contains?: String;
+  displayName_starts_with?: String;
+  displayName_not_starts_with?: String;
+  displayName_ends_with?: String;
+  displayName_not_ends_with?: String;
+  nativeName?: String;
+  nativeName_not?: String;
+  nativeName_in?: String[] | String;
+  nativeName_not_in?: String[] | String;
+  nativeName_lt?: String;
+  nativeName_lte?: String;
+  nativeName_gt?: String;
+  nativeName_gte?: String;
+  nativeName_contains?: String;
+  nativeName_not_contains?: String;
+  nativeName_starts_with?: String;
+  nativeName_not_starts_with?: String;
+  nativeName_ends_with?: String;
+  nativeName_not_ends_with?: String;
+  AND?: LanguageWhereInput[] | LanguageWhereInput;
+  OR?: LanguageWhereInput[] | LanguageWhereInput;
+  NOT?: LanguageWhereInput[] | LanguageWhereInput;
 }
 
 export interface NodeNode {
@@ -4014,25 +4126,29 @@ export interface TagSubscription
   }) => T;
 }
 
-export interface ImageFileConnection {
-  pageInfo: PageInfo;
-  edges: ImageFileEdge[];
+export interface VideoStreamPreviousValues {
+  id: ID_Output;
+  site?: String;
+  url?: String;
+  embedUrl?: String;
 }
 
-export interface ImageFileConnectionPromise
-  extends Promise<ImageFileConnection>,
+export interface VideoStreamPreviousValuesPromise
+  extends Promise<VideoStreamPreviousValues>,
     Fragmentable {
-  pageInfo: <T = PageInfoPromise>() => T;
-  edges: <T = FragmentableArray<ImageFileEdge>>() => T;
-  aggregate: <T = AggregateImageFilePromise>() => T;
+  id: () => Promise<ID_Output>;
+  site: () => Promise<String>;
+  url: () => Promise<String>;
+  embedUrl: () => Promise<String>;
 }
 
-export interface ImageFileConnectionSubscription
-  extends Promise<AsyncIterator<ImageFileConnection>>,
+export interface VideoStreamPreviousValuesSubscription
+  extends Promise<AsyncIterator<VideoStreamPreviousValues>>,
     Fragmentable {
-  pageInfo: <T = PageInfoSubscription>() => T;
-  edges: <T = Promise<AsyncIterator<ImageFileEdgeSubscription>>>() => T;
-  aggregate: <T = AggregateImageFileSubscription>() => T;
+  id: () => Promise<AsyncIterator<ID_Output>>;
+  site: () => Promise<AsyncIterator<String>>;
+  url: () => Promise<AsyncIterator<String>>;
+  embedUrl: () => Promise<AsyncIterator<String>>;
 }
 
 export interface AggregateSupportFile {
@@ -4049,60 +4165,6 @@ export interface AggregateSupportFileSubscription
   extends Promise<AsyncIterator<AggregateSupportFile>>,
     Fragmentable {
   count: () => Promise<AsyncIterator<Int>>;
-}
-
-export interface ImageFileEdge {
-  node: ImageFile;
-  cursor: String;
-}
-
-export interface ImageFileEdgePromise
-  extends Promise<ImageFileEdge>,
-    Fragmentable {
-  node: <T = ImageFilePromise>() => T;
-  cursor: () => Promise<String>;
-}
-
-export interface ImageFileEdgeSubscription
-  extends Promise<AsyncIterator<ImageFileEdge>>,
-    Fragmentable {
-  node: <T = ImageFileSubscription>() => T;
-  cursor: () => Promise<AsyncIterator<String>>;
-}
-
-export interface SupportFileEdge {
-  node: SupportFile;
-  cursor: String;
-}
-
-export interface SupportFileEdgePromise
-  extends Promise<SupportFileEdge>,
-    Fragmentable {
-  node: <T = SupportFilePromise>() => T;
-  cursor: () => Promise<String>;
-}
-
-export interface SupportFileEdgeSubscription
-  extends Promise<AsyncIterator<SupportFileEdge>>,
-    Fragmentable {
-  node: <T = SupportFileSubscription>() => T;
-  cursor: () => Promise<AsyncIterator<String>>;
-}
-
-export interface BatchPayload {
-  count: Long;
-}
-
-export interface BatchPayloadPromise
-  extends Promise<BatchPayload>,
-    Fragmentable {
-  count: () => Promise<Long>;
-}
-
-export interface BatchPayloadSubscription
-  extends Promise<AsyncIterator<BatchPayload>>,
-    Fragmentable {
-  count: () => Promise<AsyncIterator<Long>>;
 }
 
 export interface SupportFileConnection {
@@ -4126,23 +4188,218 @@ export interface SupportFileConnectionSubscription
   aggregate: <T = AggregateSupportFileSubscription>() => T;
 }
 
-export interface VideoUseEdge {
-  node: VideoUse;
+export interface SupportFileEdge {
+  node: SupportFile;
   cursor: String;
 }
 
-export interface VideoUseEdgePromise
-  extends Promise<VideoUseEdge>,
+export interface SupportFileEdgePromise
+  extends Promise<SupportFileEdge>,
     Fragmentable {
-  node: <T = VideoUsePromise>() => T;
+  node: <T = SupportFilePromise>() => T;
   cursor: () => Promise<String>;
 }
 
-export interface VideoUseEdgeSubscription
-  extends Promise<AsyncIterator<VideoUseEdge>>,
+export interface SupportFileEdgeSubscription
+  extends Promise<AsyncIterator<SupportFileEdge>>,
     Fragmentable {
-  node: <T = VideoUseSubscription>() => T;
+  node: <T = SupportFileSubscription>() => T;
   cursor: () => Promise<AsyncIterator<String>>;
+}
+
+export interface AggregateVideoUse {
+  count: Int;
+}
+
+export interface AggregateVideoUsePromise
+  extends Promise<AggregateVideoUse>,
+    Fragmentable {
+  count: () => Promise<Int>;
+}
+
+export interface AggregateVideoUseSubscription
+  extends Promise<AsyncIterator<AggregateVideoUse>>,
+    Fragmentable {
+  count: () => Promise<AsyncIterator<Int>>;
+}
+
+export interface VideoUnitSubscriptionPayload {
+  mutation: MutationType;
+  node: VideoUnit;
+  updatedFields: String[];
+  previousValues: VideoUnitPreviousValues;
+}
+
+export interface VideoUnitSubscriptionPayloadPromise
+  extends Promise<VideoUnitSubscriptionPayload>,
+    Fragmentable {
+  mutation: () => Promise<MutationType>;
+  node: <T = VideoUnitPromise>() => T;
+  updatedFields: () => Promise<String[]>;
+  previousValues: <T = VideoUnitPreviousValuesPromise>() => T;
+}
+
+export interface VideoUnitSubscriptionPayloadSubscription
+  extends Promise<AsyncIterator<VideoUnitSubscriptionPayload>>,
+    Fragmentable {
+  mutation: () => Promise<AsyncIterator<MutationType>>;
+  node: <T = VideoUnitSubscription>() => T;
+  updatedFields: () => Promise<AsyncIterator<String[]>>;
+  previousValues: <T = VideoUnitPreviousValuesSubscription>() => T;
+}
+
+export interface VideoUseConnection {
+  pageInfo: PageInfo;
+  edges: VideoUseEdge[];
+}
+
+export interface VideoUseConnectionPromise
+  extends Promise<VideoUseConnection>,
+    Fragmentable {
+  pageInfo: <T = PageInfoPromise>() => T;
+  edges: <T = FragmentableArray<VideoUseEdge>>() => T;
+  aggregate: <T = AggregateVideoUsePromise>() => T;
+}
+
+export interface VideoUseConnectionSubscription
+  extends Promise<AsyncIterator<VideoUseConnection>>,
+    Fragmentable {
+  pageInfo: <T = PageInfoSubscription>() => T;
+  edges: <T = Promise<AsyncIterator<VideoUseEdgeSubscription>>>() => T;
+  aggregate: <T = AggregateVideoUseSubscription>() => T;
+}
+
+export interface DimensionsEdge {
+  node: Dimensions;
+  cursor: String;
+}
+
+export interface DimensionsEdgePromise
+  extends Promise<DimensionsEdge>,
+    Fragmentable {
+  node: <T = DimensionsPromise>() => T;
+  cursor: () => Promise<String>;
+}
+
+export interface DimensionsEdgeSubscription
+  extends Promise<AsyncIterator<DimensionsEdge>>,
+    Fragmentable {
+  node: <T = DimensionsSubscription>() => T;
+  cursor: () => Promise<AsyncIterator<String>>;
+}
+
+export interface VideoUnitEdge {
+  node: VideoUnit;
+  cursor: String;
+}
+
+export interface VideoUnitEdgePromise
+  extends Promise<VideoUnitEdge>,
+    Fragmentable {
+  node: <T = VideoUnitPromise>() => T;
+  cursor: () => Promise<String>;
+}
+
+export interface VideoUnitEdgeSubscription
+  extends Promise<AsyncIterator<VideoUnitEdge>>,
+    Fragmentable {
+  node: <T = VideoUnitSubscription>() => T;
+  cursor: () => Promise<AsyncIterator<String>>;
+}
+
+export interface ImageFileConnection {
+  pageInfo: PageInfo;
+  edges: ImageFileEdge[];
+}
+
+export interface ImageFileConnectionPromise
+  extends Promise<ImageFileConnection>,
+    Fragmentable {
+  pageInfo: <T = PageInfoPromise>() => T;
+  edges: <T = FragmentableArray<ImageFileEdge>>() => T;
+  aggregate: <T = AggregateImageFilePromise>() => T;
+}
+
+export interface ImageFileConnectionSubscription
+  extends Promise<AsyncIterator<ImageFileConnection>>,
+    Fragmentable {
+  pageInfo: <T = PageInfoSubscription>() => T;
+  edges: <T = Promise<AsyncIterator<ImageFileEdgeSubscription>>>() => T;
+  aggregate: <T = AggregateImageFileSubscription>() => T;
+}
+
+export interface AggregateVideoStream {
+  count: Int;
+}
+
+export interface AggregateVideoStreamPromise
+  extends Promise<AggregateVideoStream>,
+    Fragmentable {
+  count: () => Promise<Int>;
+}
+
+export interface AggregateVideoStreamSubscription
+  extends Promise<AsyncIterator<AggregateVideoStream>>,
+    Fragmentable {
+  count: () => Promise<AsyncIterator<Int>>;
+}
+
+export interface SupportFile {
+  id: ID_Output;
+  createdAt: DateTimeOutput;
+  updatedAt: DateTimeOutput;
+  url?: String;
+  md5?: String;
+  filename?: String;
+  filetype?: String;
+  filesize?: Float;
+}
+
+export interface SupportFilePromise extends Promise<SupportFile>, Fragmentable {
+  id: () => Promise<ID_Output>;
+  createdAt: () => Promise<DateTimeOutput>;
+  updatedAt: () => Promise<DateTimeOutput>;
+  language: <T = LanguagePromise>() => T;
+  url: () => Promise<String>;
+  md5: () => Promise<String>;
+  filename: () => Promise<String>;
+  filetype: () => Promise<String>;
+  filesize: () => Promise<Float>;
+}
+
+export interface SupportFileSubscription
+  extends Promise<AsyncIterator<SupportFile>>,
+    Fragmentable {
+  id: () => Promise<AsyncIterator<ID_Output>>;
+  createdAt: () => Promise<AsyncIterator<DateTimeOutput>>;
+  updatedAt: () => Promise<AsyncIterator<DateTimeOutput>>;
+  language: <T = LanguageSubscription>() => T;
+  url: () => Promise<AsyncIterator<String>>;
+  md5: () => Promise<AsyncIterator<String>>;
+  filename: () => Promise<AsyncIterator<String>>;
+  filetype: () => Promise<AsyncIterator<String>>;
+  filesize: () => Promise<AsyncIterator<Float>>;
+}
+
+export interface VideoStreamConnection {
+  pageInfo: PageInfo;
+  edges: VideoStreamEdge[];
+}
+
+export interface VideoStreamConnectionPromise
+  extends Promise<VideoStreamConnection>,
+    Fragmentable {
+  pageInfo: <T = PageInfoPromise>() => T;
+  edges: <T = FragmentableArray<VideoStreamEdge>>() => T;
+  aggregate: <T = AggregateVideoStreamPromise>() => T;
+}
+
+export interface VideoStreamConnectionSubscription
+  extends Promise<AsyncIterator<VideoStreamConnection>>,
+    Fragmentable {
+  pageInfo: <T = PageInfoSubscription>() => T;
+  edges: <T = Promise<AsyncIterator<VideoStreamEdgeSubscription>>>() => T;
+  aggregate: <T = AggregateVideoStreamSubscription>() => T;
 }
 
 export interface Category {
@@ -4179,18 +4436,18 @@ export interface CategorySubscription
   }) => T;
 }
 
-export interface AggregateVideoUnit {
+export interface AggregateVideoProject {
   count: Int;
 }
 
-export interface AggregateVideoUnitPromise
-  extends Promise<AggregateVideoUnit>,
+export interface AggregateVideoProjectPromise
+  extends Promise<AggregateVideoProject>,
     Fragmentable {
   count: () => Promise<Int>;
 }
 
-export interface AggregateVideoUnitSubscription
-  extends Promise<AsyncIterator<AggregateVideoUnit>>,
+export interface AggregateVideoProjectSubscription
+  extends Promise<AsyncIterator<AggregateVideoProject>>,
     Fragmentable {
   count: () => Promise<AsyncIterator<Int>>;
 }
@@ -4220,151 +4477,6 @@ export interface CategorySubscriptionPayloadSubscription
   previousValues: <T = CategoryPreviousValuesSubscription>() => T;
 }
 
-export interface VideoUnitConnection {
-  pageInfo: PageInfo;
-  edges: VideoUnitEdge[];
-}
-
-export interface VideoUnitConnectionPromise
-  extends Promise<VideoUnitConnection>,
-    Fragmentable {
-  pageInfo: <T = PageInfoPromise>() => T;
-  edges: <T = FragmentableArray<VideoUnitEdge>>() => T;
-  aggregate: <T = AggregateVideoUnitPromise>() => T;
-}
-
-export interface VideoUnitConnectionSubscription
-  extends Promise<AsyncIterator<VideoUnitConnection>>,
-    Fragmentable {
-  pageInfo: <T = PageInfoSubscription>() => T;
-  edges: <T = Promise<AsyncIterator<VideoUnitEdgeSubscription>>>() => T;
-  aggregate: <T = AggregateVideoUnitSubscription>() => T;
-}
-
-export interface CategoryPreviousValues {
-  id: ID_Output;
-}
-
-export interface CategoryPreviousValuesPromise
-  extends Promise<CategoryPreviousValues>,
-    Fragmentable {
-  id: () => Promise<ID_Output>;
-}
-
-export interface CategoryPreviousValuesSubscription
-  extends Promise<AsyncIterator<CategoryPreviousValues>>,
-    Fragmentable {
-  id: () => Promise<AsyncIterator<ID_Output>>;
-}
-
-export interface VideoStreamEdge {
-  node: VideoStream;
-  cursor: String;
-}
-
-export interface VideoStreamEdgePromise
-  extends Promise<VideoStreamEdge>,
-    Fragmentable {
-  node: <T = VideoStreamPromise>() => T;
-  cursor: () => Promise<String>;
-}
-
-export interface VideoStreamEdgeSubscription
-  extends Promise<AsyncIterator<VideoStreamEdge>>,
-    Fragmentable {
-  node: <T = VideoStreamSubscription>() => T;
-  cursor: () => Promise<AsyncIterator<String>>;
-}
-
-export interface AggregateVideoStream {
-  count: Int;
-}
-
-export interface AggregateVideoStreamPromise
-  extends Promise<AggregateVideoStream>,
-    Fragmentable {
-  count: () => Promise<Int>;
-}
-
-export interface AggregateVideoStreamSubscription
-  extends Promise<AsyncIterator<AggregateVideoStream>>,
-    Fragmentable {
-  count: () => Promise<AsyncIterator<Int>>;
-}
-
-export interface ImageUse {
-  id: ID_Output;
-  name: String;
-}
-
-export interface ImageUsePromise extends Promise<ImageUse>, Fragmentable {
-  id: () => Promise<ID_Output>;
-  name: () => Promise<String>;
-}
-
-export interface ImageUseSubscription
-  extends Promise<AsyncIterator<ImageUse>>,
-    Fragmentable {
-  id: () => Promise<AsyncIterator<ID_Output>>;
-  name: () => Promise<AsyncIterator<String>>;
-}
-
-export interface VideoStreamConnection {
-  pageInfo: PageInfo;
-  edges: VideoStreamEdge[];
-}
-
-export interface VideoStreamConnectionPromise
-  extends Promise<VideoStreamConnection>,
-    Fragmentable {
-  pageInfo: <T = PageInfoPromise>() => T;
-  edges: <T = FragmentableArray<VideoStreamEdge>>() => T;
-  aggregate: <T = AggregateVideoStreamPromise>() => T;
-}
-
-export interface VideoStreamConnectionSubscription
-  extends Promise<AsyncIterator<VideoStreamConnection>>,
-    Fragmentable {
-  pageInfo: <T = PageInfoSubscription>() => T;
-  edges: <T = Promise<AsyncIterator<VideoStreamEdgeSubscription>>>() => T;
-  aggregate: <T = AggregateVideoStreamSubscription>() => T;
-}
-
-export interface DimensionsEdge {
-  node: Dimensions;
-  cursor: String;
-}
-
-export interface DimensionsEdgePromise
-  extends Promise<DimensionsEdge>,
-    Fragmentable {
-  node: <T = DimensionsPromise>() => T;
-  cursor: () => Promise<String>;
-}
-
-export interface DimensionsEdgeSubscription
-  extends Promise<AsyncIterator<DimensionsEdge>>,
-    Fragmentable {
-  node: <T = DimensionsSubscription>() => T;
-  cursor: () => Promise<AsyncIterator<String>>;
-}
-
-export interface AggregateVideoProject {
-  count: Int;
-}
-
-export interface AggregateVideoProjectPromise
-  extends Promise<AggregateVideoProject>,
-    Fragmentable {
-  count: () => Promise<Int>;
-}
-
-export interface AggregateVideoProjectSubscription
-  extends Promise<AsyncIterator<AggregateVideoProject>>,
-    Fragmentable {
-  count: () => Promise<AsyncIterator<Int>>;
-}
-
 export interface VideoProjectConnection {
   pageInfo: PageInfo;
   edges: VideoProjectEdge[];
@@ -4386,76 +4498,81 @@ export interface VideoProjectConnectionSubscription
   aggregate: <T = AggregateVideoProjectSubscription>() => T;
 }
 
-export interface DimensionsSubscriptionPayload {
-  mutation: MutationType;
-  node: Dimensions;
-  updatedFields: String[];
-  previousValues: DimensionsPreviousValues;
-}
-
-export interface DimensionsSubscriptionPayloadPromise
-  extends Promise<DimensionsSubscriptionPayload>,
-    Fragmentable {
-  mutation: () => Promise<MutationType>;
-  node: <T = DimensionsPromise>() => T;
-  updatedFields: () => Promise<String[]>;
-  previousValues: <T = DimensionsPreviousValuesPromise>() => T;
-}
-
-export interface DimensionsSubscriptionPayloadSubscription
-  extends Promise<AsyncIterator<DimensionsSubscriptionPayload>>,
-    Fragmentable {
-  mutation: () => Promise<AsyncIterator<MutationType>>;
-  node: <T = DimensionsSubscription>() => T;
-  updatedFields: () => Promise<AsyncIterator<String[]>>;
-  previousValues: <T = DimensionsPreviousValuesSubscription>() => T;
-}
-
-export interface VideoUseSubscriptionPayload {
-  mutation: MutationType;
-  node: VideoUse;
-  updatedFields: String[];
-  previousValues: VideoUsePreviousValues;
-}
-
-export interface VideoUseSubscriptionPayloadPromise
-  extends Promise<VideoUseSubscriptionPayload>,
-    Fragmentable {
-  mutation: () => Promise<MutationType>;
-  node: <T = VideoUsePromise>() => T;
-  updatedFields: () => Promise<String[]>;
-  previousValues: <T = VideoUsePreviousValuesPromise>() => T;
-}
-
-export interface VideoUseSubscriptionPayloadSubscription
-  extends Promise<AsyncIterator<VideoUseSubscriptionPayload>>,
-    Fragmentable {
-  mutation: () => Promise<AsyncIterator<MutationType>>;
-  node: <T = VideoUseSubscription>() => T;
-  updatedFields: () => Promise<AsyncIterator<String[]>>;
-  previousValues: <T = VideoUsePreviousValuesSubscription>() => T;
-}
-
-export interface DimensionsPreviousValues {
+export interface CategoryPreviousValues {
   id: ID_Output;
-  width?: Int;
-  height?: Int;
 }
 
-export interface DimensionsPreviousValuesPromise
-  extends Promise<DimensionsPreviousValues>,
+export interface CategoryPreviousValuesPromise
+  extends Promise<CategoryPreviousValues>,
     Fragmentable {
   id: () => Promise<ID_Output>;
-  width: () => Promise<Int>;
-  height: () => Promise<Int>;
 }
 
-export interface DimensionsPreviousValuesSubscription
-  extends Promise<AsyncIterator<DimensionsPreviousValues>>,
+export interface CategoryPreviousValuesSubscription
+  extends Promise<AsyncIterator<CategoryPreviousValues>>,
     Fragmentable {
   id: () => Promise<AsyncIterator<ID_Output>>;
-  width: () => Promise<AsyncIterator<Int>>;
-  height: () => Promise<AsyncIterator<Int>>;
+}
+
+export interface ImageFile {
+  id: ID_Output;
+  createdAt: DateTimeOutput;
+  updatedAt: DateTimeOutput;
+  alt?: String;
+  longdesc?: String;
+  caption?: String;
+  filename?: String;
+  filetype?: String;
+  md5?: String;
+  url?: String;
+}
+
+export interface ImageFilePromise extends Promise<ImageFile>, Fragmentable {
+  id: () => Promise<ID_Output>;
+  createdAt: () => Promise<DateTimeOutput>;
+  updatedAt: () => Promise<DateTimeOutput>;
+  language: <T = LanguagePromise>() => T;
+  dimensions: <T = DimensionsPromise>() => T;
+  alt: () => Promise<String>;
+  longdesc: () => Promise<String>;
+  caption: () => Promise<String>;
+  filename: () => Promise<String>;
+  filetype: () => Promise<String>;
+  md5: () => Promise<String>;
+  url: () => Promise<String>;
+}
+
+export interface ImageFileSubscription
+  extends Promise<AsyncIterator<ImageFile>>,
+    Fragmentable {
+  id: () => Promise<AsyncIterator<ID_Output>>;
+  createdAt: () => Promise<AsyncIterator<DateTimeOutput>>;
+  updatedAt: () => Promise<AsyncIterator<DateTimeOutput>>;
+  language: <T = LanguageSubscription>() => T;
+  dimensions: <T = DimensionsSubscription>() => T;
+  alt: () => Promise<AsyncIterator<String>>;
+  longdesc: () => Promise<AsyncIterator<String>>;
+  caption: () => Promise<AsyncIterator<String>>;
+  filename: () => Promise<AsyncIterator<String>>;
+  filetype: () => Promise<AsyncIterator<String>>;
+  md5: () => Promise<AsyncIterator<String>>;
+  url: () => Promise<AsyncIterator<String>>;
+}
+
+export interface AggregateLanguageTranslation {
+  count: Int;
+}
+
+export interface AggregateLanguageTranslationPromise
+  extends Promise<AggregateLanguageTranslation>,
+    Fragmentable {
+  count: () => Promise<Int>;
+}
+
+export interface AggregateLanguageTranslationSubscription
+  extends Promise<AsyncIterator<AggregateLanguageTranslation>>,
+    Fragmentable {
+  count: () => Promise<AsyncIterator<Int>>;
 }
 
 export interface Language {
@@ -4487,29 +4604,29 @@ export interface LanguageSubscription
   nativeName: () => Promise<AsyncIterator<String>>;
 }
 
-export interface VideoUnitSubscriptionPayload {
+export interface DimensionsSubscriptionPayload {
   mutation: MutationType;
-  node: VideoUnit;
+  node: Dimensions;
   updatedFields: String[];
-  previousValues: VideoUnitPreviousValues;
+  previousValues: DimensionsPreviousValues;
 }
 
-export interface VideoUnitSubscriptionPayloadPromise
-  extends Promise<VideoUnitSubscriptionPayload>,
+export interface DimensionsSubscriptionPayloadPromise
+  extends Promise<DimensionsSubscriptionPayload>,
     Fragmentable {
   mutation: () => Promise<MutationType>;
-  node: <T = VideoUnitPromise>() => T;
+  node: <T = DimensionsPromise>() => T;
   updatedFields: () => Promise<String[]>;
-  previousValues: <T = VideoUnitPreviousValuesPromise>() => T;
+  previousValues: <T = DimensionsPreviousValuesPromise>() => T;
 }
 
-export interface VideoUnitSubscriptionPayloadSubscription
-  extends Promise<AsyncIterator<VideoUnitSubscriptionPayload>>,
+export interface DimensionsSubscriptionPayloadSubscription
+  extends Promise<AsyncIterator<DimensionsSubscriptionPayload>>,
     Fragmentable {
   mutation: () => Promise<AsyncIterator<MutationType>>;
-  node: <T = VideoUnitSubscription>() => T;
+  node: <T = DimensionsSubscription>() => T;
   updatedFields: () => Promise<AsyncIterator<String[]>>;
-  previousValues: <T = VideoUnitPreviousValuesSubscription>() => T;
+  previousValues: <T = DimensionsPreviousValuesSubscription>() => T;
 }
 
 export interface AggregateVideoFile {
@@ -4526,6 +4643,89 @@ export interface AggregateVideoFileSubscription
   extends Promise<AsyncIterator<AggregateVideoFile>>,
     Fragmentable {
   count: () => Promise<AsyncIterator<Int>>;
+}
+
+export interface DimensionsPreviousValues {
+  id: ID_Output;
+  width?: Int;
+  height?: Int;
+}
+
+export interface DimensionsPreviousValuesPromise
+  extends Promise<DimensionsPreviousValues>,
+    Fragmentable {
+  id: () => Promise<ID_Output>;
+  width: () => Promise<Int>;
+  height: () => Promise<Int>;
+}
+
+export interface DimensionsPreviousValuesSubscription
+  extends Promise<AsyncIterator<DimensionsPreviousValues>>,
+    Fragmentable {
+  id: () => Promise<AsyncIterator<ID_Output>>;
+  width: () => Promise<AsyncIterator<Int>>;
+  height: () => Promise<AsyncIterator<Int>>;
+}
+
+export interface VideoFileConnection {
+  pageInfo: PageInfo;
+  edges: VideoFileEdge[];
+}
+
+export interface VideoFileConnectionPromise
+  extends Promise<VideoFileConnection>,
+    Fragmentable {
+  pageInfo: <T = PageInfoPromise>() => T;
+  edges: <T = FragmentableArray<VideoFileEdge>>() => T;
+  aggregate: <T = AggregateVideoFilePromise>() => T;
+}
+
+export interface VideoFileConnectionSubscription
+  extends Promise<AsyncIterator<VideoFileConnection>>,
+    Fragmentable {
+  pageInfo: <T = PageInfoSubscription>() => T;
+  edges: <T = Promise<AsyncIterator<VideoFileEdgeSubscription>>>() => T;
+  aggregate: <T = AggregateVideoFileSubscription>() => T;
+}
+
+export interface LanguageTranslationEdge {
+  node: LanguageTranslation;
+  cursor: String;
+}
+
+export interface LanguageTranslationEdgePromise
+  extends Promise<LanguageTranslationEdge>,
+    Fragmentable {
+  node: <T = LanguageTranslationPromise>() => T;
+  cursor: () => Promise<String>;
+}
+
+export interface LanguageTranslationEdgeSubscription
+  extends Promise<AsyncIterator<LanguageTranslationEdge>>,
+    Fragmentable {
+  node: <T = LanguageTranslationSubscription>() => T;
+  cursor: () => Promise<AsyncIterator<String>>;
+}
+
+export interface CategoryConnection {
+  pageInfo: PageInfo;
+  edges: CategoryEdge[];
+}
+
+export interface CategoryConnectionPromise
+  extends Promise<CategoryConnection>,
+    Fragmentable {
+  pageInfo: <T = PageInfoPromise>() => T;
+  edges: <T = FragmentableArray<CategoryEdge>>() => T;
+  aggregate: <T = AggregateCategoryPromise>() => T;
+}
+
+export interface CategoryConnectionSubscription
+  extends Promise<AsyncIterator<CategoryConnection>>,
+    Fragmentable {
+  pageInfo: <T = PageInfoSubscription>() => T;
+  edges: <T = Promise<AsyncIterator<CategoryEdgeSubscription>>>() => T;
+  aggregate: <T = AggregateCategorySubscription>() => T;
 }
 
 export interface ImageFileSubscriptionPayload {
@@ -4553,116 +4753,6 @@ export interface ImageFileSubscriptionPayloadSubscription
   previousValues: <T = ImageFilePreviousValuesSubscription>() => T;
 }
 
-export interface VideoFileConnection {
-  pageInfo: PageInfo;
-  edges: VideoFileEdge[];
-}
-
-export interface VideoFileConnectionPromise
-  extends Promise<VideoFileConnection>,
-    Fragmentable {
-  pageInfo: <T = PageInfoPromise>() => T;
-  edges: <T = FragmentableArray<VideoFileEdge>>() => T;
-  aggregate: <T = AggregateVideoFilePromise>() => T;
-}
-
-export interface VideoFileConnectionSubscription
-  extends Promise<AsyncIterator<VideoFileConnection>>,
-    Fragmentable {
-  pageInfo: <T = PageInfoSubscription>() => T;
-  edges: <T = Promise<AsyncIterator<VideoFileEdgeSubscription>>>() => T;
-  aggregate: <T = AggregateVideoFileSubscription>() => T;
-}
-
-export interface ImageFilePreviousValues {
-  id: ID_Output;
-  alt?: String;
-  longdesc?: String;
-  caption?: String;
-  filename?: String;
-  filetype?: String;
-  md5?: String;
-  url?: String;
-}
-
-export interface ImageFilePreviousValuesPromise
-  extends Promise<ImageFilePreviousValues>,
-    Fragmentable {
-  id: () => Promise<ID_Output>;
-  alt: () => Promise<String>;
-  longdesc: () => Promise<String>;
-  caption: () => Promise<String>;
-  filename: () => Promise<String>;
-  filetype: () => Promise<String>;
-  md5: () => Promise<String>;
-  url: () => Promise<String>;
-}
-
-export interface ImageFilePreviousValuesSubscription
-  extends Promise<AsyncIterator<ImageFilePreviousValues>>,
-    Fragmentable {
-  id: () => Promise<AsyncIterator<ID_Output>>;
-  alt: () => Promise<AsyncIterator<String>>;
-  longdesc: () => Promise<AsyncIterator<String>>;
-  caption: () => Promise<AsyncIterator<String>>;
-  filename: () => Promise<AsyncIterator<String>>;
-  filetype: () => Promise<AsyncIterator<String>>;
-  md5: () => Promise<AsyncIterator<String>>;
-  url: () => Promise<AsyncIterator<String>>;
-}
-
-export interface CategoryConnection {
-  pageInfo: PageInfo;
-  edges: CategoryEdge[];
-}
-
-export interface CategoryConnectionPromise
-  extends Promise<CategoryConnection>,
-    Fragmentable {
-  pageInfo: <T = PageInfoPromise>() => T;
-  edges: <T = FragmentableArray<CategoryEdge>>() => T;
-  aggregate: <T = AggregateCategoryPromise>() => T;
-}
-
-export interface CategoryConnectionSubscription
-  extends Promise<AsyncIterator<CategoryConnection>>,
-    Fragmentable {
-  pageInfo: <T = PageInfoSubscription>() => T;
-  edges: <T = Promise<AsyncIterator<CategoryEdgeSubscription>>>() => T;
-  aggregate: <T = AggregateCategorySubscription>() => T;
-}
-
-export interface SupportFile {
-  id: ID_Output;
-  url?: String;
-  md5?: String;
-  filename?: String;
-  filetype?: String;
-  filesize?: Float;
-}
-
-export interface SupportFilePromise extends Promise<SupportFile>, Fragmentable {
-  id: () => Promise<ID_Output>;
-  language: <T = LanguagePromise>() => T;
-  url: () => Promise<String>;
-  md5: () => Promise<String>;
-  filename: () => Promise<String>;
-  filetype: () => Promise<String>;
-  filesize: () => Promise<Float>;
-}
-
-export interface SupportFileSubscription
-  extends Promise<AsyncIterator<SupportFile>>,
-    Fragmentable {
-  id: () => Promise<AsyncIterator<ID_Output>>;
-  language: <T = LanguageSubscription>() => T;
-  url: () => Promise<AsyncIterator<String>>;
-  md5: () => Promise<AsyncIterator<String>>;
-  filename: () => Promise<AsyncIterator<String>>;
-  filetype: () => Promise<AsyncIterator<String>>;
-  filesize: () => Promise<AsyncIterator<Float>>;
-}
-
 export interface VideoUse {
   id: ID_Output;
   name: String;
@@ -4678,6 +4768,109 @@ export interface VideoUseSubscription
     Fragmentable {
   id: () => Promise<AsyncIterator<ID_Output>>;
   name: () => Promise<AsyncIterator<String>>;
+}
+
+export interface ImageFilePreviousValues {
+  id: ID_Output;
+  createdAt: DateTimeOutput;
+  updatedAt: DateTimeOutput;
+  alt?: String;
+  longdesc?: String;
+  caption?: String;
+  filename?: String;
+  filetype?: String;
+  md5?: String;
+  url?: String;
+}
+
+export interface ImageFilePreviousValuesPromise
+  extends Promise<ImageFilePreviousValues>,
+    Fragmentable {
+  id: () => Promise<ID_Output>;
+  createdAt: () => Promise<DateTimeOutput>;
+  updatedAt: () => Promise<DateTimeOutput>;
+  alt: () => Promise<String>;
+  longdesc: () => Promise<String>;
+  caption: () => Promise<String>;
+  filename: () => Promise<String>;
+  filetype: () => Promise<String>;
+  md5: () => Promise<String>;
+  url: () => Promise<String>;
+}
+
+export interface ImageFilePreviousValuesSubscription
+  extends Promise<AsyncIterator<ImageFilePreviousValues>>,
+    Fragmentable {
+  id: () => Promise<AsyncIterator<ID_Output>>;
+  createdAt: () => Promise<AsyncIterator<DateTimeOutput>>;
+  updatedAt: () => Promise<AsyncIterator<DateTimeOutput>>;
+  alt: () => Promise<AsyncIterator<String>>;
+  longdesc: () => Promise<AsyncIterator<String>>;
+  caption: () => Promise<AsyncIterator<String>>;
+  filename: () => Promise<AsyncIterator<String>>;
+  filetype: () => Promise<AsyncIterator<String>>;
+  md5: () => Promise<AsyncIterator<String>>;
+  url: () => Promise<AsyncIterator<String>>;
+}
+
+export interface AggregateUser {
+  count: Int;
+}
+
+export interface AggregateUserPromise
+  extends Promise<AggregateUser>,
+    Fragmentable {
+  count: () => Promise<Int>;
+}
+
+export interface AggregateUserSubscription
+  extends Promise<AsyncIterator<AggregateUser>>,
+    Fragmentable {
+  count: () => Promise<AsyncIterator<Int>>;
+}
+
+export interface LanguageTranslationConnection {
+  pageInfo: PageInfo;
+  edges: LanguageTranslationEdge[];
+}
+
+export interface LanguageTranslationConnectionPromise
+  extends Promise<LanguageTranslationConnection>,
+    Fragmentable {
+  pageInfo: <T = PageInfoPromise>() => T;
+  edges: <T = FragmentableArray<LanguageTranslationEdge>>() => T;
+  aggregate: <T = AggregateLanguageTranslationPromise>() => T;
+}
+
+export interface LanguageTranslationConnectionSubscription
+  extends Promise<AsyncIterator<LanguageTranslationConnection>>,
+    Fragmentable {
+  pageInfo: <T = PageInfoSubscription>() => T;
+  edges: <
+    T = Promise<AsyncIterator<LanguageTranslationEdgeSubscription>>
+  >() => T;
+  aggregate: <T = AggregateLanguageTranslationSubscription>() => T;
+}
+
+export interface UserConnection {
+  pageInfo: PageInfo;
+  edges: UserEdge[];
+}
+
+export interface UserConnectionPromise
+  extends Promise<UserConnection>,
+    Fragmentable {
+  pageInfo: <T = PageInfoPromise>() => T;
+  edges: <T = FragmentableArray<UserEdge>>() => T;
+  aggregate: <T = AggregateUserPromise>() => T;
+}
+
+export interface UserConnectionSubscription
+  extends Promise<AsyncIterator<UserConnection>>,
+    Fragmentable {
+  pageInfo: <T = PageInfoSubscription>() => T;
+  edges: <T = Promise<AsyncIterator<UserEdgeSubscription>>>() => T;
+  aggregate: <T = AggregateUserSubscription>() => T;
 }
 
 export interface ImageUseSubscriptionPayload {
@@ -4705,20 +4898,23 @@ export interface ImageUseSubscriptionPayloadSubscription
   previousValues: <T = ImageUsePreviousValuesSubscription>() => T;
 }
 
-export interface AggregateUser {
-  count: Int;
+export interface ThumbnailEdge {
+  node: Thumbnail;
+  cursor: String;
 }
 
-export interface AggregateUserPromise
-  extends Promise<AggregateUser>,
+export interface ThumbnailEdgePromise
+  extends Promise<ThumbnailEdge>,
     Fragmentable {
-  count: () => Promise<Int>;
+  node: <T = ThumbnailPromise>() => T;
+  cursor: () => Promise<String>;
 }
 
-export interface AggregateUserSubscription
-  extends Promise<AsyncIterator<AggregateUser>>,
+export interface ThumbnailEdgeSubscription
+  extends Promise<AsyncIterator<ThumbnailEdge>>,
     Fragmentable {
-  count: () => Promise<AsyncIterator<Int>>;
+  node: <T = ThumbnailSubscription>() => T;
+  cursor: () => Promise<AsyncIterator<String>>;
 }
 
 export interface ImageUsePreviousValues {
@@ -4740,60 +4936,61 @@ export interface ImageUsePreviousValuesSubscription
   name: () => Promise<AsyncIterator<String>>;
 }
 
-export interface UserConnection {
-  pageInfo: PageInfo;
-  edges: UserEdge[];
+export interface VideoUnitPreviousValues {
+  id: ID_Output;
+  title: String;
+  descPublic?: String;
 }
 
-export interface UserConnectionPromise
-  extends Promise<UserConnection>,
+export interface VideoUnitPreviousValuesPromise
+  extends Promise<VideoUnitPreviousValues>,
     Fragmentable {
-  pageInfo: <T = PageInfoPromise>() => T;
-  edges: <T = FragmentableArray<UserEdge>>() => T;
-  aggregate: <T = AggregateUserPromise>() => T;
+  id: () => Promise<ID_Output>;
+  title: () => Promise<String>;
+  descPublic: () => Promise<String>;
 }
 
-export interface UserConnectionSubscription
-  extends Promise<AsyncIterator<UserConnection>>,
+export interface VideoUnitPreviousValuesSubscription
+  extends Promise<AsyncIterator<VideoUnitPreviousValues>>,
     Fragmentable {
-  pageInfo: <T = PageInfoSubscription>() => T;
-  edges: <T = Promise<AsyncIterator<UserEdgeSubscription>>>() => T;
-  aggregate: <T = AggregateUserSubscription>() => T;
+  id: () => Promise<AsyncIterator<ID_Output>>;
+  title: () => Promise<AsyncIterator<String>>;
+  descPublic: () => Promise<AsyncIterator<String>>;
 }
 
-export interface AggregateLanguageTranslation {
+export interface AggregateLanguage {
   count: Int;
 }
 
-export interface AggregateLanguageTranslationPromise
-  extends Promise<AggregateLanguageTranslation>,
+export interface AggregateLanguagePromise
+  extends Promise<AggregateLanguage>,
     Fragmentable {
   count: () => Promise<Int>;
 }
 
-export interface AggregateLanguageTranslationSubscription
-  extends Promise<AsyncIterator<AggregateLanguageTranslation>>,
+export interface AggregateLanguageSubscription
+  extends Promise<AsyncIterator<AggregateLanguage>>,
     Fragmentable {
   count: () => Promise<AsyncIterator<Int>>;
 }
 
-export interface ThumbnailEdge {
-  node: Thumbnail;
-  cursor: String;
+export interface Thumbnail {
+  id: ID_Output;
+  size?: ThumbnailSize;
 }
 
-export interface ThumbnailEdgePromise
-  extends Promise<ThumbnailEdge>,
-    Fragmentable {
-  node: <T = ThumbnailPromise>() => T;
-  cursor: () => Promise<String>;
+export interface ThumbnailPromise extends Promise<Thumbnail>, Fragmentable {
+  id: () => Promise<ID_Output>;
+  size: () => Promise<ThumbnailSize>;
+  image: <T = ImageFilePromise>() => T;
 }
 
-export interface ThumbnailEdgeSubscription
-  extends Promise<AsyncIterator<ThumbnailEdge>>,
+export interface ThumbnailSubscription
+  extends Promise<AsyncIterator<Thumbnail>>,
     Fragmentable {
-  node: <T = ThumbnailSubscription>() => T;
-  cursor: () => Promise<AsyncIterator<String>>;
+  id: () => Promise<AsyncIterator<ID_Output>>;
+  size: () => Promise<AsyncIterator<ThumbnailSize>>;
+  image: <T = ImageFileSubscription>() => T;
 }
 
 export interface LanguageSubscriptionPayload {
@@ -4821,20 +5018,21 @@ export interface LanguageSubscriptionPayloadSubscription
   previousValues: <T = LanguagePreviousValuesSubscription>() => T;
 }
 
-export interface AggregateImageFile {
-  count: Int;
+export interface TeamEdge {
+  node: Team;
+  cursor: String;
 }
 
-export interface AggregateImageFilePromise
-  extends Promise<AggregateImageFile>,
-    Fragmentable {
-  count: () => Promise<Int>;
+export interface TeamEdgePromise extends Promise<TeamEdge>, Fragmentable {
+  node: <T = TeamPromise>() => T;
+  cursor: () => Promise<String>;
 }
 
-export interface AggregateImageFileSubscription
-  extends Promise<AsyncIterator<AggregateImageFile>>,
+export interface TeamEdgeSubscription
+  extends Promise<AsyncIterator<TeamEdge>>,
     Fragmentable {
-  count: () => Promise<AsyncIterator<Int>>;
+  node: <T = TeamSubscription>() => T;
+  cursor: () => Promise<AsyncIterator<String>>;
 }
 
 export interface LanguagePreviousValues {
@@ -4868,86 +5066,6 @@ export interface LanguagePreviousValuesSubscription
   nativeName: () => Promise<AsyncIterator<String>>;
 }
 
-export interface Thumbnail {
-  id: ID_Output;
-  size?: ThumbnailSize;
-}
-
-export interface ThumbnailPromise extends Promise<Thumbnail>, Fragmentable {
-  id: () => Promise<ID_Output>;
-  size: () => Promise<ThumbnailSize>;
-  image: <T = ImageFilePromise>() => T;
-}
-
-export interface ThumbnailSubscription
-  extends Promise<AsyncIterator<Thumbnail>>,
-    Fragmentable {
-  id: () => Promise<AsyncIterator<ID_Output>>;
-  size: () => Promise<AsyncIterator<ThumbnailSize>>;
-  image: <T = ImageFileSubscription>() => T;
-}
-
-export interface LanguageTranslationEdge {
-  node: LanguageTranslation;
-  cursor: String;
-}
-
-export interface LanguageTranslationEdgePromise
-  extends Promise<LanguageTranslationEdge>,
-    Fragmentable {
-  node: <T = LanguageTranslationPromise>() => T;
-  cursor: () => Promise<String>;
-}
-
-export interface LanguageTranslationEdgeSubscription
-  extends Promise<AsyncIterator<LanguageTranslationEdge>>,
-    Fragmentable {
-  node: <T = LanguageTranslationSubscription>() => T;
-  cursor: () => Promise<AsyncIterator<String>>;
-}
-
-export interface TeamEdge {
-  node: Team;
-  cursor: String;
-}
-
-export interface TeamEdgePromise extends Promise<TeamEdge>, Fragmentable {
-  node: <T = TeamPromise>() => T;
-  cursor: () => Promise<String>;
-}
-
-export interface TeamEdgeSubscription
-  extends Promise<AsyncIterator<TeamEdge>>,
-    Fragmentable {
-  node: <T = TeamSubscription>() => T;
-  cursor: () => Promise<AsyncIterator<String>>;
-}
-
-export interface LanguageTranslationSubscriptionPayload {
-  mutation: MutationType;
-  node: LanguageTranslation;
-  updatedFields: String[];
-  previousValues: LanguageTranslationPreviousValues;
-}
-
-export interface LanguageTranslationSubscriptionPayloadPromise
-  extends Promise<LanguageTranslationSubscriptionPayload>,
-    Fragmentable {
-  mutation: () => Promise<MutationType>;
-  node: <T = LanguageTranslationPromise>() => T;
-  updatedFields: () => Promise<String[]>;
-  previousValues: <T = LanguageTranslationPreviousValuesPromise>() => T;
-}
-
-export interface LanguageTranslationSubscriptionPayloadSubscription
-  extends Promise<AsyncIterator<LanguageTranslationSubscriptionPayload>>,
-    Fragmentable {
-  mutation: () => Promise<AsyncIterator<MutationType>>;
-  node: <T = LanguageTranslationSubscription>() => T;
-  updatedFields: () => Promise<AsyncIterator<String[]>>;
-  previousValues: <T = LanguageTranslationPreviousValuesSubscription>() => T;
-}
-
 export interface AggregateCategory {
   count: Int;
 }
@@ -4964,23 +5082,23 @@ export interface AggregateCategorySubscription
   count: () => Promise<AsyncIterator<Int>>;
 }
 
-export interface LanguageTranslationPreviousValues {
-  id: ID_Output;
-  name: String;
+export interface LanguageEdge {
+  node: Language;
+  cursor: String;
 }
 
-export interface LanguageTranslationPreviousValuesPromise
-  extends Promise<LanguageTranslationPreviousValues>,
+export interface LanguageEdgePromise
+  extends Promise<LanguageEdge>,
     Fragmentable {
-  id: () => Promise<ID_Output>;
-  name: () => Promise<String>;
+  node: <T = LanguagePromise>() => T;
+  cursor: () => Promise<String>;
 }
 
-export interface LanguageTranslationPreviousValuesSubscription
-  extends Promise<AsyncIterator<LanguageTranslationPreviousValues>>,
+export interface LanguageEdgeSubscription
+  extends Promise<AsyncIterator<LanguageEdge>>,
     Fragmentable {
-  id: () => Promise<AsyncIterator<ID_Output>>;
-  name: () => Promise<AsyncIterator<String>>;
+  node: <T = LanguageSubscription>() => T;
+  cursor: () => Promise<AsyncIterator<String>>;
 }
 
 export interface User {
@@ -5035,27 +5153,29 @@ export interface UserSubscription
   isConfirmed: () => Promise<AsyncIterator<Boolean>>;
 }
 
-export interface LanguageTranslationConnection {
-  pageInfo: PageInfo;
-  edges: LanguageTranslationEdge[];
+export interface LanguageTranslationSubscriptionPayload {
+  mutation: MutationType;
+  node: LanguageTranslation;
+  updatedFields: String[];
+  previousValues: LanguageTranslationPreviousValues;
 }
 
-export interface LanguageTranslationConnectionPromise
-  extends Promise<LanguageTranslationConnection>,
+export interface LanguageTranslationSubscriptionPayloadPromise
+  extends Promise<LanguageTranslationSubscriptionPayload>,
     Fragmentable {
-  pageInfo: <T = PageInfoPromise>() => T;
-  edges: <T = FragmentableArray<LanguageTranslationEdge>>() => T;
-  aggregate: <T = AggregateLanguageTranslationPromise>() => T;
+  mutation: () => Promise<MutationType>;
+  node: <T = LanguageTranslationPromise>() => T;
+  updatedFields: () => Promise<String[]>;
+  previousValues: <T = LanguageTranslationPreviousValuesPromise>() => T;
 }
 
-export interface LanguageTranslationConnectionSubscription
-  extends Promise<AsyncIterator<LanguageTranslationConnection>>,
+export interface LanguageTranslationSubscriptionPayloadSubscription
+  extends Promise<AsyncIterator<LanguageTranslationSubscriptionPayload>>,
     Fragmentable {
-  pageInfo: <T = PageInfoSubscription>() => T;
-  edges: <
-    T = Promise<AsyncIterator<LanguageTranslationEdgeSubscription>>
-  >() => T;
-  aggregate: <T = AggregateLanguageTranslationSubscription>() => T;
+  mutation: () => Promise<AsyncIterator<MutationType>>;
+  node: <T = LanguageTranslationSubscription>() => T;
+  updatedFields: () => Promise<AsyncIterator<String[]>>;
+  previousValues: <T = LanguageTranslationPreviousValuesSubscription>() => T;
 }
 
 export interface AggregateTag {
@@ -5072,6 +5192,83 @@ export interface AggregateTagSubscription
   extends Promise<AsyncIterator<AggregateTag>>,
     Fragmentable {
   count: () => Promise<AsyncIterator<Int>>;
+}
+
+export interface LanguageTranslationPreviousValues {
+  id: ID_Output;
+  name: String;
+}
+
+export interface LanguageTranslationPreviousValuesPromise
+  extends Promise<LanguageTranslationPreviousValues>,
+    Fragmentable {
+  id: () => Promise<ID_Output>;
+  name: () => Promise<String>;
+}
+
+export interface LanguageTranslationPreviousValuesSubscription
+  extends Promise<AsyncIterator<LanguageTranslationPreviousValues>>,
+    Fragmentable {
+  id: () => Promise<AsyncIterator<ID_Output>>;
+  name: () => Promise<AsyncIterator<String>>;
+}
+
+export interface TagConnection {
+  pageInfo: PageInfo;
+  edges: TagEdge[];
+}
+
+export interface TagConnectionPromise
+  extends Promise<TagConnection>,
+    Fragmentable {
+  pageInfo: <T = PageInfoPromise>() => T;
+  edges: <T = FragmentableArray<TagEdge>>() => T;
+  aggregate: <T = AggregateTagPromise>() => T;
+}
+
+export interface TagConnectionSubscription
+  extends Promise<AsyncIterator<TagConnection>>,
+    Fragmentable {
+  pageInfo: <T = PageInfoSubscription>() => T;
+  edges: <T = Promise<AsyncIterator<TagEdgeSubscription>>>() => T;
+  aggregate: <T = AggregateTagSubscription>() => T;
+}
+
+export interface LanguageConnection {
+  pageInfo: PageInfo;
+  edges: LanguageEdge[];
+}
+
+export interface LanguageConnectionPromise
+  extends Promise<LanguageConnection>,
+    Fragmentable {
+  pageInfo: <T = PageInfoPromise>() => T;
+  edges: <T = FragmentableArray<LanguageEdge>>() => T;
+  aggregate: <T = AggregateLanguagePromise>() => T;
+}
+
+export interface LanguageConnectionSubscription
+  extends Promise<AsyncIterator<LanguageConnection>>,
+    Fragmentable {
+  pageInfo: <T = PageInfoSubscription>() => T;
+  edges: <T = Promise<AsyncIterator<LanguageEdgeSubscription>>>() => T;
+  aggregate: <T = AggregateLanguageSubscription>() => T;
+}
+
+export interface BatchPayload {
+  count: Long;
+}
+
+export interface BatchPayloadPromise
+  extends Promise<BatchPayload>,
+    Fragmentable {
+  count: () => Promise<Long>;
+}
+
+export interface BatchPayloadSubscription
+  extends Promise<AsyncIterator<BatchPayload>>,
+    Fragmentable {
+  count: () => Promise<AsyncIterator<Long>>;
 }
 
 export interface SupportFileSubscriptionPayload {
@@ -5099,29 +5296,26 @@ export interface SupportFileSubscriptionPayloadSubscription
   previousValues: <T = SupportFilePreviousValuesSubscription>() => T;
 }
 
-export interface TagConnection {
-  pageInfo: PageInfo;
-  edges: TagEdge[];
+export interface AggregateVideoUnit {
+  count: Int;
 }
 
-export interface TagConnectionPromise
-  extends Promise<TagConnection>,
+export interface AggregateVideoUnitPromise
+  extends Promise<AggregateVideoUnit>,
     Fragmentable {
-  pageInfo: <T = PageInfoPromise>() => T;
-  edges: <T = FragmentableArray<TagEdge>>() => T;
-  aggregate: <T = AggregateTagPromise>() => T;
+  count: () => Promise<Int>;
 }
 
-export interface TagConnectionSubscription
-  extends Promise<AsyncIterator<TagConnection>>,
+export interface AggregateVideoUnitSubscription
+  extends Promise<AsyncIterator<AggregateVideoUnit>>,
     Fragmentable {
-  pageInfo: <T = PageInfoSubscription>() => T;
-  edges: <T = Promise<AsyncIterator<TagEdgeSubscription>>>() => T;
-  aggregate: <T = AggregateTagSubscription>() => T;
+  count: () => Promise<AsyncIterator<Int>>;
 }
 
 export interface SupportFilePreviousValues {
   id: ID_Output;
+  createdAt: DateTimeOutput;
+  updatedAt: DateTimeOutput;
   url?: String;
   md5?: String;
   filename?: String;
@@ -5133,6 +5327,8 @@ export interface SupportFilePreviousValuesPromise
   extends Promise<SupportFilePreviousValues>,
     Fragmentable {
   id: () => Promise<ID_Output>;
+  createdAt: () => Promise<DateTimeOutput>;
+  updatedAt: () => Promise<DateTimeOutput>;
   url: () => Promise<String>;
   md5: () => Promise<String>;
   filename: () => Promise<String>;
@@ -5144,6 +5340,8 @@ export interface SupportFilePreviousValuesSubscription
   extends Promise<AsyncIterator<SupportFilePreviousValues>>,
     Fragmentable {
   id: () => Promise<AsyncIterator<ID_Output>>;
+  createdAt: () => Promise<AsyncIterator<DateTimeOutput>>;
+  updatedAt: () => Promise<AsyncIterator<DateTimeOutput>>;
   url: () => Promise<AsyncIterator<String>>;
   md5: () => Promise<AsyncIterator<String>>;
   filename: () => Promise<AsyncIterator<String>>;
@@ -5151,75 +5349,58 @@ export interface SupportFilePreviousValuesSubscription
   filesize: () => Promise<AsyncIterator<Float>>;
 }
 
-export interface ImageFile {
-  id: ID_Output;
-  alt?: String;
-  longdesc?: String;
-  caption?: String;
-  filename?: String;
-  filetype?: String;
-  md5?: String;
-  url?: String;
+export interface VideoStreamEdge {
+  node: VideoStream;
+  cursor: String;
 }
 
-export interface ImageFilePromise extends Promise<ImageFile>, Fragmentable {
-  id: () => Promise<ID_Output>;
-  language: <T = LanguagePromise>() => T;
-  dimensions: <T = DimensionsPromise>() => T;
-  alt: () => Promise<String>;
-  longdesc: () => Promise<String>;
-  caption: () => Promise<String>;
-  filename: () => Promise<String>;
-  filetype: () => Promise<String>;
-  md5: () => Promise<String>;
-  url: () => Promise<String>;
-}
-
-export interface ImageFileSubscription
-  extends Promise<AsyncIterator<ImageFile>>,
+export interface VideoStreamEdgePromise
+  extends Promise<VideoStreamEdge>,
     Fragmentable {
-  id: () => Promise<AsyncIterator<ID_Output>>;
-  language: <T = LanguageSubscription>() => T;
-  dimensions: <T = DimensionsSubscription>() => T;
-  alt: () => Promise<AsyncIterator<String>>;
-  longdesc: () => Promise<AsyncIterator<String>>;
-  caption: () => Promise<AsyncIterator<String>>;
-  filename: () => Promise<AsyncIterator<String>>;
-  filetype: () => Promise<AsyncIterator<String>>;
-  md5: () => Promise<AsyncIterator<String>>;
-  url: () => Promise<AsyncIterator<String>>;
+  node: <T = VideoStreamPromise>() => T;
+  cursor: () => Promise<String>;
 }
 
-export interface AggregateLanguage {
+export interface VideoStreamEdgeSubscription
+  extends Promise<AsyncIterator<VideoStreamEdge>>,
+    Fragmentable {
+  node: <T = VideoStreamSubscription>() => T;
+  cursor: () => Promise<AsyncIterator<String>>;
+}
+
+export interface AggregateDimensions {
   count: Int;
 }
 
-export interface AggregateLanguagePromise
-  extends Promise<AggregateLanguage>,
+export interface AggregateDimensionsPromise
+  extends Promise<AggregateDimensions>,
     Fragmentable {
   count: () => Promise<Int>;
 }
 
-export interface AggregateLanguageSubscription
-  extends Promise<AsyncIterator<AggregateLanguage>>,
+export interface AggregateDimensionsSubscription
+  extends Promise<AsyncIterator<AggregateDimensions>>,
     Fragmentable {
   count: () => Promise<AsyncIterator<Int>>;
 }
 
-export interface AggregateVideoUse {
-  count: Int;
+export interface VideoProjectEdge {
+  node: VideoProject;
+  cursor: String;
 }
 
-export interface AggregateVideoUsePromise
-  extends Promise<AggregateVideoUse>,
+export interface VideoProjectEdgePromise
+  extends Promise<VideoProjectEdge>,
     Fragmentable {
-  count: () => Promise<Int>;
+  node: <T = VideoProjectPromise>() => T;
+  cursor: () => Promise<String>;
 }
 
-export interface AggregateVideoUseSubscription
-  extends Promise<AsyncIterator<AggregateVideoUse>>,
+export interface VideoProjectEdgeSubscription
+  extends Promise<AsyncIterator<VideoProjectEdge>>,
     Fragmentable {
-  count: () => Promise<AsyncIterator<Int>>;
+  node: <T = VideoProjectSubscription>() => T;
+  cursor: () => Promise<AsyncIterator<String>>;
 }
 
 export interface TagSubscriptionPayload {
@@ -5247,23 +5428,25 @@ export interface TagSubscriptionPayloadSubscription
   previousValues: <T = TagPreviousValuesSubscription>() => T;
 }
 
-export interface VideoUnitEdge {
-  node: VideoUnit;
-  cursor: String;
+export interface LanguageTranslation {
+  id: ID_Output;
+  name: String;
 }
 
-export interface VideoUnitEdgePromise
-  extends Promise<VideoUnitEdge>,
+export interface LanguageTranslationPromise
+  extends Promise<LanguageTranslation>,
     Fragmentable {
-  node: <T = VideoUnitPromise>() => T;
-  cursor: () => Promise<String>;
+  id: () => Promise<ID_Output>;
+  name: () => Promise<String>;
+  language: <T = LanguagePromise>() => T;
 }
 
-export interface VideoUnitEdgeSubscription
-  extends Promise<AsyncIterator<VideoUnitEdge>>,
+export interface LanguageTranslationSubscription
+  extends Promise<AsyncIterator<LanguageTranslation>>,
     Fragmentable {
-  node: <T = VideoUnitSubscription>() => T;
-  cursor: () => Promise<AsyncIterator<String>>;
+  id: () => Promise<AsyncIterator<ID_Output>>;
+  name: () => Promise<AsyncIterator<String>>;
+  language: <T = LanguageSubscription>() => T;
 }
 
 export interface TagPreviousValues {
@@ -5280,6 +5463,945 @@ export interface TagPreviousValuesSubscription
   extends Promise<AsyncIterator<TagPreviousValues>>,
     Fragmentable {
   id: () => Promise<AsyncIterator<ID_Output>>;
+}
+
+export interface VideoFileEdge {
+  node: VideoFile;
+  cursor: String;
+}
+
+export interface VideoFileEdgePromise
+  extends Promise<VideoFileEdge>,
+    Fragmentable {
+  node: <T = VideoFilePromise>() => T;
+  cursor: () => Promise<String>;
+}
+
+export interface VideoFileEdgeSubscription
+  extends Promise<AsyncIterator<VideoFileEdge>>,
+    Fragmentable {
+  node: <T = VideoFileSubscription>() => T;
+  cursor: () => Promise<AsyncIterator<String>>;
+}
+
+export interface AggregateImageUse {
+  count: Int;
+}
+
+export interface AggregateImageUsePromise
+  extends Promise<AggregateImageUse>,
+    Fragmentable {
+  count: () => Promise<Int>;
+}
+
+export interface AggregateImageUseSubscription
+  extends Promise<AsyncIterator<AggregateImageUse>>,
+    Fragmentable {
+  count: () => Promise<AsyncIterator<Int>>;
+}
+
+export interface PageInfo {
+  hasNextPage: Boolean;
+  hasPreviousPage: Boolean;
+  startCursor?: String;
+  endCursor?: String;
+}
+
+export interface PageInfoPromise extends Promise<PageInfo>, Fragmentable {
+  hasNextPage: () => Promise<Boolean>;
+  hasPreviousPage: () => Promise<Boolean>;
+  startCursor: () => Promise<String>;
+  endCursor: () => Promise<String>;
+}
+
+export interface PageInfoSubscription
+  extends Promise<AsyncIterator<PageInfo>>,
+    Fragmentable {
+  hasNextPage: () => Promise<AsyncIterator<Boolean>>;
+  hasPreviousPage: () => Promise<AsyncIterator<Boolean>>;
+  startCursor: () => Promise<AsyncIterator<String>>;
+  endCursor: () => Promise<AsyncIterator<String>>;
+}
+
+export interface TeamSubscriptionPayload {
+  mutation: MutationType;
+  node: Team;
+  updatedFields: String[];
+  previousValues: TeamPreviousValues;
+}
+
+export interface TeamSubscriptionPayloadPromise
+  extends Promise<TeamSubscriptionPayload>,
+    Fragmentable {
+  mutation: () => Promise<MutationType>;
+  node: <T = TeamPromise>() => T;
+  updatedFields: () => Promise<String[]>;
+  previousValues: <T = TeamPreviousValuesPromise>() => T;
+}
+
+export interface TeamSubscriptionPayloadSubscription
+  extends Promise<AsyncIterator<TeamSubscriptionPayload>>,
+    Fragmentable {
+  mutation: () => Promise<AsyncIterator<MutationType>>;
+  node: <T = TeamSubscription>() => T;
+  updatedFields: () => Promise<AsyncIterator<String[]>>;
+  previousValues: <T = TeamPreviousValuesSubscription>() => T;
+}
+
+export interface UserEdge {
+  node: User;
+  cursor: String;
+}
+
+export interface UserEdgePromise extends Promise<UserEdge>, Fragmentable {
+  node: <T = UserPromise>() => T;
+  cursor: () => Promise<String>;
+}
+
+export interface UserEdgeSubscription
+  extends Promise<AsyncIterator<UserEdge>>,
+    Fragmentable {
+  node: <T = UserSubscription>() => T;
+  cursor: () => Promise<AsyncIterator<String>>;
+}
+
+export interface TeamPreviousValues {
+  id: ID_Output;
+  name: String;
+  organization: String;
+  contentTypes: ContentType[];
+  isConfirmed: Boolean;
+}
+
+export interface TeamPreviousValuesPromise
+  extends Promise<TeamPreviousValues>,
+    Fragmentable {
+  id: () => Promise<ID_Output>;
+  name: () => Promise<String>;
+  organization: () => Promise<String>;
+  contentTypes: () => Promise<ContentType[]>;
+  isConfirmed: () => Promise<Boolean>;
+}
+
+export interface TeamPreviousValuesSubscription
+  extends Promise<AsyncIterator<TeamPreviousValues>>,
+    Fragmentable {
+  id: () => Promise<AsyncIterator<ID_Output>>;
+  name: () => Promise<AsyncIterator<String>>;
+  organization: () => Promise<AsyncIterator<String>>;
+  contentTypes: () => Promise<AsyncIterator<ContentType[]>>;
+  isConfirmed: () => Promise<AsyncIterator<Boolean>>;
+}
+
+export interface ThumbnailConnection {
+  pageInfo: PageInfo;
+  edges: ThumbnailEdge[];
+}
+
+export interface ThumbnailConnectionPromise
+  extends Promise<ThumbnailConnection>,
+    Fragmentable {
+  pageInfo: <T = PageInfoPromise>() => T;
+  edges: <T = FragmentableArray<ThumbnailEdge>>() => T;
+  aggregate: <T = AggregateThumbnailPromise>() => T;
+}
+
+export interface ThumbnailConnectionSubscription
+  extends Promise<AsyncIterator<ThumbnailConnection>>,
+    Fragmentable {
+  pageInfo: <T = PageInfoSubscription>() => T;
+  edges: <T = Promise<AsyncIterator<ThumbnailEdgeSubscription>>>() => T;
+  aggregate: <T = AggregateThumbnailSubscription>() => T;
+}
+
+export interface ImageUseEdge {
+  node: ImageUse;
+  cursor: String;
+}
+
+export interface ImageUseEdgePromise
+  extends Promise<ImageUseEdge>,
+    Fragmentable {
+  node: <T = ImageUsePromise>() => T;
+  cursor: () => Promise<String>;
+}
+
+export interface ImageUseEdgeSubscription
+  extends Promise<AsyncIterator<ImageUseEdge>>,
+    Fragmentable {
+  node: <T = ImageUseSubscription>() => T;
+  cursor: () => Promise<AsyncIterator<String>>;
+}
+
+export interface AggregateTeam {
+  count: Int;
+}
+
+export interface AggregateTeamPromise
+  extends Promise<AggregateTeam>,
+    Fragmentable {
+  count: () => Promise<Int>;
+}
+
+export interface AggregateTeamSubscription
+  extends Promise<AsyncIterator<AggregateTeam>>,
+    Fragmentable {
+  count: () => Promise<AsyncIterator<Int>>;
+}
+
+export interface ThumbnailSubscriptionPayload {
+  mutation: MutationType;
+  node: Thumbnail;
+  updatedFields: String[];
+  previousValues: ThumbnailPreviousValues;
+}
+
+export interface ThumbnailSubscriptionPayloadPromise
+  extends Promise<ThumbnailSubscriptionPayload>,
+    Fragmentable {
+  mutation: () => Promise<MutationType>;
+  node: <T = ThumbnailPromise>() => T;
+  updatedFields: () => Promise<String[]>;
+  previousValues: <T = ThumbnailPreviousValuesPromise>() => T;
+}
+
+export interface ThumbnailSubscriptionPayloadSubscription
+  extends Promise<AsyncIterator<ThumbnailSubscriptionPayload>>,
+    Fragmentable {
+  mutation: () => Promise<AsyncIterator<MutationType>>;
+  node: <T = ThumbnailSubscription>() => T;
+  updatedFields: () => Promise<AsyncIterator<String[]>>;
+  previousValues: <T = ThumbnailPreviousValuesSubscription>() => T;
+}
+
+export interface Dimensions {
+  id: ID_Output;
+  width?: Int;
+  height?: Int;
+}
+
+export interface DimensionsPromise extends Promise<Dimensions>, Fragmentable {
+  id: () => Promise<ID_Output>;
+  width: () => Promise<Int>;
+  height: () => Promise<Int>;
+}
+
+export interface DimensionsSubscription
+  extends Promise<AsyncIterator<Dimensions>>,
+    Fragmentable {
+  id: () => Promise<AsyncIterator<ID_Output>>;
+  width: () => Promise<AsyncIterator<Int>>;
+  height: () => Promise<AsyncIterator<Int>>;
+}
+
+export interface ThumbnailPreviousValues {
+  id: ID_Output;
+  size?: ThumbnailSize;
+}
+
+export interface ThumbnailPreviousValuesPromise
+  extends Promise<ThumbnailPreviousValues>,
+    Fragmentable {
+  id: () => Promise<ID_Output>;
+  size: () => Promise<ThumbnailSize>;
+}
+
+export interface ThumbnailPreviousValuesSubscription
+  extends Promise<AsyncIterator<ThumbnailPreviousValues>>,
+    Fragmentable {
+  id: () => Promise<AsyncIterator<ID_Output>>;
+  size: () => Promise<AsyncIterator<ThumbnailSize>>;
+}
+
+export interface TagEdge {
+  node: Tag;
+  cursor: String;
+}
+
+export interface TagEdgePromise extends Promise<TagEdge>, Fragmentable {
+  node: <T = TagPromise>() => T;
+  cursor: () => Promise<String>;
+}
+
+export interface TagEdgeSubscription
+  extends Promise<AsyncIterator<TagEdge>>,
+    Fragmentable {
+  node: <T = TagSubscription>() => T;
+  cursor: () => Promise<AsyncIterator<String>>;
+}
+
+export interface ImageUseConnection {
+  pageInfo: PageInfo;
+  edges: ImageUseEdge[];
+}
+
+export interface ImageUseConnectionPromise
+  extends Promise<ImageUseConnection>,
+    Fragmentable {
+  pageInfo: <T = PageInfoPromise>() => T;
+  edges: <T = FragmentableArray<ImageUseEdge>>() => T;
+  aggregate: <T = AggregateImageUsePromise>() => T;
+}
+
+export interface ImageUseConnectionSubscription
+  extends Promise<AsyncIterator<ImageUseConnection>>,
+    Fragmentable {
+  pageInfo: <T = PageInfoSubscription>() => T;
+  edges: <T = Promise<AsyncIterator<ImageUseEdgeSubscription>>>() => T;
+  aggregate: <T = AggregateImageUseSubscription>() => T;
+}
+
+export interface VideoUseEdge {
+  node: VideoUse;
+  cursor: String;
+}
+
+export interface VideoUseEdgePromise
+  extends Promise<VideoUseEdge>,
+    Fragmentable {
+  node: <T = VideoUsePromise>() => T;
+  cursor: () => Promise<String>;
+}
+
+export interface VideoUseEdgeSubscription
+  extends Promise<AsyncIterator<VideoUseEdge>>,
+    Fragmentable {
+  node: <T = VideoUseSubscription>() => T;
+  cursor: () => Promise<AsyncIterator<String>>;
+}
+
+export interface UserSubscriptionPayload {
+  mutation: MutationType;
+  node: User;
+  updatedFields: String[];
+  previousValues: UserPreviousValues;
+}
+
+export interface UserSubscriptionPayloadPromise
+  extends Promise<UserSubscriptionPayload>,
+    Fragmentable {
+  mutation: () => Promise<MutationType>;
+  node: <T = UserPromise>() => T;
+  updatedFields: () => Promise<String[]>;
+  previousValues: <T = UserPreviousValuesPromise>() => T;
+}
+
+export interface UserSubscriptionPayloadSubscription
+  extends Promise<AsyncIterator<UserSubscriptionPayload>>,
+    Fragmentable {
+  mutation: () => Promise<AsyncIterator<MutationType>>;
+  node: <T = UserSubscription>() => T;
+  updatedFields: () => Promise<AsyncIterator<String[]>>;
+  previousValues: <T = UserPreviousValuesSubscription>() => T;
+}
+
+export interface VideoUseSubscriptionPayload {
+  mutation: MutationType;
+  node: VideoUse;
+  updatedFields: String[];
+  previousValues: VideoUsePreviousValues;
+}
+
+export interface VideoUseSubscriptionPayloadPromise
+  extends Promise<VideoUseSubscriptionPayload>,
+    Fragmentable {
+  mutation: () => Promise<MutationType>;
+  node: <T = VideoUsePromise>() => T;
+  updatedFields: () => Promise<String[]>;
+  previousValues: <T = VideoUsePreviousValuesPromise>() => T;
+}
+
+export interface VideoUseSubscriptionPayloadSubscription
+  extends Promise<AsyncIterator<VideoUseSubscriptionPayload>>,
+    Fragmentable {
+  mutation: () => Promise<AsyncIterator<MutationType>>;
+  node: <T = VideoUseSubscription>() => T;
+  updatedFields: () => Promise<AsyncIterator<String[]>>;
+  previousValues: <T = VideoUsePreviousValuesSubscription>() => T;
+}
+
+export interface UserPreviousValues {
+  id: ID_Output;
+  firstName: String;
+  lastName: String;
+  email: String;
+  password?: String;
+  tempToken?: String;
+  tempTokenExpiry?: Float;
+  jobTitle?: String;
+  country?: String;
+  city?: String;
+  howHeard?: String;
+  permissions: Permission[];
+  isConfirmed: Boolean;
+}
+
+export interface UserPreviousValuesPromise
+  extends Promise<UserPreviousValues>,
+    Fragmentable {
+  id: () => Promise<ID_Output>;
+  firstName: () => Promise<String>;
+  lastName: () => Promise<String>;
+  email: () => Promise<String>;
+  password: () => Promise<String>;
+  tempToken: () => Promise<String>;
+  tempTokenExpiry: () => Promise<Float>;
+  jobTitle: () => Promise<String>;
+  country: () => Promise<String>;
+  city: () => Promise<String>;
+  howHeard: () => Promise<String>;
+  permissions: () => Promise<Permission[]>;
+  isConfirmed: () => Promise<Boolean>;
+}
+
+export interface UserPreviousValuesSubscription
+  extends Promise<AsyncIterator<UserPreviousValues>>,
+    Fragmentable {
+  id: () => Promise<AsyncIterator<ID_Output>>;
+  firstName: () => Promise<AsyncIterator<String>>;
+  lastName: () => Promise<AsyncIterator<String>>;
+  email: () => Promise<AsyncIterator<String>>;
+  password: () => Promise<AsyncIterator<String>>;
+  tempToken: () => Promise<AsyncIterator<String>>;
+  tempTokenExpiry: () => Promise<AsyncIterator<Float>>;
+  jobTitle: () => Promise<AsyncIterator<String>>;
+  country: () => Promise<AsyncIterator<String>>;
+  city: () => Promise<AsyncIterator<String>>;
+  howHeard: () => Promise<AsyncIterator<String>>;
+  permissions: () => Promise<AsyncIterator<Permission[]>>;
+  isConfirmed: () => Promise<AsyncIterator<Boolean>>;
+}
+
+export interface VideoProject {
+  id: ID_Output;
+  createdAt: DateTimeOutput;
+  updatedAt: DateTimeOutput;
+  projectType: String;
+  projectTitle: String;
+  descPublic?: String;
+  descInternal?: String;
+  author?: String;
+  status?: ProjectPublishStatus;
+  visibility?: ProjectVisibility;
+}
+
+export interface VideoProjectPromise
+  extends Promise<VideoProject>,
+    Fragmentable {
+  id: () => Promise<ID_Output>;
+  createdAt: () => Promise<DateTimeOutput>;
+  updatedAt: () => Promise<DateTimeOutput>;
+  projectType: () => Promise<String>;
+  projectTitle: () => Promise<String>;
+  descPublic: () => Promise<String>;
+  descInternal: () => Promise<String>;
+  author: () => Promise<String>;
+  team: <T = TeamPromise>() => T;
+  status: () => Promise<ProjectPublishStatus>;
+  visibility: () => Promise<ProjectVisibility>;
+  units: <T = FragmentableArray<VideoUnit>>(args?: {
+    where?: VideoUnitWhereInput;
+    orderBy?: VideoUnitOrderByInput;
+    skip?: Int;
+    after?: String;
+    before?: String;
+    first?: Int;
+    last?: Int;
+  }) => T;
+  supportFiles: <T = FragmentableArray<SupportFile>>(args?: {
+    where?: SupportFileWhereInput;
+    orderBy?: SupportFileOrderByInput;
+    skip?: Int;
+    after?: String;
+    before?: String;
+    first?: Int;
+    last?: Int;
+  }) => T;
+  thumbnails: <T = FragmentableArray<ImageFile>>(args?: {
+    where?: ImageFileWhereInput;
+    orderBy?: ImageFileOrderByInput;
+    skip?: Int;
+    after?: String;
+    before?: String;
+    first?: Int;
+    last?: Int;
+  }) => T;
+  categories: <T = FragmentableArray<Category>>(args?: {
+    where?: CategoryWhereInput;
+    orderBy?: CategoryOrderByInput;
+    skip?: Int;
+    after?: String;
+    before?: String;
+    first?: Int;
+    last?: Int;
+  }) => T;
+  tags: <T = FragmentableArray<Tag>>(args?: {
+    where?: TagWhereInput;
+    orderBy?: TagOrderByInput;
+    skip?: Int;
+    after?: String;
+    before?: String;
+    first?: Int;
+    last?: Int;
+  }) => T;
+}
+
+export interface VideoProjectSubscription
+  extends Promise<AsyncIterator<VideoProject>>,
+    Fragmentable {
+  id: () => Promise<AsyncIterator<ID_Output>>;
+  createdAt: () => Promise<AsyncIterator<DateTimeOutput>>;
+  updatedAt: () => Promise<AsyncIterator<DateTimeOutput>>;
+  projectType: () => Promise<AsyncIterator<String>>;
+  projectTitle: () => Promise<AsyncIterator<String>>;
+  descPublic: () => Promise<AsyncIterator<String>>;
+  descInternal: () => Promise<AsyncIterator<String>>;
+  author: () => Promise<AsyncIterator<String>>;
+  team: <T = TeamSubscription>() => T;
+  status: () => Promise<AsyncIterator<ProjectPublishStatus>>;
+  visibility: () => Promise<AsyncIterator<ProjectVisibility>>;
+  units: <T = Promise<AsyncIterator<VideoUnitSubscription>>>(args?: {
+    where?: VideoUnitWhereInput;
+    orderBy?: VideoUnitOrderByInput;
+    skip?: Int;
+    after?: String;
+    before?: String;
+    first?: Int;
+    last?: Int;
+  }) => T;
+  supportFiles: <T = Promise<AsyncIterator<SupportFileSubscription>>>(args?: {
+    where?: SupportFileWhereInput;
+    orderBy?: SupportFileOrderByInput;
+    skip?: Int;
+    after?: String;
+    before?: String;
+    first?: Int;
+    last?: Int;
+  }) => T;
+  thumbnails: <T = Promise<AsyncIterator<ImageFileSubscription>>>(args?: {
+    where?: ImageFileWhereInput;
+    orderBy?: ImageFileOrderByInput;
+    skip?: Int;
+    after?: String;
+    before?: String;
+    first?: Int;
+    last?: Int;
+  }) => T;
+  categories: <T = Promise<AsyncIterator<CategorySubscription>>>(args?: {
+    where?: CategoryWhereInput;
+    orderBy?: CategoryOrderByInput;
+    skip?: Int;
+    after?: String;
+    before?: String;
+    first?: Int;
+    last?: Int;
+  }) => T;
+  tags: <T = Promise<AsyncIterator<TagSubscription>>>(args?: {
+    where?: TagWhereInput;
+    orderBy?: TagOrderByInput;
+    skip?: Int;
+    after?: String;
+    before?: String;
+    first?: Int;
+    last?: Int;
+  }) => T;
+}
+
+export interface ImageUse {
+  id: ID_Output;
+  name: String;
+}
+
+export interface ImageUsePromise extends Promise<ImageUse>, Fragmentable {
+  id: () => Promise<ID_Output>;
+  name: () => Promise<String>;
+}
+
+export interface ImageUseSubscription
+  extends Promise<AsyncIterator<ImageUse>>,
+    Fragmentable {
+  id: () => Promise<AsyncIterator<ID_Output>>;
+  name: () => Promise<AsyncIterator<String>>;
+}
+
+export interface VideoFile {
+  id: ID_Output;
+  createdAt: DateTimeOutput;
+  updatedAt: DateTimeOutput;
+  filetype?: String;
+  filename?: String;
+  quality?: VideoQuality;
+  videoBurnedInStatus?: VideoBurnedInStatus;
+  url?: String;
+  md5?: String;
+  duration?: Float;
+  bitrate?: Float;
+  filesize?: Float;
+}
+
+export interface VideoFilePromise extends Promise<VideoFile>, Fragmentable {
+  id: () => Promise<ID_Output>;
+  createdAt: () => Promise<DateTimeOutput>;
+  updatedAt: () => Promise<DateTimeOutput>;
+  language: <T = LanguagePromise>() => T;
+  filetype: () => Promise<String>;
+  filename: () => Promise<String>;
+  use: <T = VideoUsePromise>() => T;
+  quality: () => Promise<VideoQuality>;
+  videoBurnedInStatus: () => Promise<VideoBurnedInStatus>;
+  url: () => Promise<String>;
+  md5: () => Promise<String>;
+  duration: () => Promise<Float>;
+  bitrate: () => Promise<Float>;
+  filesize: () => Promise<Float>;
+  dimensions: <T = DimensionsPromise>() => T;
+  stream: <T = VideoStreamPromise>() => T;
+}
+
+export interface VideoFileSubscription
+  extends Promise<AsyncIterator<VideoFile>>,
+    Fragmentable {
+  id: () => Promise<AsyncIterator<ID_Output>>;
+  createdAt: () => Promise<AsyncIterator<DateTimeOutput>>;
+  updatedAt: () => Promise<AsyncIterator<DateTimeOutput>>;
+  language: <T = LanguageSubscription>() => T;
+  filetype: () => Promise<AsyncIterator<String>>;
+  filename: () => Promise<AsyncIterator<String>>;
+  use: <T = VideoUseSubscription>() => T;
+  quality: () => Promise<AsyncIterator<VideoQuality>>;
+  videoBurnedInStatus: () => Promise<AsyncIterator<VideoBurnedInStatus>>;
+  url: () => Promise<AsyncIterator<String>>;
+  md5: () => Promise<AsyncIterator<String>>;
+  duration: () => Promise<AsyncIterator<Float>>;
+  bitrate: () => Promise<AsyncIterator<Float>>;
+  filesize: () => Promise<AsyncIterator<Float>>;
+  dimensions: <T = DimensionsSubscription>() => T;
+  stream: <T = VideoStreamSubscription>() => T;
+}
+
+export interface VideoFileSubscriptionPayload {
+  mutation: MutationType;
+  node: VideoFile;
+  updatedFields: String[];
+  previousValues: VideoFilePreviousValues;
+}
+
+export interface VideoFileSubscriptionPayloadPromise
+  extends Promise<VideoFileSubscriptionPayload>,
+    Fragmentable {
+  mutation: () => Promise<MutationType>;
+  node: <T = VideoFilePromise>() => T;
+  updatedFields: () => Promise<String[]>;
+  previousValues: <T = VideoFilePreviousValuesPromise>() => T;
+}
+
+export interface VideoFileSubscriptionPayloadSubscription
+  extends Promise<AsyncIterator<VideoFileSubscriptionPayload>>,
+    Fragmentable {
+  mutation: () => Promise<AsyncIterator<MutationType>>;
+  node: <T = VideoFileSubscription>() => T;
+  updatedFields: () => Promise<AsyncIterator<String[]>>;
+  previousValues: <T = VideoFilePreviousValuesSubscription>() => T;
+}
+
+export interface CategoryEdge {
+  node: Category;
+  cursor: String;
+}
+
+export interface CategoryEdgePromise
+  extends Promise<CategoryEdge>,
+    Fragmentable {
+  node: <T = CategoryPromise>() => T;
+  cursor: () => Promise<String>;
+}
+
+export interface CategoryEdgeSubscription
+  extends Promise<AsyncIterator<CategoryEdge>>,
+    Fragmentable {
+  node: <T = CategorySubscription>() => T;
+  cursor: () => Promise<AsyncIterator<String>>;
+}
+
+export interface VideoFilePreviousValues {
+  id: ID_Output;
+  createdAt: DateTimeOutput;
+  updatedAt: DateTimeOutput;
+  filetype?: String;
+  filename?: String;
+  quality?: VideoQuality;
+  videoBurnedInStatus?: VideoBurnedInStatus;
+  url?: String;
+  md5?: String;
+  duration?: Float;
+  bitrate?: Float;
+  filesize?: Float;
+}
+
+export interface VideoFilePreviousValuesPromise
+  extends Promise<VideoFilePreviousValues>,
+    Fragmentable {
+  id: () => Promise<ID_Output>;
+  createdAt: () => Promise<DateTimeOutput>;
+  updatedAt: () => Promise<DateTimeOutput>;
+  filetype: () => Promise<String>;
+  filename: () => Promise<String>;
+  quality: () => Promise<VideoQuality>;
+  videoBurnedInStatus: () => Promise<VideoBurnedInStatus>;
+  url: () => Promise<String>;
+  md5: () => Promise<String>;
+  duration: () => Promise<Float>;
+  bitrate: () => Promise<Float>;
+  filesize: () => Promise<Float>;
+}
+
+export interface VideoFilePreviousValuesSubscription
+  extends Promise<AsyncIterator<VideoFilePreviousValues>>,
+    Fragmentable {
+  id: () => Promise<AsyncIterator<ID_Output>>;
+  createdAt: () => Promise<AsyncIterator<DateTimeOutput>>;
+  updatedAt: () => Promise<AsyncIterator<DateTimeOutput>>;
+  filetype: () => Promise<AsyncIterator<String>>;
+  filename: () => Promise<AsyncIterator<String>>;
+  quality: () => Promise<AsyncIterator<VideoQuality>>;
+  videoBurnedInStatus: () => Promise<AsyncIterator<VideoBurnedInStatus>>;
+  url: () => Promise<AsyncIterator<String>>;
+  md5: () => Promise<AsyncIterator<String>>;
+  duration: () => Promise<AsyncIterator<Float>>;
+  bitrate: () => Promise<AsyncIterator<Float>>;
+  filesize: () => Promise<AsyncIterator<Float>>;
+}
+
+export interface Team {
+  id: ID_Output;
+  name: String;
+  organization: String;
+  contentTypes: ContentType[];
+  isConfirmed: Boolean;
+}
+
+export interface TeamPromise extends Promise<Team>, Fragmentable {
+  id: () => Promise<ID_Output>;
+  name: () => Promise<String>;
+  organization: () => Promise<String>;
+  members: <T = FragmentableArray<User>>(args?: {
+    where?: UserWhereInput;
+    orderBy?: UserOrderByInput;
+    skip?: Int;
+    after?: String;
+    before?: String;
+    first?: Int;
+    last?: Int;
+  }) => T;
+  contentTypes: () => Promise<ContentType[]>;
+  isConfirmed: () => Promise<Boolean>;
+}
+
+export interface TeamSubscription
+  extends Promise<AsyncIterator<Team>>,
+    Fragmentable {
+  id: () => Promise<AsyncIterator<ID_Output>>;
+  name: () => Promise<AsyncIterator<String>>;
+  organization: () => Promise<AsyncIterator<String>>;
+  members: <T = Promise<AsyncIterator<UserSubscription>>>(args?: {
+    where?: UserWhereInput;
+    orderBy?: UserOrderByInput;
+    skip?: Int;
+    after?: String;
+    before?: String;
+    first?: Int;
+    last?: Int;
+  }) => T;
+  contentTypes: () => Promise<AsyncIterator<ContentType[]>>;
+  isConfirmed: () => Promise<AsyncIterator<Boolean>>;
+}
+
+export interface AggregateImageFile {
+  count: Int;
+}
+
+export interface AggregateImageFilePromise
+  extends Promise<AggregateImageFile>,
+    Fragmentable {
+  count: () => Promise<Int>;
+}
+
+export interface AggregateImageFileSubscription
+  extends Promise<AsyncIterator<AggregateImageFile>>,
+    Fragmentable {
+  count: () => Promise<AsyncIterator<Int>>;
+}
+
+export interface VideoUnitConnection {
+  pageInfo: PageInfo;
+  edges: VideoUnitEdge[];
+}
+
+export interface VideoUnitConnectionPromise
+  extends Promise<VideoUnitConnection>,
+    Fragmentable {
+  pageInfo: <T = PageInfoPromise>() => T;
+  edges: <T = FragmentableArray<VideoUnitEdge>>() => T;
+  aggregate: <T = AggregateVideoUnitPromise>() => T;
+}
+
+export interface VideoUnitConnectionSubscription
+  extends Promise<AsyncIterator<VideoUnitConnection>>,
+    Fragmentable {
+  pageInfo: <T = PageInfoSubscription>() => T;
+  edges: <T = Promise<AsyncIterator<VideoUnitEdgeSubscription>>>() => T;
+  aggregate: <T = AggregateVideoUnitSubscription>() => T;
+}
+
+export interface VideoStream {
+  id: ID_Output;
+  site?: String;
+  url?: String;
+  embedUrl?: String;
+}
+
+export interface VideoStreamPromise extends Promise<VideoStream>, Fragmentable {
+  id: () => Promise<ID_Output>;
+  site: () => Promise<String>;
+  url: () => Promise<String>;
+  embedUrl: () => Promise<String>;
+}
+
+export interface VideoStreamSubscription
+  extends Promise<AsyncIterator<VideoStream>>,
+    Fragmentable {
+  id: () => Promise<AsyncIterator<ID_Output>>;
+  site: () => Promise<AsyncIterator<String>>;
+  url: () => Promise<AsyncIterator<String>>;
+  embedUrl: () => Promise<AsyncIterator<String>>;
+}
+
+export interface VideoStreamSubscriptionPayload {
+  mutation: MutationType;
+  node: VideoStream;
+  updatedFields: String[];
+  previousValues: VideoStreamPreviousValues;
+}
+
+export interface VideoStreamSubscriptionPayloadPromise
+  extends Promise<VideoStreamSubscriptionPayload>,
+    Fragmentable {
+  mutation: () => Promise<MutationType>;
+  node: <T = VideoStreamPromise>() => T;
+  updatedFields: () => Promise<String[]>;
+  previousValues: <T = VideoStreamPreviousValuesPromise>() => T;
+}
+
+export interface VideoStreamSubscriptionPayloadSubscription
+  extends Promise<AsyncIterator<VideoStreamSubscriptionPayload>>,
+    Fragmentable {
+  mutation: () => Promise<AsyncIterator<MutationType>>;
+  node: <T = VideoStreamSubscription>() => T;
+  updatedFields: () => Promise<AsyncIterator<String[]>>;
+  previousValues: <T = VideoStreamPreviousValuesSubscription>() => T;
+}
+
+export interface ImageFileEdge {
+  node: ImageFile;
+  cursor: String;
+}
+
+export interface ImageFileEdgePromise
+  extends Promise<ImageFileEdge>,
+    Fragmentable {
+  node: <T = ImageFilePromise>() => T;
+  cursor: () => Promise<String>;
+}
+
+export interface ImageFileEdgeSubscription
+  extends Promise<AsyncIterator<ImageFileEdge>>,
+    Fragmentable {
+  node: <T = ImageFileSubscription>() => T;
+  cursor: () => Promise<AsyncIterator<String>>;
+}
+
+export interface VideoProjectPreviousValues {
+  id: ID_Output;
+  createdAt: DateTimeOutput;
+  updatedAt: DateTimeOutput;
+  projectType: String;
+  projectTitle: String;
+  descPublic?: String;
+  descInternal?: String;
+  author?: String;
+  status?: ProjectPublishStatus;
+  visibility?: ProjectVisibility;
+}
+
+export interface VideoProjectPreviousValuesPromise
+  extends Promise<VideoProjectPreviousValues>,
+    Fragmentable {
+  id: () => Promise<ID_Output>;
+  createdAt: () => Promise<DateTimeOutput>;
+  updatedAt: () => Promise<DateTimeOutput>;
+  projectType: () => Promise<String>;
+  projectTitle: () => Promise<String>;
+  descPublic: () => Promise<String>;
+  descInternal: () => Promise<String>;
+  author: () => Promise<String>;
+  status: () => Promise<ProjectPublishStatus>;
+  visibility: () => Promise<ProjectVisibility>;
+}
+
+export interface VideoProjectPreviousValuesSubscription
+  extends Promise<AsyncIterator<VideoProjectPreviousValues>>,
+    Fragmentable {
+  id: () => Promise<AsyncIterator<ID_Output>>;
+  createdAt: () => Promise<AsyncIterator<DateTimeOutput>>;
+  updatedAt: () => Promise<AsyncIterator<DateTimeOutput>>;
+  projectType: () => Promise<AsyncIterator<String>>;
+  projectTitle: () => Promise<AsyncIterator<String>>;
+  descPublic: () => Promise<AsyncIterator<String>>;
+  descInternal: () => Promise<AsyncIterator<String>>;
+  author: () => Promise<AsyncIterator<String>>;
+  status: () => Promise<AsyncIterator<ProjectPublishStatus>>;
+  visibility: () => Promise<AsyncIterator<ProjectVisibility>>;
+}
+
+export interface VideoProjectSubscriptionPayload {
+  mutation: MutationType;
+  node: VideoProject;
+  updatedFields: String[];
+  previousValues: VideoProjectPreviousValues;
+}
+
+export interface VideoProjectSubscriptionPayloadPromise
+  extends Promise<VideoProjectSubscriptionPayload>,
+    Fragmentable {
+  mutation: () => Promise<MutationType>;
+  node: <T = VideoProjectPromise>() => T;
+  updatedFields: () => Promise<String[]>;
+  previousValues: <T = VideoProjectPreviousValuesPromise>() => T;
+}
+
+export interface VideoProjectSubscriptionPayloadSubscription
+  extends Promise<AsyncIterator<VideoProjectSubscriptionPayload>>,
+    Fragmentable {
+  mutation: () => Promise<AsyncIterator<MutationType>>;
+  node: <T = VideoProjectSubscription>() => T;
+  updatedFields: () => Promise<AsyncIterator<String[]>>;
+  previousValues: <T = VideoProjectPreviousValuesSubscription>() => T;
+}
+
+export interface AggregateThumbnail {
+  count: Int;
+}
+
+export interface AggregateThumbnailPromise
+  extends Promise<AggregateThumbnail>,
+    Fragmentable {
+  count: () => Promise<Int>;
+}
+
+export interface AggregateThumbnailSubscription
+  extends Promise<AsyncIterator<AggregateThumbnail>>,
+    Fragmentable {
+  count: () => Promise<AsyncIterator<Int>>;
 }
 
 export interface VideoUnit {
@@ -5376,377 +6498,25 @@ export interface VideoUnitSubscription
   }) => T;
 }
 
-export interface LanguageEdge {
-  node: Language;
-  cursor: String;
-}
-
-export interface LanguageEdgePromise
-  extends Promise<LanguageEdge>,
-    Fragmentable {
-  node: <T = LanguagePromise>() => T;
-  cursor: () => Promise<String>;
-}
-
-export interface LanguageEdgeSubscription
-  extends Promise<AsyncIterator<LanguageEdge>>,
-    Fragmentable {
-  node: <T = LanguageSubscription>() => T;
-  cursor: () => Promise<AsyncIterator<String>>;
-}
-
-export interface VideoProject {
-  id: ID_Output;
-  projectType: String;
-  projectTitle: String;
-  descPublic?: String;
-  descInternal?: String;
-  author?: String;
-  status?: ProjectPublishStatus;
-  visibility?: ProjectVisibility;
-}
-
-export interface VideoProjectPromise
-  extends Promise<VideoProject>,
-    Fragmentable {
-  id: () => Promise<ID_Output>;
-  projectType: () => Promise<String>;
-  projectTitle: () => Promise<String>;
-  descPublic: () => Promise<String>;
-  descInternal: () => Promise<String>;
-  author: () => Promise<String>;
-  team: <T = TeamPromise>() => T;
-  status: () => Promise<ProjectPublishStatus>;
-  visibility: () => Promise<ProjectVisibility>;
-  units: <T = FragmentableArray<VideoUnit>>(args?: {
-    where?: VideoUnitWhereInput;
-    orderBy?: VideoUnitOrderByInput;
-    skip?: Int;
-    after?: String;
-    before?: String;
-    first?: Int;
-    last?: Int;
-  }) => T;
-  supportFiles: <T = FragmentableArray<SupportFile>>(args?: {
-    where?: SupportFileWhereInput;
-    orderBy?: SupportFileOrderByInput;
-    skip?: Int;
-    after?: String;
-    before?: String;
-    first?: Int;
-    last?: Int;
-  }) => T;
-  thumbnails: <T = FragmentableArray<ImageFile>>(args?: {
-    where?: ImageFileWhereInput;
-    orderBy?: ImageFileOrderByInput;
-    skip?: Int;
-    after?: String;
-    before?: String;
-    first?: Int;
-    last?: Int;
-  }) => T;
-  categories: <T = FragmentableArray<Category>>(args?: {
-    where?: CategoryWhereInput;
-    orderBy?: CategoryOrderByInput;
-    skip?: Int;
-    after?: String;
-    before?: String;
-    first?: Int;
-    last?: Int;
-  }) => T;
-  tags: <T = FragmentableArray<Tag>>(args?: {
-    where?: TagWhereInput;
-    orderBy?: TagOrderByInput;
-    skip?: Int;
-    after?: String;
-    before?: String;
-    first?: Int;
-    last?: Int;
-  }) => T;
-}
-
-export interface VideoProjectSubscription
-  extends Promise<AsyncIterator<VideoProject>>,
-    Fragmentable {
-  id: () => Promise<AsyncIterator<ID_Output>>;
-  projectType: () => Promise<AsyncIterator<String>>;
-  projectTitle: () => Promise<AsyncIterator<String>>;
-  descPublic: () => Promise<AsyncIterator<String>>;
-  descInternal: () => Promise<AsyncIterator<String>>;
-  author: () => Promise<AsyncIterator<String>>;
-  team: <T = TeamSubscription>() => T;
-  status: () => Promise<AsyncIterator<ProjectPublishStatus>>;
-  visibility: () => Promise<AsyncIterator<ProjectVisibility>>;
-  units: <T = Promise<AsyncIterator<VideoUnitSubscription>>>(args?: {
-    where?: VideoUnitWhereInput;
-    orderBy?: VideoUnitOrderByInput;
-    skip?: Int;
-    after?: String;
-    before?: String;
-    first?: Int;
-    last?: Int;
-  }) => T;
-  supportFiles: <T = Promise<AsyncIterator<SupportFileSubscription>>>(args?: {
-    where?: SupportFileWhereInput;
-    orderBy?: SupportFileOrderByInput;
-    skip?: Int;
-    after?: String;
-    before?: String;
-    first?: Int;
-    last?: Int;
-  }) => T;
-  thumbnails: <T = Promise<AsyncIterator<ImageFileSubscription>>>(args?: {
-    where?: ImageFileWhereInput;
-    orderBy?: ImageFileOrderByInput;
-    skip?: Int;
-    after?: String;
-    before?: String;
-    first?: Int;
-    last?: Int;
-  }) => T;
-  categories: <T = Promise<AsyncIterator<CategorySubscription>>>(args?: {
-    where?: CategoryWhereInput;
-    orderBy?: CategoryOrderByInput;
-    skip?: Int;
-    after?: String;
-    before?: String;
-    first?: Int;
-    last?: Int;
-  }) => T;
-  tags: <T = Promise<AsyncIterator<TagSubscription>>>(args?: {
-    where?: TagWhereInput;
-    orderBy?: TagOrderByInput;
-    skip?: Int;
-    after?: String;
-    before?: String;
-    first?: Int;
-    last?: Int;
-  }) => T;
-}
-
-export interface TeamSubscriptionPayload {
-  mutation: MutationType;
-  node: Team;
-  updatedFields: String[];
-  previousValues: TeamPreviousValues;
-}
-
-export interface TeamSubscriptionPayloadPromise
-  extends Promise<TeamSubscriptionPayload>,
-    Fragmentable {
-  mutation: () => Promise<MutationType>;
-  node: <T = TeamPromise>() => T;
-  updatedFields: () => Promise<String[]>;
-  previousValues: <T = TeamPreviousValuesPromise>() => T;
-}
-
-export interface TeamSubscriptionPayloadSubscription
-  extends Promise<AsyncIterator<TeamSubscriptionPayload>>,
-    Fragmentable {
-  mutation: () => Promise<AsyncIterator<MutationType>>;
-  node: <T = TeamSubscription>() => T;
-  updatedFields: () => Promise<AsyncIterator<String[]>>;
-  previousValues: <T = TeamPreviousValuesSubscription>() => T;
-}
-
-export interface VideoStream {
-  id: ID_Output;
-  site?: String;
-  url?: String;
-  embedUrl?: String;
-}
-
-export interface VideoStreamPromise extends Promise<VideoStream>, Fragmentable {
-  id: () => Promise<ID_Output>;
-  site: () => Promise<String>;
-  url: () => Promise<String>;
-  embedUrl: () => Promise<String>;
-}
-
-export interface VideoStreamSubscription
-  extends Promise<AsyncIterator<VideoStream>>,
-    Fragmentable {
-  id: () => Promise<AsyncIterator<ID_Output>>;
-  site: () => Promise<AsyncIterator<String>>;
-  url: () => Promise<AsyncIterator<String>>;
-  embedUrl: () => Promise<AsyncIterator<String>>;
-}
-
-export interface TeamPreviousValues {
-  id: ID_Output;
-  name: String;
-  organization: String;
-  contentTypes: ContentType[];
-  isConfirmed: Boolean;
-}
-
-export interface TeamPreviousValuesPromise
-  extends Promise<TeamPreviousValues>,
-    Fragmentable {
-  id: () => Promise<ID_Output>;
-  name: () => Promise<String>;
-  organization: () => Promise<String>;
-  contentTypes: () => Promise<ContentType[]>;
-  isConfirmed: () => Promise<Boolean>;
-}
-
-export interface TeamPreviousValuesSubscription
-  extends Promise<AsyncIterator<TeamPreviousValues>>,
-    Fragmentable {
-  id: () => Promise<AsyncIterator<ID_Output>>;
-  name: () => Promise<AsyncIterator<String>>;
-  organization: () => Promise<AsyncIterator<String>>;
-  contentTypes: () => Promise<AsyncIterator<ContentType[]>>;
-  isConfirmed: () => Promise<AsyncIterator<Boolean>>;
-}
-
-export interface VideoFile {
-  id: ID_Output;
-  filetype?: String;
-  filename?: String;
-  quality?: VideoQuality;
-  videoBurnedInStatus?: VideoBurnedInStatus;
-  url?: String;
-  md5?: String;
-  duration?: Float;
-  bitrate?: Float;
-  filesize?: Float;
-}
-
-export interface VideoFilePromise extends Promise<VideoFile>, Fragmentable {
-  id: () => Promise<ID_Output>;
-  language: <T = LanguagePromise>() => T;
-  filetype: () => Promise<String>;
-  filename: () => Promise<String>;
-  use: <T = VideoUsePromise>() => T;
-  quality: () => Promise<VideoQuality>;
-  videoBurnedInStatus: () => Promise<VideoBurnedInStatus>;
-  url: () => Promise<String>;
-  md5: () => Promise<String>;
-  duration: () => Promise<Float>;
-  bitrate: () => Promise<Float>;
-  filesize: () => Promise<Float>;
-  dimensions: <T = DimensionsPromise>() => T;
-  stream: <T = VideoStreamPromise>() => T;
-}
-
-export interface VideoFileSubscription
-  extends Promise<AsyncIterator<VideoFile>>,
-    Fragmentable {
-  id: () => Promise<AsyncIterator<ID_Output>>;
-  language: <T = LanguageSubscription>() => T;
-  filetype: () => Promise<AsyncIterator<String>>;
-  filename: () => Promise<AsyncIterator<String>>;
-  use: <T = VideoUseSubscription>() => T;
-  quality: () => Promise<AsyncIterator<VideoQuality>>;
-  videoBurnedInStatus: () => Promise<AsyncIterator<VideoBurnedInStatus>>;
-  url: () => Promise<AsyncIterator<String>>;
-  md5: () => Promise<AsyncIterator<String>>;
-  duration: () => Promise<AsyncIterator<Float>>;
-  bitrate: () => Promise<AsyncIterator<Float>>;
-  filesize: () => Promise<AsyncIterator<Float>>;
-  dimensions: <T = DimensionsSubscription>() => T;
-  stream: <T = VideoStreamSubscription>() => T;
-}
-
-export interface LanguageConnection {
+export interface DimensionsConnection {
   pageInfo: PageInfo;
-  edges: LanguageEdge[];
+  edges: DimensionsEdge[];
 }
 
-export interface LanguageConnectionPromise
-  extends Promise<LanguageConnection>,
+export interface DimensionsConnectionPromise
+  extends Promise<DimensionsConnection>,
     Fragmentable {
   pageInfo: <T = PageInfoPromise>() => T;
-  edges: <T = FragmentableArray<LanguageEdge>>() => T;
-  aggregate: <T = AggregateLanguagePromise>() => T;
+  edges: <T = FragmentableArray<DimensionsEdge>>() => T;
+  aggregate: <T = AggregateDimensionsPromise>() => T;
 }
 
-export interface LanguageConnectionSubscription
-  extends Promise<AsyncIterator<LanguageConnection>>,
+export interface DimensionsConnectionSubscription
+  extends Promise<AsyncIterator<DimensionsConnection>>,
     Fragmentable {
   pageInfo: <T = PageInfoSubscription>() => T;
-  edges: <T = Promise<AsyncIterator<LanguageEdgeSubscription>>>() => T;
-  aggregate: <T = AggregateLanguageSubscription>() => T;
-}
-
-export interface AggregateThumbnail {
-  count: Int;
-}
-
-export interface AggregateThumbnailPromise
-  extends Promise<AggregateThumbnail>,
-    Fragmentable {
-  count: () => Promise<Int>;
-}
-
-export interface AggregateThumbnailSubscription
-  extends Promise<AsyncIterator<AggregateThumbnail>>,
-    Fragmentable {
-  count: () => Promise<AsyncIterator<Int>>;
-}
-
-export interface ThumbnailSubscriptionPayload {
-  mutation: MutationType;
-  node: Thumbnail;
-  updatedFields: String[];
-  previousValues: ThumbnailPreviousValues;
-}
-
-export interface ThumbnailSubscriptionPayloadPromise
-  extends Promise<ThumbnailSubscriptionPayload>,
-    Fragmentable {
-  mutation: () => Promise<MutationType>;
-  node: <T = ThumbnailPromise>() => T;
-  updatedFields: () => Promise<String[]>;
-  previousValues: <T = ThumbnailPreviousValuesPromise>() => T;
-}
-
-export interface ThumbnailSubscriptionPayloadSubscription
-  extends Promise<AsyncIterator<ThumbnailSubscriptionPayload>>,
-    Fragmentable {
-  mutation: () => Promise<AsyncIterator<MutationType>>;
-  node: <T = ThumbnailSubscription>() => T;
-  updatedFields: () => Promise<AsyncIterator<String[]>>;
-  previousValues: <T = ThumbnailPreviousValuesSubscription>() => T;
-}
-
-export interface CategoryEdge {
-  node: Category;
-  cursor: String;
-}
-
-export interface CategoryEdgePromise
-  extends Promise<CategoryEdge>,
-    Fragmentable {
-  node: <T = CategoryPromise>() => T;
-  cursor: () => Promise<String>;
-}
-
-export interface CategoryEdgeSubscription
-  extends Promise<AsyncIterator<CategoryEdge>>,
-    Fragmentable {
-  node: <T = CategorySubscription>() => T;
-  cursor: () => Promise<AsyncIterator<String>>;
-}
-
-export interface ThumbnailPreviousValues {
-  id: ID_Output;
-  size?: ThumbnailSize;
-}
-
-export interface ThumbnailPreviousValuesPromise
-  extends Promise<ThumbnailPreviousValues>,
-    Fragmentable {
-  id: () => Promise<ID_Output>;
-  size: () => Promise<ThumbnailSize>;
-}
-
-export interface ThumbnailPreviousValuesSubscription
-  extends Promise<AsyncIterator<ThumbnailPreviousValues>>,
-    Fragmentable {
-  id: () => Promise<AsyncIterator<ID_Output>>;
-  size: () => Promise<AsyncIterator<ThumbnailSize>>;
+  edges: <T = Promise<AsyncIterator<DimensionsEdgeSubscription>>>() => T;
+  aggregate: <T = AggregateDimensionsSubscription>() => T;
 }
 
 export interface TeamConnection {
@@ -5770,615 +6540,15 @@ export interface TeamConnectionSubscription
   aggregate: <T = AggregateTeamSubscription>() => T;
 }
 
-export interface AggregateDimensions {
-  count: Int;
-}
-
-export interface AggregateDimensionsPromise
-  extends Promise<AggregateDimensions>,
-    Fragmentable {
-  count: () => Promise<Int>;
-}
-
-export interface AggregateDimensionsSubscription
-  extends Promise<AsyncIterator<AggregateDimensions>>,
-    Fragmentable {
-  count: () => Promise<AsyncIterator<Int>>;
-}
-
-export interface Team {
-  id: ID_Output;
-  name: String;
-  organization: String;
-  contentTypes: ContentType[];
-  isConfirmed: Boolean;
-}
-
-export interface TeamPromise extends Promise<Team>, Fragmentable {
-  id: () => Promise<ID_Output>;
-  name: () => Promise<String>;
-  organization: () => Promise<String>;
-  members: <T = FragmentableArray<User>>(args?: {
-    where?: UserWhereInput;
-    orderBy?: UserOrderByInput;
-    skip?: Int;
-    after?: String;
-    before?: String;
-    first?: Int;
-    last?: Int;
-  }) => T;
-  contentTypes: () => Promise<ContentType[]>;
-  isConfirmed: () => Promise<Boolean>;
-}
-
-export interface TeamSubscription
-  extends Promise<AsyncIterator<Team>>,
-    Fragmentable {
-  id: () => Promise<AsyncIterator<ID_Output>>;
-  name: () => Promise<AsyncIterator<String>>;
-  organization: () => Promise<AsyncIterator<String>>;
-  members: <T = Promise<AsyncIterator<UserSubscription>>>(args?: {
-    where?: UserWhereInput;
-    orderBy?: UserOrderByInput;
-    skip?: Int;
-    after?: String;
-    before?: String;
-    first?: Int;
-    last?: Int;
-  }) => T;
-  contentTypes: () => Promise<AsyncIterator<ContentType[]>>;
-  isConfirmed: () => Promise<AsyncIterator<Boolean>>;
-}
-
-export interface UserSubscriptionPayload {
-  mutation: MutationType;
-  node: User;
-  updatedFields: String[];
-  previousValues: UserPreviousValues;
-}
-
-export interface UserSubscriptionPayloadPromise
-  extends Promise<UserSubscriptionPayload>,
-    Fragmentable {
-  mutation: () => Promise<MutationType>;
-  node: <T = UserPromise>() => T;
-  updatedFields: () => Promise<String[]>;
-  previousValues: <T = UserPreviousValuesPromise>() => T;
-}
-
-export interface UserSubscriptionPayloadSubscription
-  extends Promise<AsyncIterator<UserSubscriptionPayload>>,
-    Fragmentable {
-  mutation: () => Promise<AsyncIterator<MutationType>>;
-  node: <T = UserSubscription>() => T;
-  updatedFields: () => Promise<AsyncIterator<String[]>>;
-  previousValues: <T = UserPreviousValuesSubscription>() => T;
-}
-
-export interface DimensionsConnection {
-  pageInfo: PageInfo;
-  edges: DimensionsEdge[];
-}
-
-export interface DimensionsConnectionPromise
-  extends Promise<DimensionsConnection>,
-    Fragmentable {
-  pageInfo: <T = PageInfoPromise>() => T;
-  edges: <T = FragmentableArray<DimensionsEdge>>() => T;
-  aggregate: <T = AggregateDimensionsPromise>() => T;
-}
-
-export interface DimensionsConnectionSubscription
-  extends Promise<AsyncIterator<DimensionsConnection>>,
-    Fragmentable {
-  pageInfo: <T = PageInfoSubscription>() => T;
-  edges: <T = Promise<AsyncIterator<DimensionsEdgeSubscription>>>() => T;
-  aggregate: <T = AggregateDimensionsSubscription>() => T;
-}
-
-export interface UserPreviousValues {
-  id: ID_Output;
-  firstName: String;
-  lastName: String;
-  email: String;
-  password?: String;
-  tempToken?: String;
-  tempTokenExpiry?: Float;
-  jobTitle?: String;
-  country?: String;
-  city?: String;
-  howHeard?: String;
-  permissions: Permission[];
-  isConfirmed: Boolean;
-}
-
-export interface UserPreviousValuesPromise
-  extends Promise<UserPreviousValues>,
-    Fragmentable {
-  id: () => Promise<ID_Output>;
-  firstName: () => Promise<String>;
-  lastName: () => Promise<String>;
-  email: () => Promise<String>;
-  password: () => Promise<String>;
-  tempToken: () => Promise<String>;
-  tempTokenExpiry: () => Promise<Float>;
-  jobTitle: () => Promise<String>;
-  country: () => Promise<String>;
-  city: () => Promise<String>;
-  howHeard: () => Promise<String>;
-  permissions: () => Promise<Permission[]>;
-  isConfirmed: () => Promise<Boolean>;
-}
-
-export interface UserPreviousValuesSubscription
-  extends Promise<AsyncIterator<UserPreviousValues>>,
-    Fragmentable {
-  id: () => Promise<AsyncIterator<ID_Output>>;
-  firstName: () => Promise<AsyncIterator<String>>;
-  lastName: () => Promise<AsyncIterator<String>>;
-  email: () => Promise<AsyncIterator<String>>;
-  password: () => Promise<AsyncIterator<String>>;
-  tempToken: () => Promise<AsyncIterator<String>>;
-  tempTokenExpiry: () => Promise<AsyncIterator<Float>>;
-  jobTitle: () => Promise<AsyncIterator<String>>;
-  country: () => Promise<AsyncIterator<String>>;
-  city: () => Promise<AsyncIterator<String>>;
-  howHeard: () => Promise<AsyncIterator<String>>;
-  permissions: () => Promise<AsyncIterator<Permission[]>>;
-  isConfirmed: () => Promise<AsyncIterator<Boolean>>;
-}
-
-export interface VideoUseConnection {
-  pageInfo: PageInfo;
-  edges: VideoUseEdge[];
-}
-
-export interface VideoUseConnectionPromise
-  extends Promise<VideoUseConnection>,
-    Fragmentable {
-  pageInfo: <T = PageInfoPromise>() => T;
-  edges: <T = FragmentableArray<VideoUseEdge>>() => T;
-  aggregate: <T = AggregateVideoUsePromise>() => T;
-}
-
-export interface VideoUseConnectionSubscription
-  extends Promise<AsyncIterator<VideoUseConnection>>,
-    Fragmentable {
-  pageInfo: <T = PageInfoSubscription>() => T;
-  edges: <T = Promise<AsyncIterator<VideoUseEdgeSubscription>>>() => T;
-  aggregate: <T = AggregateVideoUseSubscription>() => T;
-}
-
-export interface AggregateImageUse {
-  count: Int;
-}
-
-export interface AggregateImageUsePromise
-  extends Promise<AggregateImageUse>,
-    Fragmentable {
-  count: () => Promise<Int>;
-}
-
-export interface AggregateImageUseSubscription
-  extends Promise<AsyncIterator<AggregateImageUse>>,
-    Fragmentable {
-  count: () => Promise<AsyncIterator<Int>>;
-}
-
-export interface LanguageTranslation {
-  id: ID_Output;
-  name: String;
-}
-
-export interface LanguageTranslationPromise
-  extends Promise<LanguageTranslation>,
-    Fragmentable {
-  id: () => Promise<ID_Output>;
-  name: () => Promise<String>;
-  language: <T = LanguagePromise>() => T;
-}
-
-export interface LanguageTranslationSubscription
-  extends Promise<AsyncIterator<LanguageTranslation>>,
-    Fragmentable {
-  id: () => Promise<AsyncIterator<ID_Output>>;
-  name: () => Promise<AsyncIterator<String>>;
-  language: <T = LanguageSubscription>() => T;
-}
-
-export interface VideoFileSubscriptionPayload {
-  mutation: MutationType;
-  node: VideoFile;
-  updatedFields: String[];
-  previousValues: VideoFilePreviousValues;
-}
-
-export interface VideoFileSubscriptionPayloadPromise
-  extends Promise<VideoFileSubscriptionPayload>,
-    Fragmentable {
-  mutation: () => Promise<MutationType>;
-  node: <T = VideoFilePromise>() => T;
-  updatedFields: () => Promise<String[]>;
-  previousValues: <T = VideoFilePreviousValuesPromise>() => T;
-}
-
-export interface VideoFileSubscriptionPayloadSubscription
-  extends Promise<AsyncIterator<VideoFileSubscriptionPayload>>,
-    Fragmentable {
-  mutation: () => Promise<AsyncIterator<MutationType>>;
-  node: <T = VideoFileSubscription>() => T;
-  updatedFields: () => Promise<AsyncIterator<String[]>>;
-  previousValues: <T = VideoFilePreviousValuesSubscription>() => T;
-}
-
-export interface PageInfo {
-  hasNextPage: Boolean;
-  hasPreviousPage: Boolean;
-  startCursor?: String;
-  endCursor?: String;
-}
-
-export interface PageInfoPromise extends Promise<PageInfo>, Fragmentable {
-  hasNextPage: () => Promise<Boolean>;
-  hasPreviousPage: () => Promise<Boolean>;
-  startCursor: () => Promise<String>;
-  endCursor: () => Promise<String>;
-}
-
-export interface PageInfoSubscription
-  extends Promise<AsyncIterator<PageInfo>>,
-    Fragmentable {
-  hasNextPage: () => Promise<AsyncIterator<Boolean>>;
-  hasPreviousPage: () => Promise<AsyncIterator<Boolean>>;
-  startCursor: () => Promise<AsyncIterator<String>>;
-  endCursor: () => Promise<AsyncIterator<String>>;
-}
-
-export interface VideoFilePreviousValues {
-  id: ID_Output;
-  filetype?: String;
-  filename?: String;
-  quality?: VideoQuality;
-  videoBurnedInStatus?: VideoBurnedInStatus;
-  url?: String;
-  md5?: String;
-  duration?: Float;
-  bitrate?: Float;
-  filesize?: Float;
-}
-
-export interface VideoFilePreviousValuesPromise
-  extends Promise<VideoFilePreviousValues>,
-    Fragmentable {
-  id: () => Promise<ID_Output>;
-  filetype: () => Promise<String>;
-  filename: () => Promise<String>;
-  quality: () => Promise<VideoQuality>;
-  videoBurnedInStatus: () => Promise<VideoBurnedInStatus>;
-  url: () => Promise<String>;
-  md5: () => Promise<String>;
-  duration: () => Promise<Float>;
-  bitrate: () => Promise<Float>;
-  filesize: () => Promise<Float>;
-}
-
-export interface VideoFilePreviousValuesSubscription
-  extends Promise<AsyncIterator<VideoFilePreviousValues>>,
-    Fragmentable {
-  id: () => Promise<AsyncIterator<ID_Output>>;
-  filetype: () => Promise<AsyncIterator<String>>;
-  filename: () => Promise<AsyncIterator<String>>;
-  quality: () => Promise<AsyncIterator<VideoQuality>>;
-  videoBurnedInStatus: () => Promise<AsyncIterator<VideoBurnedInStatus>>;
-  url: () => Promise<AsyncIterator<String>>;
-  md5: () => Promise<AsyncIterator<String>>;
-  duration: () => Promise<AsyncIterator<Float>>;
-  bitrate: () => Promise<AsyncIterator<Float>>;
-  filesize: () => Promise<AsyncIterator<Float>>;
-}
-
-export interface ThumbnailConnection {
-  pageInfo: PageInfo;
-  edges: ThumbnailEdge[];
-}
-
-export interface ThumbnailConnectionPromise
-  extends Promise<ThumbnailConnection>,
-    Fragmentable {
-  pageInfo: <T = PageInfoPromise>() => T;
-  edges: <T = FragmentableArray<ThumbnailEdge>>() => T;
-  aggregate: <T = AggregateThumbnailPromise>() => T;
-}
-
-export interface ThumbnailConnectionSubscription
-  extends Promise<AsyncIterator<ThumbnailConnection>>,
-    Fragmentable {
-  pageInfo: <T = PageInfoSubscription>() => T;
-  edges: <T = Promise<AsyncIterator<ThumbnailEdgeSubscription>>>() => T;
-  aggregate: <T = AggregateThumbnailSubscription>() => T;
-}
-
-export interface ImageUseEdge {
-  node: ImageUse;
-  cursor: String;
-}
-
-export interface ImageUseEdgePromise
-  extends Promise<ImageUseEdge>,
-    Fragmentable {
-  node: <T = ImageUsePromise>() => T;
-  cursor: () => Promise<String>;
-}
-
-export interface ImageUseEdgeSubscription
-  extends Promise<AsyncIterator<ImageUseEdge>>,
-    Fragmentable {
-  node: <T = ImageUseSubscription>() => T;
-  cursor: () => Promise<AsyncIterator<String>>;
-}
-
-export interface Dimensions {
-  id: ID_Output;
-  width?: Int;
-  height?: Int;
-}
-
-export interface DimensionsPromise extends Promise<Dimensions>, Fragmentable {
-  id: () => Promise<ID_Output>;
-  width: () => Promise<Int>;
-  height: () => Promise<Int>;
-}
-
-export interface DimensionsSubscription
-  extends Promise<AsyncIterator<Dimensions>>,
-    Fragmentable {
-  id: () => Promise<AsyncIterator<ID_Output>>;
-  width: () => Promise<AsyncIterator<Int>>;
-  height: () => Promise<AsyncIterator<Int>>;
-}
-
-export interface VideoProjectSubscriptionPayload {
-  mutation: MutationType;
-  node: VideoProject;
-  updatedFields: String[];
-  previousValues: VideoProjectPreviousValues;
-}
-
-export interface VideoProjectSubscriptionPayloadPromise
-  extends Promise<VideoProjectSubscriptionPayload>,
-    Fragmentable {
-  mutation: () => Promise<MutationType>;
-  node: <T = VideoProjectPromise>() => T;
-  updatedFields: () => Promise<String[]>;
-  previousValues: <T = VideoProjectPreviousValuesPromise>() => T;
-}
-
-export interface VideoProjectSubscriptionPayloadSubscription
-  extends Promise<AsyncIterator<VideoProjectSubscriptionPayload>>,
-    Fragmentable {
-  mutation: () => Promise<AsyncIterator<MutationType>>;
-  node: <T = VideoProjectSubscription>() => T;
-  updatedFields: () => Promise<AsyncIterator<String[]>>;
-  previousValues: <T = VideoProjectPreviousValuesSubscription>() => T;
-}
-
-export interface VideoUnitPreviousValues {
-  id: ID_Output;
-  title: String;
-  descPublic?: String;
-}
-
-export interface VideoUnitPreviousValuesPromise
-  extends Promise<VideoUnitPreviousValues>,
-    Fragmentable {
-  id: () => Promise<ID_Output>;
-  title: () => Promise<String>;
-  descPublic: () => Promise<String>;
-}
-
-export interface VideoUnitPreviousValuesSubscription
-  extends Promise<AsyncIterator<VideoUnitPreviousValues>>,
-    Fragmentable {
-  id: () => Promise<AsyncIterator<ID_Output>>;
-  title: () => Promise<AsyncIterator<String>>;
-  descPublic: () => Promise<AsyncIterator<String>>;
-}
-
-export interface VideoFileEdge {
-  node: VideoFile;
-  cursor: String;
-}
-
-export interface VideoFileEdgePromise
-  extends Promise<VideoFileEdge>,
-    Fragmentable {
-  node: <T = VideoFilePromise>() => T;
-  cursor: () => Promise<String>;
-}
-
-export interface VideoFileEdgeSubscription
-  extends Promise<AsyncIterator<VideoFileEdge>>,
-    Fragmentable {
-  node: <T = VideoFileSubscription>() => T;
-  cursor: () => Promise<AsyncIterator<String>>;
-}
-
-export interface VideoStreamPreviousValues {
-  id: ID_Output;
-  site?: String;
-  url?: String;
-  embedUrl?: String;
-}
-
-export interface VideoStreamPreviousValuesPromise
-  extends Promise<VideoStreamPreviousValues>,
-    Fragmentable {
-  id: () => Promise<ID_Output>;
-  site: () => Promise<String>;
-  url: () => Promise<String>;
-  embedUrl: () => Promise<String>;
-}
-
-export interface VideoStreamPreviousValuesSubscription
-  extends Promise<AsyncIterator<VideoStreamPreviousValues>>,
-    Fragmentable {
-  id: () => Promise<AsyncIterator<ID_Output>>;
-  site: () => Promise<AsyncIterator<String>>;
-  url: () => Promise<AsyncIterator<String>>;
-  embedUrl: () => Promise<AsyncIterator<String>>;
-}
-
-export interface VideoStreamSubscriptionPayload {
-  mutation: MutationType;
-  node: VideoStream;
-  updatedFields: String[];
-  previousValues: VideoStreamPreviousValues;
-}
-
-export interface VideoStreamSubscriptionPayloadPromise
-  extends Promise<VideoStreamSubscriptionPayload>,
-    Fragmentable {
-  mutation: () => Promise<MutationType>;
-  node: <T = VideoStreamPromise>() => T;
-  updatedFields: () => Promise<String[]>;
-  previousValues: <T = VideoStreamPreviousValuesPromise>() => T;
-}
-
-export interface VideoStreamSubscriptionPayloadSubscription
-  extends Promise<AsyncIterator<VideoStreamSubscriptionPayload>>,
-    Fragmentable {
-  mutation: () => Promise<AsyncIterator<MutationType>>;
-  node: <T = VideoStreamSubscription>() => T;
-  updatedFields: () => Promise<AsyncIterator<String[]>>;
-  previousValues: <T = VideoStreamPreviousValuesSubscription>() => T;
-}
-
-export interface ImageUseConnection {
-  pageInfo: PageInfo;
-  edges: ImageUseEdge[];
-}
-
-export interface ImageUseConnectionPromise
-  extends Promise<ImageUseConnection>,
-    Fragmentable {
-  pageInfo: <T = PageInfoPromise>() => T;
-  edges: <T = FragmentableArray<ImageUseEdge>>() => T;
-  aggregate: <T = AggregateImageUsePromise>() => T;
-}
-
-export interface ImageUseConnectionSubscription
-  extends Promise<AsyncIterator<ImageUseConnection>>,
-    Fragmentable {
-  pageInfo: <T = PageInfoSubscription>() => T;
-  edges: <T = Promise<AsyncIterator<ImageUseEdgeSubscription>>>() => T;
-  aggregate: <T = AggregateImageUseSubscription>() => T;
-}
-
-export interface VideoProjectPreviousValues {
-  id: ID_Output;
-  projectType: String;
-  projectTitle: String;
-  descPublic?: String;
-  descInternal?: String;
-  author?: String;
-  status?: ProjectPublishStatus;
-  visibility?: ProjectVisibility;
-}
-
-export interface VideoProjectPreviousValuesPromise
-  extends Promise<VideoProjectPreviousValues>,
-    Fragmentable {
-  id: () => Promise<ID_Output>;
-  projectType: () => Promise<String>;
-  projectTitle: () => Promise<String>;
-  descPublic: () => Promise<String>;
-  descInternal: () => Promise<String>;
-  author: () => Promise<String>;
-  status: () => Promise<ProjectPublishStatus>;
-  visibility: () => Promise<ProjectVisibility>;
-}
-
-export interface VideoProjectPreviousValuesSubscription
-  extends Promise<AsyncIterator<VideoProjectPreviousValues>>,
-    Fragmentable {
-  id: () => Promise<AsyncIterator<ID_Output>>;
-  projectType: () => Promise<AsyncIterator<String>>;
-  projectTitle: () => Promise<AsyncIterator<String>>;
-  descPublic: () => Promise<AsyncIterator<String>>;
-  descInternal: () => Promise<AsyncIterator<String>>;
-  author: () => Promise<AsyncIterator<String>>;
-  status: () => Promise<AsyncIterator<ProjectPublishStatus>>;
-  visibility: () => Promise<AsyncIterator<ProjectVisibility>>;
-}
-
-export interface UserEdge {
-  node: User;
-  cursor: String;
-}
-
-export interface UserEdgePromise extends Promise<UserEdge>, Fragmentable {
-  node: <T = UserPromise>() => T;
-  cursor: () => Promise<String>;
-}
-
-export interface UserEdgeSubscription
-  extends Promise<AsyncIterator<UserEdge>>,
-    Fragmentable {
-  node: <T = UserSubscription>() => T;
-  cursor: () => Promise<AsyncIterator<String>>;
-}
-
-export interface VideoProjectEdge {
-  node: VideoProject;
-  cursor: String;
-}
-
-export interface VideoProjectEdgePromise
-  extends Promise<VideoProjectEdge>,
-    Fragmentable {
-  node: <T = VideoProjectPromise>() => T;
-  cursor: () => Promise<String>;
-}
-
-export interface VideoProjectEdgeSubscription
-  extends Promise<AsyncIterator<VideoProjectEdge>>,
-    Fragmentable {
-  node: <T = VideoProjectSubscription>() => T;
-  cursor: () => Promise<AsyncIterator<String>>;
-}
-
-export interface TagEdge {
-  node: Tag;
-  cursor: String;
-}
-
-export interface TagEdgePromise extends Promise<TagEdge>, Fragmentable {
-  node: <T = TagPromise>() => T;
-  cursor: () => Promise<String>;
-}
-
-export interface TagEdgeSubscription
-  extends Promise<AsyncIterator<TagEdge>>,
-    Fragmentable {
-  node: <T = TagSubscription>() => T;
-  cursor: () => Promise<AsyncIterator<String>>;
-}
-
-export interface AggregateTeam {
-  count: Int;
-}
-
-export interface AggregateTeamPromise
-  extends Promise<AggregateTeam>,
-    Fragmentable {
-  count: () => Promise<Int>;
-}
-
-export interface AggregateTeamSubscription
-  extends Promise<AsyncIterator<AggregateTeam>>,
-    Fragmentable {
-  count: () => Promise<AsyncIterator<Int>>;
-}
+/*
+DateTime scalar input type, allowing Date
+*/
+export type DateTimeInput = Date | string;
+
+/*
+DateTime scalar output type, which is always a string
+*/
+export type DateTimeOutput = string;
 
 /*
 The `ID` scalar type represents a unique identifier, often used to refetch an object or as key for a cache. The ID type appears in a JSON response as a String; however, it is not intended to be human-readable. When expected as an input type, any string (such as `"4"`) or integer (such as `4`) input value will be accepted as an ID.

--- a/src/schema/generated/prisma-client/index.d.ts
+++ b/src/schema/generated/prisma-client/index.d.ts
@@ -760,7 +760,9 @@ export type VideoProjectOrderByInput =
   | "status_ASC"
   | "status_DESC"
   | "visibility_ASC"
-  | "visibility_DESC";
+  | "visibility_DESC"
+  | "protectImages_ASC"
+  | "protectImages_DESC";
 
 export type TeamOrderByInput =
   | "id_ASC"
@@ -1393,6 +1395,7 @@ export interface VideoProjectUpdateManyMutationInput {
   author?: String;
   status?: ProjectPublishStatus;
   visibility?: ProjectVisibility;
+  protectImages?: Boolean;
 }
 
 export interface LanguageTranslationUpdateManyWithWhereNestedInput {
@@ -2171,6 +2174,7 @@ export interface VideoProjectUpdateInput {
   team?: TeamUpdateOneInput;
   status?: ProjectPublishStatus;
   visibility?: ProjectVisibility;
+  protectImages?: Boolean;
   units?: VideoUnitUpdateManyInput;
   supportFiles?: SupportFileUpdateManyInput;
   thumbnails?: ImageFileUpdateManyInput;
@@ -2303,6 +2307,8 @@ export interface VideoProjectWhereInput {
   visibility_not?: ProjectVisibility;
   visibility_in?: ProjectVisibility[] | ProjectVisibility;
   visibility_not_in?: ProjectVisibility[] | ProjectVisibility;
+  protectImages?: Boolean;
+  protectImages_not?: Boolean;
   units_every?: VideoUnitWhereInput;
   units_some?: VideoUnitWhereInput;
   units_none?: VideoUnitWhereInput;
@@ -3850,6 +3856,7 @@ export interface VideoProjectCreateInput {
   team?: TeamCreateOneInput;
   status?: ProjectPublishStatus;
   visibility?: ProjectVisibility;
+  protectImages?: Boolean;
   units?: VideoUnitCreateManyInput;
   supportFiles?: SupportFileCreateManyInput;
   thumbnails?: ImageFileCreateManyInput;
@@ -5883,6 +5890,7 @@ export interface VideoProject {
   author?: String;
   status?: ProjectPublishStatus;
   visibility?: ProjectVisibility;
+  protectImages?: Boolean;
 }
 
 export interface VideoProjectPromise
@@ -5899,6 +5907,7 @@ export interface VideoProjectPromise
   team: <T = TeamPromise>() => T;
   status: () => Promise<ProjectPublishStatus>;
   visibility: () => Promise<ProjectVisibility>;
+  protectImages: () => Promise<Boolean>;
   units: <T = FragmentableArray<VideoUnit>>(args?: {
     where?: VideoUnitWhereInput;
     orderBy?: VideoUnitOrderByInput;
@@ -5960,6 +5969,7 @@ export interface VideoProjectSubscription
   team: <T = TeamSubscription>() => T;
   status: () => Promise<AsyncIterator<ProjectPublishStatus>>;
   visibility: () => Promise<AsyncIterator<ProjectVisibility>>;
+  protectImages: () => Promise<AsyncIterator<Boolean>>;
   units: <T = Promise<AsyncIterator<VideoUnitSubscription>>>(args?: {
     where?: VideoUnitWhereInput;
     orderBy?: VideoUnitOrderByInput;
@@ -6331,6 +6341,7 @@ export interface VideoProjectPreviousValues {
   author?: String;
   status?: ProjectPublishStatus;
   visibility?: ProjectVisibility;
+  protectImages?: Boolean;
 }
 
 export interface VideoProjectPreviousValuesPromise
@@ -6346,6 +6357,7 @@ export interface VideoProjectPreviousValuesPromise
   author: () => Promise<String>;
   status: () => Promise<ProjectPublishStatus>;
   visibility: () => Promise<ProjectVisibility>;
+  protectImages: () => Promise<Boolean>;
 }
 
 export interface VideoProjectPreviousValuesSubscription
@@ -6361,6 +6373,7 @@ export interface VideoProjectPreviousValuesSubscription
   author: () => Promise<AsyncIterator<String>>;
   status: () => Promise<AsyncIterator<ProjectPublishStatus>>;
   visibility: () => Promise<AsyncIterator<ProjectVisibility>>;
+  protectImages: () => Promise<AsyncIterator<Boolean>>;
 }
 
 export interface VideoProjectSubscriptionPayload {

--- a/src/schema/generated/prisma-client/index.d.ts
+++ b/src/schema/generated/prisma-client/index.d.ts
@@ -23,6 +23,7 @@ export interface Exists {
     where?: LanguageTranslationWhereInput
   ) => Promise<boolean>;
   supportFile: (where?: SupportFileWhereInput) => Promise<boolean>;
+  supportFileUse: (where?: SupportFileUseWhereInput) => Promise<boolean>;
   tag: (where?: TagWhereInput) => Promise<boolean>;
   team: (where?: TeamWhereInput) => Promise<boolean>;
   thumbnail: (where?: ThumbnailWhereInput) => Promise<boolean>;
@@ -188,6 +189,27 @@ export interface Prisma {
     first?: Int;
     last?: Int;
   }) => SupportFileConnectionPromise;
+  supportFileUse: (
+    where: SupportFileUseWhereUniqueInput
+  ) => SupportFileUsePromise;
+  supportFileUses: (args?: {
+    where?: SupportFileUseWhereInput;
+    orderBy?: SupportFileUseOrderByInput;
+    skip?: Int;
+    after?: String;
+    before?: String;
+    first?: Int;
+    last?: Int;
+  }) => FragmentableArray<SupportFileUse>;
+  supportFileUsesConnection: (args?: {
+    where?: SupportFileUseWhereInput;
+    orderBy?: SupportFileUseOrderByInput;
+    skip?: Int;
+    after?: String;
+    before?: String;
+    first?: Int;
+    last?: Int;
+  }) => SupportFileUseConnectionPromise;
   tag: (where: TagWhereUniqueInput) => TagPromise;
   tags: (args?: {
     where?: TagWhereInput;
@@ -481,6 +503,28 @@ export interface Prisma {
   deleteManySupportFiles: (
     where?: SupportFileWhereInput
   ) => BatchPayloadPromise;
+  createSupportFileUse: (
+    data: SupportFileUseCreateInput
+  ) => SupportFileUsePromise;
+  updateSupportFileUse: (args: {
+    data: SupportFileUseUpdateInput;
+    where: SupportFileUseWhereUniqueInput;
+  }) => SupportFileUsePromise;
+  updateManySupportFileUses: (args: {
+    data: SupportFileUseUpdateManyMutationInput;
+    where?: SupportFileUseWhereInput;
+  }) => BatchPayloadPromise;
+  upsertSupportFileUse: (args: {
+    where: SupportFileUseWhereUniqueInput;
+    create: SupportFileUseCreateInput;
+    update: SupportFileUseUpdateInput;
+  }) => SupportFileUsePromise;
+  deleteSupportFileUse: (
+    where: SupportFileUseWhereUniqueInput
+  ) => SupportFileUsePromise;
+  deleteManySupportFileUses: (
+    where?: SupportFileUseWhereInput
+  ) => BatchPayloadPromise;
   createTag: (data: TagCreateInput) => TagPromise;
   updateTag: (args: {
     data: TagUpdateInput;
@@ -657,6 +701,9 @@ export interface Subscription {
   supportFile: (
     where?: SupportFileSubscriptionWhereInput
   ) => SupportFileSubscriptionPayloadSubscription;
+  supportFileUse: (
+    where?: SupportFileUseSubscriptionWhereInput
+  ) => SupportFileUseSubscriptionPayloadSubscription;
   tag: (
     where?: TagSubscriptionWhereInput
   ) => TagSubscriptionPayloadSubscription;
@@ -694,7 +741,15 @@ export interface ClientConstructor<T> {
  * Types
  */
 
-export type VideoQuality = "WEB" | "BROADCAST";
+export type ThumbnailOrderByInput =
+  | "id_ASC"
+  | "id_DESC"
+  | "size_ASC"
+  | "size_DESC"
+  | "createdAt_ASC"
+  | "createdAt_DESC"
+  | "updatedAt_ASC"
+  | "updatedAt_DESC";
 
 export type ImageFileOrderByInput =
   | "id_ASC"
@@ -718,15 +773,7 @@ export type ImageFileOrderByInput =
   | "url_ASC"
   | "url_DESC";
 
-export type ThumbnailOrderByInput =
-  | "id_ASC"
-  | "id_DESC"
-  | "size_ASC"
-  | "size_DESC"
-  | "createdAt_ASC"
-  | "createdAt_DESC"
-  | "updatedAt_ASC"
-  | "updatedAt_DESC";
+export type ThumbnailSize = "SMALL" | "MEDIUM" | "LARGE" | "FULL";
 
 export type VideoUseOrderByInput =
   | "id_ASC"
@@ -737,32 +784,6 @@ export type VideoUseOrderByInput =
   | "createdAt_DESC"
   | "updatedAt_ASC"
   | "updatedAt_DESC";
-
-export type ThumbnailSize = "SMALL" | "MEDIUM" | "LARGE" | "FULL";
-
-export type VideoProjectOrderByInput =
-  | "id_ASC"
-  | "id_DESC"
-  | "createdAt_ASC"
-  | "createdAt_DESC"
-  | "updatedAt_ASC"
-  | "updatedAt_DESC"
-  | "projectType_ASC"
-  | "projectType_DESC"
-  | "projectTitle_ASC"
-  | "projectTitle_DESC"
-  | "descPublic_ASC"
-  | "descPublic_DESC"
-  | "descInternal_ASC"
-  | "descInternal_DESC"
-  | "author_ASC"
-  | "author_DESC"
-  | "status_ASC"
-  | "status_DESC"
-  | "visibility_ASC"
-  | "visibility_DESC"
-  | "protectImages_ASC"
-  | "protectImages_DESC";
 
 export type TeamOrderByInput =
   | "id_ASC"
@@ -781,14 +802,14 @@ export type TeamOrderByInput =
 export type VideoUnitOrderByInput =
   | "id_ASC"
   | "id_DESC"
-  | "title_ASC"
-  | "title_DESC"
-  | "descPublic_ASC"
-  | "descPublic_DESC"
   | "createdAt_ASC"
   | "createdAt_DESC"
   | "updatedAt_ASC"
-  | "updatedAt_DESC";
+  | "updatedAt_DESC"
+  | "title_ASC"
+  | "title_DESC"
+  | "descPublic_ASC"
+  | "descPublic_DESC";
 
 export type ContentType =
   | "AUDIO"
@@ -797,7 +818,7 @@ export type ContentType =
   | "IMAGE"
   | "TEACHING_MATERIAL";
 
-export type ProjectPublishStatus = "DRAFT" | "PUBLISHED" | "EMBARGOED";
+export type ProjectVisibility = "INTERNAL" | "PUBLIC";
 
 export type Permission =
   | "SUBSCRIBER"
@@ -806,13 +827,31 @@ export type Permission =
   | "TEAM_ADMIN"
   | "ADMIN";
 
-export type CategoryOrderByInput =
+export type VideoFileOrderByInput =
   | "id_ASC"
   | "id_DESC"
   | "createdAt_ASC"
   | "createdAt_DESC"
   | "updatedAt_ASC"
-  | "updatedAt_DESC";
+  | "updatedAt_DESC"
+  | "filetype_ASC"
+  | "filetype_DESC"
+  | "filename_ASC"
+  | "filename_DESC"
+  | "quality_ASC"
+  | "quality_DESC"
+  | "videoBurnedInStatus_ASC"
+  | "videoBurnedInStatus_DESC"
+  | "url_ASC"
+  | "url_DESC"
+  | "md5_ASC"
+  | "md5_DESC"
+  | "duration_ASC"
+  | "duration_DESC"
+  | "bitrate_ASC"
+  | "bitrate_DESC"
+  | "filesize_ASC"
+  | "filesize_DESC";
 
 export type UserOrderByInput =
   | "id_ASC"
@@ -844,7 +883,13 @@ export type UserOrderByInput =
   | "updatedAt_ASC"
   | "updatedAt_DESC";
 
-export type MutationType = "CREATED" | "UPDATED" | "DELETED";
+export type CategoryOrderByInput =
+  | "id_ASC"
+  | "id_DESC"
+  | "createdAt_ASC"
+  | "createdAt_DESC"
+  | "updatedAt_ASC"
+  | "updatedAt_DESC";
 
 export type DimensionsOrderByInput =
   | "id_ASC"
@@ -858,15 +903,39 @@ export type DimensionsOrderByInput =
   | "updatedAt_ASC"
   | "updatedAt_DESC";
 
-export type LanguageTranslationOrderByInput =
+export type VideoQuality = "WEB" | "BROADCAST";
+
+export type TagOrderByInput =
   | "id_ASC"
   | "id_DESC"
-  | "name_ASC"
-  | "name_DESC"
   | "createdAt_ASC"
   | "createdAt_DESC"
   | "updatedAt_ASC"
   | "updatedAt_DESC";
+
+export type VideoProjectOrderByInput =
+  | "id_ASC"
+  | "id_DESC"
+  | "createdAt_ASC"
+  | "createdAt_DESC"
+  | "updatedAt_ASC"
+  | "updatedAt_DESC"
+  | "projectType_ASC"
+  | "projectType_DESC"
+  | "projectTitle_ASC"
+  | "projectTitle_DESC"
+  | "descPublic_ASC"
+  | "descPublic_DESC"
+  | "descInternal_ASC"
+  | "descInternal_DESC"
+  | "author_ASC"
+  | "author_DESC"
+  | "status_ASC"
+  | "status_DESC"
+  | "visibility_ASC"
+  | "visibility_DESC"
+  | "protectImages_ASC"
+  | "protectImages_DESC";
 
 export type ImageUseOrderByInput =
   | "id_ASC"
@@ -914,15 +983,29 @@ export type SupportFileOrderByInput =
   | "filesize_ASC"
   | "filesize_DESC";
 
-export type TagOrderByInput =
+export type SupportFileUseOrderByInput =
   | "id_ASC"
   | "id_DESC"
+  | "name_ASC"
+  | "name_DESC"
   | "createdAt_ASC"
   | "createdAt_DESC"
   | "updatedAt_ASC"
   | "updatedAt_DESC";
 
-export type ProjectVisibility = "INTERNAL" | "PUBLIC";
+export type LanguageTranslationOrderByInput =
+  | "id_ASC"
+  | "id_DESC"
+  | "name_ASC"
+  | "name_DESC"
+  | "createdAt_ASC"
+  | "createdAt_DESC"
+  | "updatedAt_ASC"
+  | "updatedAt_DESC";
+
+export type MutationType = "CREATED" | "UPDATED" | "DELETED";
+
+export type VideoBurnedInStatus = "SUBTITLED" | "CAPTIONED" | "CLEAN";
 
 export type VideoStreamOrderByInput =
   | "id_ASC"
@@ -938,130 +1021,24 @@ export type VideoStreamOrderByInput =
   | "updatedAt_ASC"
   | "updatedAt_DESC";
 
-export type VideoBurnedInStatus = "SUBTITLED" | "CAPTIONED" | "CLEAN";
+export type ProjectPublishStatus = "DRAFT" | "PUBLISHED" | "EMBARGOED";
 
-export type VideoFileOrderByInput =
-  | "id_ASC"
-  | "id_DESC"
-  | "createdAt_ASC"
-  | "createdAt_DESC"
-  | "updatedAt_ASC"
-  | "updatedAt_DESC"
-  | "filetype_ASC"
-  | "filetype_DESC"
-  | "filename_ASC"
-  | "filename_DESC"
-  | "quality_ASC"
-  | "quality_DESC"
-  | "videoBurnedInStatus_ASC"
-  | "videoBurnedInStatus_DESC"
-  | "url_ASC"
-  | "url_DESC"
-  | "md5_ASC"
-  | "md5_DESC"
-  | "duration_ASC"
-  | "duration_DESC"
-  | "bitrate_ASC"
-  | "bitrate_DESC"
-  | "filesize_ASC"
-  | "filesize_DESC";
-
-export interface SupportFileCreateInput {
-  language: LanguageCreateOneInput;
-  url?: String;
-  md5?: String;
-  filename?: String;
-  filetype?: String;
-  filesize?: Float;
+export interface SupportFileUseCreateOneInput {
+  create?: SupportFileUseCreateInput;
+  connect?: SupportFileUseWhereUniqueInput;
 }
 
 export type CategoryWhereUniqueInput = AtLeastOne<{
   id: ID_Input;
 }>;
 
-export interface VideoUnitUpdateManyInput {
-  create?: VideoUnitCreateInput[] | VideoUnitCreateInput;
-  update?:
-    | VideoUnitUpdateWithWhereUniqueNestedInput[]
-    | VideoUnitUpdateWithWhereUniqueNestedInput;
-  upsert?:
-    | VideoUnitUpsertWithWhereUniqueNestedInput[]
-    | VideoUnitUpsertWithWhereUniqueNestedInput;
-  delete?: VideoUnitWhereUniqueInput[] | VideoUnitWhereUniqueInput;
-  connect?: VideoUnitWhereUniqueInput[] | VideoUnitWhereUniqueInput;
-  disconnect?: VideoUnitWhereUniqueInput[] | VideoUnitWhereUniqueInput;
-  deleteMany?: VideoUnitScalarWhereInput[] | VideoUnitScalarWhereInput;
-  updateMany?:
-    | VideoUnitUpdateManyWithWhereNestedInput[]
-    | VideoUnitUpdateManyWithWhereNestedInput;
-}
-
-export interface ImageFileCreateManyInput {
-  create?: ImageFileCreateInput[] | ImageFileCreateInput;
-  connect?: ImageFileWhereUniqueInput[] | ImageFileWhereUniqueInput;
-}
-
-export interface TeamUpsertNestedInput {
-  update: TeamUpdateDataInput;
-  create: TeamCreateInput;
-}
-
-export interface UserUpdateWithoutTeamDataInput {
-  firstName?: String;
-  lastName?: String;
-  email?: String;
-  password?: String;
-  tempToken?: String;
-  tempTokenExpiry?: Float;
-  jobTitle?: String;
-  country?: String;
-  city?: String;
-  howHeard?: String;
-  permissions?: UserUpdatepermissionsInput;
-  isConfirmed?: Boolean;
-}
-
-export interface VideoUnitSubscriptionWhereInput {
-  mutation_in?: MutationType[] | MutationType;
-  updatedFields_contains?: String;
-  updatedFields_contains_every?: String[] | String;
-  updatedFields_contains_some?: String[] | String;
-  node?: VideoUnitWhereInput;
-  AND?: VideoUnitSubscriptionWhereInput[] | VideoUnitSubscriptionWhereInput;
-  OR?: VideoUnitSubscriptionWhereInput[] | VideoUnitSubscriptionWhereInput;
-  NOT?: VideoUnitSubscriptionWhereInput[] | VideoUnitSubscriptionWhereInput;
-}
-
-export interface VideoProjectSubscriptionWhereInput {
-  mutation_in?: MutationType[] | MutationType;
-  updatedFields_contains?: String;
-  updatedFields_contains_every?: String[] | String;
-  updatedFields_contains_some?: String[] | String;
-  node?: VideoProjectWhereInput;
-  AND?:
-    | VideoProjectSubscriptionWhereInput[]
-    | VideoProjectSubscriptionWhereInput;
-  OR?:
-    | VideoProjectSubscriptionWhereInput[]
-    | VideoProjectSubscriptionWhereInput;
-  NOT?:
-    | VideoProjectSubscriptionWhereInput[]
-    | VideoProjectSubscriptionWhereInput;
-}
-
 export interface CategoryCreateInput {
   translations?: LanguageTranslationCreateManyInput;
 }
 
-export interface VideoFileSubscriptionWhereInput {
-  mutation_in?: MutationType[] | MutationType;
-  updatedFields_contains?: String;
-  updatedFields_contains_every?: String[] | String;
-  updatedFields_contains_some?: String[] | String;
-  node?: VideoFileWhereInput;
-  AND?: VideoFileSubscriptionWhereInput[] | VideoFileSubscriptionWhereInput;
-  OR?: VideoFileSubscriptionWhereInput[] | VideoFileSubscriptionWhereInput;
-  NOT?: VideoFileSubscriptionWhereInput[] | VideoFileSubscriptionWhereInput;
+export interface CategoryCreateManyInput {
+  create?: CategoryCreateInput[] | CategoryCreateInput;
+  connect?: CategoryWhereUniqueInput[] | CategoryWhereUniqueInput;
 }
 
 export interface LanguageTranslationCreateManyInput {
@@ -1071,24 +1048,24 @@ export interface LanguageTranslationCreateManyInput {
     | LanguageTranslationWhereUniqueInput;
 }
 
-export type ImageFileWhereUniqueInput = AtLeastOne<{
-  id: ID_Input;
-}>;
+export interface UserCreatepermissionsInput {
+  set?: Permission[] | Permission;
+}
 
 export interface LanguageTranslationCreateInput {
   name: String;
   language: LanguageCreateOneInput;
 }
 
-export interface ThumbnailSubscriptionWhereInput {
+export interface VideoUseSubscriptionWhereInput {
   mutation_in?: MutationType[] | MutationType;
   updatedFields_contains?: String;
   updatedFields_contains_every?: String[] | String;
   updatedFields_contains_some?: String[] | String;
-  node?: ThumbnailWhereInput;
-  AND?: ThumbnailSubscriptionWhereInput[] | ThumbnailSubscriptionWhereInput;
-  OR?: ThumbnailSubscriptionWhereInput[] | ThumbnailSubscriptionWhereInput;
-  NOT?: ThumbnailSubscriptionWhereInput[] | ThumbnailSubscriptionWhereInput;
+  node?: VideoUseWhereInput;
+  AND?: VideoUseSubscriptionWhereInput[] | VideoUseSubscriptionWhereInput;
+  OR?: VideoUseSubscriptionWhereInput[] | VideoUseSubscriptionWhereInput;
+  NOT?: VideoUseSubscriptionWhereInput[] | VideoUseSubscriptionWhereInput;
 }
 
 export interface LanguageCreateOneInput {
@@ -1096,10 +1073,16 @@ export interface LanguageCreateOneInput {
   connect?: LanguageWhereUniqueInput;
 }
 
-export type LanguageWhereUniqueInput = AtLeastOne<{
-  id: ID_Input;
-  locale?: String;
-}>;
+export interface VideoStreamSubscriptionWhereInput {
+  mutation_in?: MutationType[] | MutationType;
+  updatedFields_contains?: String;
+  updatedFields_contains_every?: String[] | String;
+  updatedFields_contains_some?: String[] | String;
+  node?: VideoStreamWhereInput;
+  AND?: VideoStreamSubscriptionWhereInput[] | VideoStreamSubscriptionWhereInput;
+  OR?: VideoStreamSubscriptionWhereInput[] | VideoStreamSubscriptionWhereInput;
+  NOT?: VideoStreamSubscriptionWhereInput[] | VideoStreamSubscriptionWhereInput;
+}
 
 export interface LanguageCreateInput {
   languageCode: String;
@@ -1109,30 +1092,24 @@ export interface LanguageCreateInput {
   nativeName: String;
 }
 
-export interface SupportFileSubscriptionWhereInput {
-  mutation_in?: MutationType[] | MutationType;
-  updatedFields_contains?: String;
-  updatedFields_contains_every?: String[] | String;
-  updatedFields_contains_some?: String[] | String;
-  node?: SupportFileWhereInput;
-  AND?: SupportFileSubscriptionWhereInput[] | SupportFileSubscriptionWhereInput;
-  OR?: SupportFileSubscriptionWhereInput[] | SupportFileSubscriptionWhereInput;
-  NOT?: SupportFileSubscriptionWhereInput[] | SupportFileSubscriptionWhereInput;
-}
+export type ImageUseWhereUniqueInput = AtLeastOne<{
+  id: ID_Input;
+  name?: String;
+}>;
 
 export interface CategoryUpdateInput {
   translations?: LanguageTranslationUpdateManyInput;
 }
 
-export interface LanguageSubscriptionWhereInput {
+export interface UserSubscriptionWhereInput {
   mutation_in?: MutationType[] | MutationType;
   updatedFields_contains?: String;
   updatedFields_contains_every?: String[] | String;
   updatedFields_contains_some?: String[] | String;
-  node?: LanguageWhereInput;
-  AND?: LanguageSubscriptionWhereInput[] | LanguageSubscriptionWhereInput;
-  OR?: LanguageSubscriptionWhereInput[] | LanguageSubscriptionWhereInput;
-  NOT?: LanguageSubscriptionWhereInput[] | LanguageSubscriptionWhereInput;
+  node?: UserWhereInput;
+  AND?: UserSubscriptionWhereInput[] | UserSubscriptionWhereInput;
+  OR?: UserSubscriptionWhereInput[] | UserSubscriptionWhereInput;
+  NOT?: UserSubscriptionWhereInput[] | UserSubscriptionWhereInput;
 }
 
 export interface LanguageTranslationUpdateManyInput {
@@ -1160,20 +1137,91 @@ export interface LanguageTranslationUpdateManyInput {
     | LanguageTranslationUpdateManyWithWhereNestedInput;
 }
 
-export interface ImageUseSubscriptionWhereInput {
+export interface TeamSubscriptionWhereInput {
   mutation_in?: MutationType[] | MutationType;
   updatedFields_contains?: String;
   updatedFields_contains_every?: String[] | String;
   updatedFields_contains_some?: String[] | String;
-  node?: ImageUseWhereInput;
-  AND?: ImageUseSubscriptionWhereInput[] | ImageUseSubscriptionWhereInput;
-  OR?: ImageUseSubscriptionWhereInput[] | ImageUseSubscriptionWhereInput;
-  NOT?: ImageUseSubscriptionWhereInput[] | ImageUseSubscriptionWhereInput;
+  node?: TeamWhereInput;
+  AND?: TeamSubscriptionWhereInput[] | TeamSubscriptionWhereInput;
+  OR?: TeamSubscriptionWhereInput[] | TeamSubscriptionWhereInput;
+  NOT?: TeamSubscriptionWhereInput[] | TeamSubscriptionWhereInput;
 }
 
 export interface LanguageTranslationUpdateWithWhereUniqueNestedInput {
   where: LanguageTranslationWhereUniqueInput;
   data: LanguageTranslationUpdateDataInput;
+}
+
+export type ImageFileWhereUniqueInput = AtLeastOne<{
+  id: ID_Input;
+}>;
+
+export interface LanguageTranslationUpdateDataInput {
+  name?: String;
+  language?: LanguageUpdateOneRequiredInput;
+}
+
+export interface SupportFileUseSubscriptionWhereInput {
+  mutation_in?: MutationType[] | MutationType;
+  updatedFields_contains?: String;
+  updatedFields_contains_every?: String[] | String;
+  updatedFields_contains_some?: String[] | String;
+  node?: SupportFileUseWhereInput;
+  AND?:
+    | SupportFileUseSubscriptionWhereInput[]
+    | SupportFileUseSubscriptionWhereInput;
+  OR?:
+    | SupportFileUseSubscriptionWhereInput[]
+    | SupportFileUseSubscriptionWhereInput;
+  NOT?:
+    | SupportFileUseSubscriptionWhereInput[]
+    | SupportFileUseSubscriptionWhereInput;
+}
+
+export interface LanguageUpdateOneRequiredInput {
+  create?: LanguageCreateInput;
+  update?: LanguageUpdateDataInput;
+  upsert?: LanguageUpsertNestedInput;
+  connect?: LanguageWhereUniqueInput;
+}
+
+export type LanguageTranslationWhereUniqueInput = AtLeastOne<{
+  id: ID_Input;
+}>;
+
+export interface LanguageUpdateDataInput {
+  languageCode?: String;
+  locale?: String;
+  textDirection?: String;
+  displayName?: String;
+  nativeName?: String;
+}
+
+export interface LanguageSubscriptionWhereInput {
+  mutation_in?: MutationType[] | MutationType;
+  updatedFields_contains?: String;
+  updatedFields_contains_every?: String[] | String;
+  updatedFields_contains_some?: String[] | String;
+  node?: LanguageWhereInput;
+  AND?: LanguageSubscriptionWhereInput[] | LanguageSubscriptionWhereInput;
+  OR?: LanguageSubscriptionWhereInput[] | LanguageSubscriptionWhereInput;
+  NOT?: LanguageSubscriptionWhereInput[] | LanguageSubscriptionWhereInput;
+}
+
+export interface LanguageUpsertNestedInput {
+  update: LanguageUpdateDataInput;
+  create: LanguageCreateInput;
+}
+
+export type SupportFileWhereUniqueInput = AtLeastOne<{
+  id: ID_Input;
+}>;
+
+export interface LanguageTranslationUpsertWithWhereUniqueNestedInput {
+  where: LanguageTranslationWhereUniqueInput;
+  update: LanguageTranslationUpdateDataInput;
+  create: LanguageTranslationCreateInput;
 }
 
 export interface DimensionsSubscriptionWhereInput {
@@ -1187,27 +1235,44 @@ export interface DimensionsSubscriptionWhereInput {
   NOT?: DimensionsSubscriptionWhereInput[] | DimensionsSubscriptionWhereInput;
 }
 
-export interface LanguageTranslationUpdateDataInput {
+export interface LanguageTranslationScalarWhereInput {
+  id?: ID_Input;
+  id_not?: ID_Input;
+  id_in?: ID_Input[] | ID_Input;
+  id_not_in?: ID_Input[] | ID_Input;
+  id_lt?: ID_Input;
+  id_lte?: ID_Input;
+  id_gt?: ID_Input;
+  id_gte?: ID_Input;
+  id_contains?: ID_Input;
+  id_not_contains?: ID_Input;
+  id_starts_with?: ID_Input;
+  id_not_starts_with?: ID_Input;
+  id_ends_with?: ID_Input;
+  id_not_ends_with?: ID_Input;
   name?: String;
-  language?: LanguageUpdateOneRequiredInput;
-}
-
-export interface CategorySubscriptionWhereInput {
-  mutation_in?: MutationType[] | MutationType;
-  updatedFields_contains?: String;
-  updatedFields_contains_every?: String[] | String;
-  updatedFields_contains_some?: String[] | String;
-  node?: CategoryWhereInput;
-  AND?: CategorySubscriptionWhereInput[] | CategorySubscriptionWhereInput;
-  OR?: CategorySubscriptionWhereInput[] | CategorySubscriptionWhereInput;
-  NOT?: CategorySubscriptionWhereInput[] | CategorySubscriptionWhereInput;
-}
-
-export interface LanguageUpdateOneRequiredInput {
-  create?: LanguageCreateInput;
-  update?: LanguageUpdateDataInput;
-  upsert?: LanguageUpsertNestedInput;
-  connect?: LanguageWhereUniqueInput;
+  name_not?: String;
+  name_in?: String[] | String;
+  name_not_in?: String[] | String;
+  name_lt?: String;
+  name_lte?: String;
+  name_gt?: String;
+  name_gte?: String;
+  name_contains?: String;
+  name_not_contains?: String;
+  name_starts_with?: String;
+  name_not_starts_with?: String;
+  name_ends_with?: String;
+  name_not_ends_with?: String;
+  AND?:
+    | LanguageTranslationScalarWhereInput[]
+    | LanguageTranslationScalarWhereInput;
+  OR?:
+    | LanguageTranslationScalarWhereInput[]
+    | LanguageTranslationScalarWhereInput;
+  NOT?:
+    | LanguageTranslationScalarWhereInput[]
+    | LanguageTranslationScalarWhereInput;
 }
 
 export interface SupportFileWhereInput {
@@ -1306,17 +1371,23 @@ export interface SupportFileWhereInput {
   filesize_lte?: Float;
   filesize_gt?: Float;
   filesize_gte?: Float;
+  use?: SupportFileUseWhereInput;
   AND?: SupportFileWhereInput[] | SupportFileWhereInput;
   OR?: SupportFileWhereInput[] | SupportFileWhereInput;
   NOT?: SupportFileWhereInput[] | SupportFileWhereInput;
 }
 
-export interface LanguageUpdateDataInput {
-  languageCode?: String;
-  locale?: String;
-  textDirection?: String;
-  displayName?: String;
-  nativeName?: String;
+export interface LanguageTranslationUpdateManyWithWhereNestedInput {
+  where: LanguageTranslationScalarWhereInput;
+  data: LanguageTranslationUpdateManyDataInput;
+}
+
+export interface VideoUseUpdateManyMutationInput {
+  name?: String;
+}
+
+export interface LanguageTranslationUpdateManyDataInput {
+  name?: String;
 }
 
 export interface VideoUnitUpdateManyMutationInput {
@@ -1324,21 +1395,19 @@ export interface VideoUnitUpdateManyMutationInput {
   descPublic?: String;
 }
 
-export interface LanguageUpsertNestedInput {
-  update: LanguageUpdateDataInput;
-  create: LanguageCreateInput;
+export interface ImageFileCreateManyInput {
+  create?: ImageFileCreateInput[] | ImageFileCreateInput;
+  connect?: ImageFileWhereUniqueInput[] | ImageFileWhereUniqueInput;
 }
 
-export interface VideoStreamUpdateManyMutationInput {
-  site?: String;
-  url?: String;
-  embedUrl?: String;
-}
+export type SupportFileUseWhereUniqueInput = AtLeastOne<{
+  id: ID_Input;
+  name?: String;
+}>;
 
-export interface LanguageTranslationUpsertWithWhereUniqueNestedInput {
-  where: LanguageTranslationWhereUniqueInput;
-  update: LanguageTranslationUpdateDataInput;
-  create: LanguageTranslationCreateInput;
+export interface SupportFileCreateManyInput {
+  create?: SupportFileCreateInput[] | SupportFileCreateInput;
+  connect?: SupportFileWhereUniqueInput[] | SupportFileWhereUniqueInput;
 }
 
 export interface VideoStreamUpdateInput {
@@ -1347,7 +1416,37 @@ export interface VideoStreamUpdateInput {
   embedUrl?: String;
 }
 
-export interface LanguageTranslationScalarWhereInput {
+export interface DimensionsCreateInput {
+  width?: Int;
+  height?: Int;
+}
+
+export interface ImageFileUpdateManyDataInput {
+  alt?: String;
+  longdesc?: String;
+  caption?: String;
+  filename?: String;
+  filetype?: String;
+  md5?: String;
+  url?: String;
+}
+
+export interface DimensionsUpdateInput {
+  width?: Int;
+  height?: Int;
+}
+
+export interface ImageFileUpdateManyWithWhereNestedInput {
+  where: ImageFileScalarWhereInput;
+  data: ImageFileUpdateManyDataInput;
+}
+
+export interface DimensionsUpdateManyMutationInput {
+  width?: Int;
+  height?: Int;
+}
+
+export interface ImageFileScalarWhereInput {
   id?: ID_Input;
   id_not?: ID_Input;
   id_in?: ID_Input[] | ID_Input;
@@ -1362,54 +1461,146 @@ export interface LanguageTranslationScalarWhereInput {
   id_not_starts_with?: ID_Input;
   id_ends_with?: ID_Input;
   id_not_ends_with?: ID_Input;
-  name?: String;
-  name_not?: String;
-  name_in?: String[] | String;
-  name_not_in?: String[] | String;
-  name_lt?: String;
-  name_lte?: String;
-  name_gt?: String;
-  name_gte?: String;
-  name_contains?: String;
-  name_not_contains?: String;
-  name_starts_with?: String;
-  name_not_starts_with?: String;
-  name_ends_with?: String;
-  name_not_ends_with?: String;
-  AND?:
-    | LanguageTranslationScalarWhereInput[]
-    | LanguageTranslationScalarWhereInput;
-  OR?:
-    | LanguageTranslationScalarWhereInput[]
-    | LanguageTranslationScalarWhereInput;
-  NOT?:
-    | LanguageTranslationScalarWhereInput[]
-    | LanguageTranslationScalarWhereInput;
+  createdAt?: DateTimeInput;
+  createdAt_not?: DateTimeInput;
+  createdAt_in?: DateTimeInput[] | DateTimeInput;
+  createdAt_not_in?: DateTimeInput[] | DateTimeInput;
+  createdAt_lt?: DateTimeInput;
+  createdAt_lte?: DateTimeInput;
+  createdAt_gt?: DateTimeInput;
+  createdAt_gte?: DateTimeInput;
+  updatedAt?: DateTimeInput;
+  updatedAt_not?: DateTimeInput;
+  updatedAt_in?: DateTimeInput[] | DateTimeInput;
+  updatedAt_not_in?: DateTimeInput[] | DateTimeInput;
+  updatedAt_lt?: DateTimeInput;
+  updatedAt_lte?: DateTimeInput;
+  updatedAt_gt?: DateTimeInput;
+  updatedAt_gte?: DateTimeInput;
+  alt?: String;
+  alt_not?: String;
+  alt_in?: String[] | String;
+  alt_not_in?: String[] | String;
+  alt_lt?: String;
+  alt_lte?: String;
+  alt_gt?: String;
+  alt_gte?: String;
+  alt_contains?: String;
+  alt_not_contains?: String;
+  alt_starts_with?: String;
+  alt_not_starts_with?: String;
+  alt_ends_with?: String;
+  alt_not_ends_with?: String;
+  longdesc?: String;
+  longdesc_not?: String;
+  longdesc_in?: String[] | String;
+  longdesc_not_in?: String[] | String;
+  longdesc_lt?: String;
+  longdesc_lte?: String;
+  longdesc_gt?: String;
+  longdesc_gte?: String;
+  longdesc_contains?: String;
+  longdesc_not_contains?: String;
+  longdesc_starts_with?: String;
+  longdesc_not_starts_with?: String;
+  longdesc_ends_with?: String;
+  longdesc_not_ends_with?: String;
+  caption?: String;
+  caption_not?: String;
+  caption_in?: String[] | String;
+  caption_not_in?: String[] | String;
+  caption_lt?: String;
+  caption_lte?: String;
+  caption_gt?: String;
+  caption_gte?: String;
+  caption_contains?: String;
+  caption_not_contains?: String;
+  caption_starts_with?: String;
+  caption_not_starts_with?: String;
+  caption_ends_with?: String;
+  caption_not_ends_with?: String;
+  filename?: String;
+  filename_not?: String;
+  filename_in?: String[] | String;
+  filename_not_in?: String[] | String;
+  filename_lt?: String;
+  filename_lte?: String;
+  filename_gt?: String;
+  filename_gte?: String;
+  filename_contains?: String;
+  filename_not_contains?: String;
+  filename_starts_with?: String;
+  filename_not_starts_with?: String;
+  filename_ends_with?: String;
+  filename_not_ends_with?: String;
+  filetype?: String;
+  filetype_not?: String;
+  filetype_in?: String[] | String;
+  filetype_not_in?: String[] | String;
+  filetype_lt?: String;
+  filetype_lte?: String;
+  filetype_gt?: String;
+  filetype_gte?: String;
+  filetype_contains?: String;
+  filetype_not_contains?: String;
+  filetype_starts_with?: String;
+  filetype_not_starts_with?: String;
+  filetype_ends_with?: String;
+  filetype_not_ends_with?: String;
+  md5?: String;
+  md5_not?: String;
+  md5_in?: String[] | String;
+  md5_not_in?: String[] | String;
+  md5_lt?: String;
+  md5_lte?: String;
+  md5_gt?: String;
+  md5_gte?: String;
+  md5_contains?: String;
+  md5_not_contains?: String;
+  md5_starts_with?: String;
+  md5_not_starts_with?: String;
+  md5_ends_with?: String;
+  md5_not_ends_with?: String;
+  url?: String;
+  url_not?: String;
+  url_in?: String[] | String;
+  url_not_in?: String[] | String;
+  url_lt?: String;
+  url_lte?: String;
+  url_gt?: String;
+  url_gte?: String;
+  url_contains?: String;
+  url_not_contains?: String;
+  url_starts_with?: String;
+  url_not_starts_with?: String;
+  url_ends_with?: String;
+  url_not_ends_with?: String;
+  AND?: ImageFileScalarWhereInput[] | ImageFileScalarWhereInput;
+  OR?: ImageFileScalarWhereInput[] | ImageFileScalarWhereInput;
+  NOT?: ImageFileScalarWhereInput[] | ImageFileScalarWhereInput;
 }
 
-export interface VideoProjectUpdateManyMutationInput {
-  projectType?: String;
-  projectTitle?: String;
-  descPublic?: String;
-  descInternal?: String;
-  author?: String;
-  status?: ProjectPublishStatus;
-  visibility?: ProjectVisibility;
-  protectImages?: Boolean;
+export interface ImageFileCreateInput {
+  language?: LanguageCreateOneInput;
+  dimensions?: DimensionsCreateOneInput;
+  alt?: String;
+  longdesc?: String;
+  caption?: String;
+  filename?: String;
+  filetype?: String;
+  use?: ImageUseCreateOneInput;
+  md5?: String;
+  url?: String;
 }
 
-export interface LanguageTranslationUpdateManyWithWhereNestedInput {
-  where: LanguageTranslationScalarWhereInput;
-  data: LanguageTranslationUpdateManyDataInput;
+export interface ImageFileUpdateWithWhereUniqueNestedInput {
+  where: ImageFileWhereUniqueInput;
+  data: ImageFileUpdateDataInput;
 }
 
-export interface ImageFileUpdateManyWithWhereNestedInput {
-  where: ImageFileScalarWhereInput;
-  data: ImageFileUpdateManyDataInput;
-}
-
-export interface LanguageTranslationUpdateManyDataInput {
-  name?: String;
+export interface DimensionsCreateOneInput {
+  create?: DimensionsCreateInput;
+  connect?: DimensionsWhereUniqueInput;
 }
 
 export type TeamWhereUniqueInput = AtLeastOne<{
@@ -1417,12 +1608,9 @@ export type TeamWhereUniqueInput = AtLeastOne<{
   name?: String;
 }>;
 
-export interface TeamUpdateDataInput {
-  name?: String;
-  organization?: String;
-  members?: UserUpdateManyWithoutTeamInput;
-  contentTypes?: TeamUpdatecontentTypesInput;
-  isConfirmed?: Boolean;
+export interface ImageUseCreateOneInput {
+  create?: ImageUseCreateInput;
+  connect?: ImageUseWhereUniqueInput;
 }
 
 export interface UserWhereInput {
@@ -1582,13 +1770,8 @@ export interface UserWhereInput {
   NOT?: UserWhereInput[] | UserWhereInput;
 }
 
-export interface TeamUpdateOneInput {
-  create?: TeamCreateInput;
-  update?: TeamUpdateDataInput;
-  upsert?: TeamUpsertNestedInput;
-  delete?: Boolean;
-  disconnect?: Boolean;
-  connect?: TeamWhereUniqueInput;
+export interface ImageUseCreateInput {
+  name: String;
 }
 
 export interface DimensionsWhereInput {
@@ -1627,44 +1810,17 @@ export interface DimensionsWhereInput {
   NOT?: DimensionsWhereInput[] | DimensionsWhereInput;
 }
 
-export interface DimensionsCreateInput {
-  width?: Int;
-  height?: Int;
-}
-
-export interface ImageFileUpdateManyInput {
-  create?: ImageFileCreateInput[] | ImageFileCreateInput;
-  update?:
-    | ImageFileUpdateWithWhereUniqueNestedInput[]
-    | ImageFileUpdateWithWhereUniqueNestedInput;
-  upsert?:
-    | ImageFileUpsertWithWhereUniqueNestedInput[]
-    | ImageFileUpsertWithWhereUniqueNestedInput;
-  delete?: ImageFileWhereUniqueInput[] | ImageFileWhereUniqueInput;
-  connect?: ImageFileWhereUniqueInput[] | ImageFileWhereUniqueInput;
-  disconnect?: ImageFileWhereUniqueInput[] | ImageFileWhereUniqueInput;
-  deleteMany?: ImageFileScalarWhereInput[] | ImageFileScalarWhereInput;
-  updateMany?:
-    | ImageFileUpdateManyWithWhereNestedInput[]
-    | ImageFileUpdateManyWithWhereNestedInput;
-}
-
-export interface DimensionsUpdateInput {
-  width?: Int;
-  height?: Int;
-}
-
-export interface SupportFileUpdateManyDataInput {
-  url?: String;
-  md5?: String;
+export interface ImageFileUpdateInput {
+  language?: LanguageUpdateOneInput;
+  dimensions?: DimensionsUpdateOneInput;
+  alt?: String;
+  longdesc?: String;
+  caption?: String;
   filename?: String;
   filetype?: String;
-  filesize?: Float;
-}
-
-export interface DimensionsUpdateManyMutationInput {
-  width?: Int;
-  height?: Int;
+  use?: ImageUseUpdateOneInput;
+  md5?: String;
+  url?: String;
 }
 
 export interface SupportFileScalarWhereInput {
@@ -1767,61 +1923,6 @@ export interface SupportFileScalarWhereInput {
   NOT?: SupportFileScalarWhereInput[] | SupportFileScalarWhereInput;
 }
 
-export interface ImageFileCreateInput {
-  language?: LanguageCreateOneInput;
-  dimensions?: DimensionsCreateOneInput;
-  alt?: String;
-  longdesc?: String;
-  caption?: String;
-  filename?: String;
-  filetype?: String;
-  md5?: String;
-  url?: String;
-}
-
-export type ThumbnailWhereUniqueInput = AtLeastOne<{
-  id: ID_Input;
-}>;
-
-export interface DimensionsCreateOneInput {
-  create?: DimensionsCreateInput;
-  connect?: DimensionsWhereUniqueInput;
-}
-
-export interface SupportFileUpdateWithWhereUniqueNestedInput {
-  where: SupportFileWhereUniqueInput;
-  data: SupportFileUpdateDataInput;
-}
-
-export interface ImageFileUpdateInput {
-  language?: LanguageUpdateOneInput;
-  dimensions?: DimensionsUpdateOneInput;
-  alt?: String;
-  longdesc?: String;
-  caption?: String;
-  filename?: String;
-  filetype?: String;
-  md5?: String;
-  url?: String;
-}
-
-export interface SupportFileUpdateManyInput {
-  create?: SupportFileCreateInput[] | SupportFileCreateInput;
-  update?:
-    | SupportFileUpdateWithWhereUniqueNestedInput[]
-    | SupportFileUpdateWithWhereUniqueNestedInput;
-  upsert?:
-    | SupportFileUpsertWithWhereUniqueNestedInput[]
-    | SupportFileUpsertWithWhereUniqueNestedInput;
-  delete?: SupportFileWhereUniqueInput[] | SupportFileWhereUniqueInput;
-  connect?: SupportFileWhereUniqueInput[] | SupportFileWhereUniqueInput;
-  disconnect?: SupportFileWhereUniqueInput[] | SupportFileWhereUniqueInput;
-  deleteMany?: SupportFileScalarWhereInput[] | SupportFileScalarWhereInput;
-  updateMany?:
-    | SupportFileUpdateManyWithWhereNestedInput[]
-    | SupportFileUpdateManyWithWhereNestedInput;
-}
-
 export interface LanguageUpdateOneInput {
   create?: LanguageCreateInput;
   update?: LanguageUpdateDataInput;
@@ -1831,9 +1932,10 @@ export interface LanguageUpdateOneInput {
   connect?: LanguageWhereUniqueInput;
 }
 
-export interface VideoUnitUpdateManyWithWhereNestedInput {
-  where: VideoUnitScalarWhereInput;
-  data: VideoUnitUpdateManyDataInput;
+export interface SupportFileUpsertWithWhereUniqueNestedInput {
+  where: SupportFileWhereUniqueInput;
+  update: SupportFileUpdateDataInput;
+  create: SupportFileCreateInput;
 }
 
 export interface DimensionsUpdateOneInput {
@@ -1845,27 +1947,119 @@ export interface DimensionsUpdateOneInput {
   connect?: DimensionsWhereUniqueInput;
 }
 
-export type UserWhereUniqueInput = AtLeastOne<{
-  id: ID_Input;
-  email?: String;
-}>;
+export interface SupportFileUpdateWithWhereUniqueNestedInput {
+  where: SupportFileWhereUniqueInput;
+  data: SupportFileUpdateDataInput;
+}
 
 export interface DimensionsUpdateDataInput {
   width?: Int;
   height?: Int;
 }
 
-export interface ThumbnailUpdateManyDataInput {
-  size?: ThumbnailSize;
-}
+export type ThumbnailWhereUniqueInput = AtLeastOne<{
+  id: ID_Input;
+}>;
 
 export interface DimensionsUpsertNestedInput {
   update: DimensionsUpdateDataInput;
   create: DimensionsCreateInput;
 }
 
-export type VideoFileWhereUniqueInput = AtLeastOne<{
+export interface VideoUnitUpdateManyWithWhereNestedInput {
+  where: VideoUnitScalarWhereInput;
+  data: VideoUnitUpdateManyDataInput;
+}
+
+export interface ImageUseUpdateOneInput {
+  create?: ImageUseCreateInput;
+  update?: ImageUseUpdateDataInput;
+  upsert?: ImageUseUpsertNestedInput;
+  delete?: Boolean;
+  disconnect?: Boolean;
+  connect?: ImageUseWhereUniqueInput;
+}
+
+export interface VideoUnitScalarWhereInput {
+  id?: ID_Input;
+  id_not?: ID_Input;
+  id_in?: ID_Input[] | ID_Input;
+  id_not_in?: ID_Input[] | ID_Input;
+  id_lt?: ID_Input;
+  id_lte?: ID_Input;
+  id_gt?: ID_Input;
+  id_gte?: ID_Input;
+  id_contains?: ID_Input;
+  id_not_contains?: ID_Input;
+  id_starts_with?: ID_Input;
+  id_not_starts_with?: ID_Input;
+  id_ends_with?: ID_Input;
+  id_not_ends_with?: ID_Input;
+  createdAt?: DateTimeInput;
+  createdAt_not?: DateTimeInput;
+  createdAt_in?: DateTimeInput[] | DateTimeInput;
+  createdAt_not_in?: DateTimeInput[] | DateTimeInput;
+  createdAt_lt?: DateTimeInput;
+  createdAt_lte?: DateTimeInput;
+  createdAt_gt?: DateTimeInput;
+  createdAt_gte?: DateTimeInput;
+  updatedAt?: DateTimeInput;
+  updatedAt_not?: DateTimeInput;
+  updatedAt_in?: DateTimeInput[] | DateTimeInput;
+  updatedAt_not_in?: DateTimeInput[] | DateTimeInput;
+  updatedAt_lt?: DateTimeInput;
+  updatedAt_lte?: DateTimeInput;
+  updatedAt_gt?: DateTimeInput;
+  updatedAt_gte?: DateTimeInput;
+  title?: String;
+  title_not?: String;
+  title_in?: String[] | String;
+  title_not_in?: String[] | String;
+  title_lt?: String;
+  title_lte?: String;
+  title_gt?: String;
+  title_gte?: String;
+  title_contains?: String;
+  title_not_contains?: String;
+  title_starts_with?: String;
+  title_not_starts_with?: String;
+  title_ends_with?: String;
+  title_not_ends_with?: String;
+  descPublic?: String;
+  descPublic_not?: String;
+  descPublic_in?: String[] | String;
+  descPublic_not_in?: String[] | String;
+  descPublic_lt?: String;
+  descPublic_lte?: String;
+  descPublic_gt?: String;
+  descPublic_gte?: String;
+  descPublic_contains?: String;
+  descPublic_not_contains?: String;
+  descPublic_starts_with?: String;
+  descPublic_not_starts_with?: String;
+  descPublic_ends_with?: String;
+  descPublic_not_ends_with?: String;
+  AND?: VideoUnitScalarWhereInput[] | VideoUnitScalarWhereInput;
+  OR?: VideoUnitScalarWhereInput[] | VideoUnitScalarWhereInput;
+  NOT?: VideoUnitScalarWhereInput[] | VideoUnitScalarWhereInput;
+}
+
+export interface ImageUseUpdateDataInput {
+  name?: String;
+}
+
+export interface ThumbnailUpdateManyDataInput {
+  size?: ThumbnailSize;
+}
+
+export interface ImageUseUpsertNestedInput {
+  update: ImageUseUpdateDataInput;
+  create: ImageUseCreateInput;
+}
+
+export type UserWhereUniqueInput = AtLeastOne<{
   id: ID_Input;
+  email?: String;
 }>;
 
 export interface ImageFileUpdateManyMutationInput {
@@ -1884,17 +2078,83 @@ export interface ThumbnailUpsertWithWhereUniqueNestedInput {
   create: ThumbnailCreateInput;
 }
 
-export interface ImageUseCreateInput {
-  name: String;
-}
-
-export interface ThumbnailUpdateWithWhereUniqueNestedInput {
-  where: ThumbnailWhereUniqueInput;
-  data: ThumbnailUpdateDataInput;
-}
-
 export interface ImageUseUpdateInput {
   name?: String;
+}
+
+export type VideoFileWhereUniqueInput = AtLeastOne<{
+  id: ID_Input;
+}>;
+
+export interface ImageUseUpdateManyMutationInput {
+  name?: String;
+}
+
+export interface ThumbnailUpdateManyInput {
+  create?: ThumbnailCreateInput[] | ThumbnailCreateInput;
+  update?:
+    | ThumbnailUpdateWithWhereUniqueNestedInput[]
+    | ThumbnailUpdateWithWhereUniqueNestedInput;
+  upsert?:
+    | ThumbnailUpsertWithWhereUniqueNestedInput[]
+    | ThumbnailUpsertWithWhereUniqueNestedInput;
+  delete?: ThumbnailWhereUniqueInput[] | ThumbnailWhereUniqueInput;
+  connect?: ThumbnailWhereUniqueInput[] | ThumbnailWhereUniqueInput;
+  disconnect?: ThumbnailWhereUniqueInput[] | ThumbnailWhereUniqueInput;
+  deleteMany?: ThumbnailScalarWhereInput[] | ThumbnailScalarWhereInput;
+  updateMany?:
+    | ThumbnailUpdateManyWithWhereNestedInput[]
+    | ThumbnailUpdateManyWithWhereNestedInput;
+}
+
+export interface LanguageUpdateInput {
+  languageCode?: String;
+  locale?: String;
+  textDirection?: String;
+  displayName?: String;
+  nativeName?: String;
+}
+
+export interface CategoryUpsertWithWhereUniqueNestedInput {
+  where: CategoryWhereUniqueInput;
+  update: CategoryUpdateDataInput;
+  create: CategoryCreateInput;
+}
+
+export interface LanguageUpdateManyMutationInput {
+  languageCode?: String;
+  locale?: String;
+  textDirection?: String;
+  displayName?: String;
+  nativeName?: String;
+}
+
+export interface CategoryWhereInput {
+  id?: ID_Input;
+  id_not?: ID_Input;
+  id_in?: ID_Input[] | ID_Input;
+  id_not_in?: ID_Input[] | ID_Input;
+  id_lt?: ID_Input;
+  id_lte?: ID_Input;
+  id_gt?: ID_Input;
+  id_gte?: ID_Input;
+  id_contains?: ID_Input;
+  id_not_contains?: ID_Input;
+  id_starts_with?: ID_Input;
+  id_not_starts_with?: ID_Input;
+  id_ends_with?: ID_Input;
+  id_not_ends_with?: ID_Input;
+  translations_every?: LanguageTranslationWhereInput;
+  translations_some?: LanguageTranslationWhereInput;
+  translations_none?: LanguageTranslationWhereInput;
+  AND?: CategoryWhereInput[] | CategoryWhereInput;
+  OR?: CategoryWhereInput[] | CategoryWhereInput;
+  NOT?: CategoryWhereInput[] | CategoryWhereInput;
+}
+
+export interface LanguageTranslationUpdateInput {
+  name?: String;
+  language?: LanguageUpdateOneRequiredInput;
 }
 
 export interface VideoFileWhereInput {
@@ -2019,121 +2279,16 @@ export interface VideoFileWhereInput {
   filesize_gt?: Float;
   filesize_gte?: Float;
   dimensions?: DimensionsWhereInput;
-  stream?: VideoStreamWhereInput;
+  stream_every?: VideoStreamWhereInput;
+  stream_some?: VideoStreamWhereInput;
+  stream_none?: VideoStreamWhereInput;
   AND?: VideoFileWhereInput[] | VideoFileWhereInput;
   OR?: VideoFileWhereInput[] | VideoFileWhereInput;
   NOT?: VideoFileWhereInput[] | VideoFileWhereInput;
 }
 
-export interface ImageUseUpdateManyMutationInput {
+export interface LanguageTranslationUpdateManyMutationInput {
   name?: String;
-}
-
-export interface VideoStreamWhereInput {
-  id?: ID_Input;
-  id_not?: ID_Input;
-  id_in?: ID_Input[] | ID_Input;
-  id_not_in?: ID_Input[] | ID_Input;
-  id_lt?: ID_Input;
-  id_lte?: ID_Input;
-  id_gt?: ID_Input;
-  id_gte?: ID_Input;
-  id_contains?: ID_Input;
-  id_not_contains?: ID_Input;
-  id_starts_with?: ID_Input;
-  id_not_starts_with?: ID_Input;
-  id_ends_with?: ID_Input;
-  id_not_ends_with?: ID_Input;
-  site?: String;
-  site_not?: String;
-  site_in?: String[] | String;
-  site_not_in?: String[] | String;
-  site_lt?: String;
-  site_lte?: String;
-  site_gt?: String;
-  site_gte?: String;
-  site_contains?: String;
-  site_not_contains?: String;
-  site_starts_with?: String;
-  site_not_starts_with?: String;
-  site_ends_with?: String;
-  site_not_ends_with?: String;
-  url?: String;
-  url_not?: String;
-  url_in?: String[] | String;
-  url_not_in?: String[] | String;
-  url_lt?: String;
-  url_lte?: String;
-  url_gt?: String;
-  url_gte?: String;
-  url_contains?: String;
-  url_not_contains?: String;
-  url_starts_with?: String;
-  url_not_starts_with?: String;
-  url_ends_with?: String;
-  url_not_ends_with?: String;
-  embedUrl?: String;
-  embedUrl_not?: String;
-  embedUrl_in?: String[] | String;
-  embedUrl_not_in?: String[] | String;
-  embedUrl_lt?: String;
-  embedUrl_lte?: String;
-  embedUrl_gt?: String;
-  embedUrl_gte?: String;
-  embedUrl_contains?: String;
-  embedUrl_not_contains?: String;
-  embedUrl_starts_with?: String;
-  embedUrl_not_starts_with?: String;
-  embedUrl_ends_with?: String;
-  embedUrl_not_ends_with?: String;
-  AND?: VideoStreamWhereInput[] | VideoStreamWhereInput;
-  OR?: VideoStreamWhereInput[] | VideoStreamWhereInput;
-  NOT?: VideoStreamWhereInput[] | VideoStreamWhereInput;
-}
-
-export interface LanguageUpdateInput {
-  languageCode?: String;
-  locale?: String;
-  textDirection?: String;
-  displayName?: String;
-  nativeName?: String;
-}
-
-export interface CategoryScalarWhereInput {
-  id?: ID_Input;
-  id_not?: ID_Input;
-  id_in?: ID_Input[] | ID_Input;
-  id_not_in?: ID_Input[] | ID_Input;
-  id_lt?: ID_Input;
-  id_lte?: ID_Input;
-  id_gt?: ID_Input;
-  id_gte?: ID_Input;
-  id_contains?: ID_Input;
-  id_not_contains?: ID_Input;
-  id_starts_with?: ID_Input;
-  id_not_starts_with?: ID_Input;
-  id_ends_with?: ID_Input;
-  id_not_ends_with?: ID_Input;
-  AND?: CategoryScalarWhereInput[] | CategoryScalarWhereInput;
-  OR?: CategoryScalarWhereInput[] | CategoryScalarWhereInput;
-  NOT?: CategoryScalarWhereInput[] | CategoryScalarWhereInput;
-}
-
-export interface LanguageUpdateManyMutationInput {
-  languageCode?: String;
-  locale?: String;
-  textDirection?: String;
-  displayName?: String;
-  nativeName?: String;
-}
-
-export interface CategoryUpdateDataInput {
-  translations?: LanguageTranslationUpdateManyInput;
-}
-
-export interface LanguageTranslationUpdateInput {
-  name?: String;
-  language?: LanguageUpdateOneRequiredInput;
 }
 
 export interface CategoryUpdateWithWhereUniqueNestedInput {
@@ -2141,8 +2296,14 @@ export interface CategoryUpdateWithWhereUniqueNestedInput {
   data: CategoryUpdateDataInput;
 }
 
-export interface LanguageTranslationUpdateManyMutationInput {
-  name?: String;
+export interface SupportFileCreateInput {
+  language: LanguageCreateOneInput;
+  url?: String;
+  md5?: String;
+  filename?: String;
+  filetype?: String;
+  filesize?: Float;
+  use?: SupportFileUseCreateOneInput;
 }
 
 export interface TagScalarWhereInput {
@@ -2165,27 +2326,22 @@ export interface TagScalarWhereInput {
   NOT?: TagScalarWhereInput[] | TagScalarWhereInput;
 }
 
-export interface VideoProjectUpdateInput {
-  projectType?: String;
-  projectTitle?: String;
-  descPublic?: String;
-  descInternal?: String;
-  author?: String;
-  team?: TeamUpdateOneInput;
-  status?: ProjectPublishStatus;
-  visibility?: ProjectVisibility;
-  protectImages?: Boolean;
-  units?: VideoUnitUpdateManyInput;
-  supportFiles?: SupportFileUpdateManyInput;
-  thumbnails?: ImageFileUpdateManyInput;
-  categories?: CategoryUpdateManyInput;
-  tags?: TagUpdateManyInput;
+export interface ThumbnailCreateManyInput {
+  create?: ThumbnailCreateInput[] | ThumbnailCreateInput;
+  connect?: ThumbnailWhereUniqueInput[] | ThumbnailWhereUniqueInput;
 }
 
-export interface TagUpsertWithWhereUniqueNestedInput {
+export type VideoProjectWhereUniqueInput = AtLeastOne<{
+  id: ID_Input;
+}>;
+
+export interface SupportFileUseCreateInput {
+  name: String;
+}
+
+export interface TagUpdateWithWhereUniqueNestedInput {
   where: TagWhereUniqueInput;
-  update: TagUpdateDataInput;
-  create: TagCreateInput;
+  data: TagUpdateDataInput;
 }
 
 export interface SupportFileUpdateInput {
@@ -2195,9 +2351,10 @@ export interface SupportFileUpdateInput {
   filename?: String;
   filetype?: String;
   filesize?: Float;
+  use?: SupportFileUseUpdateOneInput;
 }
 
-export interface VideoProjectWhereInput {
+export interface VideoUnitWhereInput {
   id?: ID_Input;
   id_not?: ID_Input;
   id_in?: ID_Input[] | ID_Input;
@@ -2228,34 +2385,21 @@ export interface VideoProjectWhereInput {
   updatedAt_lte?: DateTimeInput;
   updatedAt_gt?: DateTimeInput;
   updatedAt_gte?: DateTimeInput;
-  projectType?: String;
-  projectType_not?: String;
-  projectType_in?: String[] | String;
-  projectType_not_in?: String[] | String;
-  projectType_lt?: String;
-  projectType_lte?: String;
-  projectType_gt?: String;
-  projectType_gte?: String;
-  projectType_contains?: String;
-  projectType_not_contains?: String;
-  projectType_starts_with?: String;
-  projectType_not_starts_with?: String;
-  projectType_ends_with?: String;
-  projectType_not_ends_with?: String;
-  projectTitle?: String;
-  projectTitle_not?: String;
-  projectTitle_in?: String[] | String;
-  projectTitle_not_in?: String[] | String;
-  projectTitle_lt?: String;
-  projectTitle_lte?: String;
-  projectTitle_gt?: String;
-  projectTitle_gte?: String;
-  projectTitle_contains?: String;
-  projectTitle_not_contains?: String;
-  projectTitle_starts_with?: String;
-  projectTitle_not_starts_with?: String;
-  projectTitle_ends_with?: String;
-  projectTitle_not_ends_with?: String;
+  language?: LanguageWhereInput;
+  title?: String;
+  title_not?: String;
+  title_in?: String[] | String;
+  title_not_in?: String[] | String;
+  title_lt?: String;
+  title_lte?: String;
+  title_gt?: String;
+  title_gte?: String;
+  title_contains?: String;
+  title_not_contains?: String;
+  title_starts_with?: String;
+  title_not_starts_with?: String;
+  title_ends_with?: String;
+  title_not_ends_with?: String;
   descPublic?: String;
   descPublic_not?: String;
   descPublic_in?: String[] | String;
@@ -2270,80 +2414,30 @@ export interface VideoProjectWhereInput {
   descPublic_not_starts_with?: String;
   descPublic_ends_with?: String;
   descPublic_not_ends_with?: String;
-  descInternal?: String;
-  descInternal_not?: String;
-  descInternal_in?: String[] | String;
-  descInternal_not_in?: String[] | String;
-  descInternal_lt?: String;
-  descInternal_lte?: String;
-  descInternal_gt?: String;
-  descInternal_gte?: String;
-  descInternal_contains?: String;
-  descInternal_not_contains?: String;
-  descInternal_starts_with?: String;
-  descInternal_not_starts_with?: String;
-  descInternal_ends_with?: String;
-  descInternal_not_ends_with?: String;
-  author?: String;
-  author_not?: String;
-  author_in?: String[] | String;
-  author_not_in?: String[] | String;
-  author_lt?: String;
-  author_lte?: String;
-  author_gt?: String;
-  author_gte?: String;
-  author_contains?: String;
-  author_not_contains?: String;
-  author_starts_with?: String;
-  author_not_starts_with?: String;
-  author_ends_with?: String;
-  author_not_ends_with?: String;
-  team?: TeamWhereInput;
-  status?: ProjectPublishStatus;
-  status_not?: ProjectPublishStatus;
-  status_in?: ProjectPublishStatus[] | ProjectPublishStatus;
-  status_not_in?: ProjectPublishStatus[] | ProjectPublishStatus;
-  visibility?: ProjectVisibility;
-  visibility_not?: ProjectVisibility;
-  visibility_in?: ProjectVisibility[] | ProjectVisibility;
-  visibility_not_in?: ProjectVisibility[] | ProjectVisibility;
-  protectImages?: Boolean;
-  protectImages_not?: Boolean;
-  units_every?: VideoUnitWhereInput;
-  units_some?: VideoUnitWhereInput;
-  units_none?: VideoUnitWhereInput;
-  supportFiles_every?: SupportFileWhereInput;
-  supportFiles_some?: SupportFileWhereInput;
-  supportFiles_none?: SupportFileWhereInput;
-  thumbnails_every?: ImageFileWhereInput;
-  thumbnails_some?: ImageFileWhereInput;
-  thumbnails_none?: ImageFileWhereInput;
-  categories_every?: CategoryWhereInput;
-  categories_some?: CategoryWhereInput;
-  categories_none?: CategoryWhereInput;
+  files_every?: VideoFileWhereInput;
+  files_some?: VideoFileWhereInput;
+  files_none?: VideoFileWhereInput;
   tags_every?: TagWhereInput;
   tags_some?: TagWhereInput;
   tags_none?: TagWhereInput;
-  AND?: VideoProjectWhereInput[] | VideoProjectWhereInput;
-  OR?: VideoProjectWhereInput[] | VideoProjectWhereInput;
-  NOT?: VideoProjectWhereInput[] | VideoProjectWhereInput;
+  categories_every?: CategoryWhereInput;
+  categories_some?: CategoryWhereInput;
+  categories_none?: CategoryWhereInput;
+  thumbnails_every?: ThumbnailWhereInput;
+  thumbnails_some?: ThumbnailWhereInput;
+  thumbnails_none?: ThumbnailWhereInput;
+  AND?: VideoUnitWhereInput[] | VideoUnitWhereInput;
+  OR?: VideoUnitWhereInput[] | VideoUnitWhereInput;
+  NOT?: VideoUnitWhereInput[] | VideoUnitWhereInput;
 }
 
-export interface SupportFileUpdateManyMutationInput {
-  url?: String;
-  md5?: String;
-  filename?: String;
-  filetype?: String;
-  filesize?: Float;
-}
-
-export interface TagUpdateWithWhereUniqueNestedInput {
-  where: TagWhereUniqueInput;
-  data: TagUpdateDataInput;
-}
-
-export interface TagCreateInput {
-  translations?: LanguageTranslationCreateManyInput;
+export interface SupportFileUseUpdateOneInput {
+  create?: SupportFileUseCreateInput;
+  update?: SupportFileUseUpdateDataInput;
+  upsert?: SupportFileUseUpsertNestedInput;
+  delete?: Boolean;
+  disconnect?: Boolean;
+  connect?: SupportFileUseWhereUniqueInput;
 }
 
 export interface VideoFileUpdateManyDataInput {
@@ -2358,8 +2452,8 @@ export interface VideoFileUpdateManyDataInput {
   filesize?: Float;
 }
 
-export interface TagUpdateInput {
-  translations?: LanguageTranslationUpdateManyInput;
+export interface SupportFileUseUpdateDataInput {
+  name?: String;
 }
 
 export interface VideoFileUpdateManyWithWhereNestedInput {
@@ -2367,12 +2461,9 @@ export interface VideoFileUpdateManyWithWhereNestedInput {
   data: VideoFileUpdateManyDataInput;
 }
 
-export interface TeamCreateInput {
-  name: String;
-  organization: String;
-  members?: UserCreateManyWithoutTeamInput;
-  contentTypes?: TeamCreatecontentTypesInput;
-  isConfirmed?: Boolean;
+export interface SupportFileUseUpsertNestedInput {
+  update: SupportFileUseUpdateDataInput;
+  create: SupportFileUseCreateInput;
 }
 
 export interface VideoFileUpsertWithWhereUniqueNestedInput {
@@ -2381,28 +2472,20 @@ export interface VideoFileUpsertWithWhereUniqueNestedInput {
   create: VideoFileCreateInput;
 }
 
-export interface UserCreateManyWithoutTeamInput {
-  create?: UserCreateWithoutTeamInput[] | UserCreateWithoutTeamInput;
-  connect?: UserWhereUniqueInput[] | UserWhereUniqueInput;
+export interface SupportFileUpdateManyMutationInput {
+  url?: String;
+  md5?: String;
+  filename?: String;
+  filetype?: String;
+  filesize?: Float;
 }
 
-export type VideoUnitWhereUniqueInput = AtLeastOne<{
+export type VideoStreamWhereUniqueInput = AtLeastOne<{
   id: ID_Input;
 }>;
 
-export interface UserCreateWithoutTeamInput {
-  firstName: String;
-  lastName: String;
-  email: String;
-  password?: String;
-  tempToken?: String;
-  tempTokenExpiry?: Float;
-  jobTitle?: String;
-  country?: String;
-  city?: String;
-  howHeard?: String;
-  permissions?: UserCreatepermissionsInput;
-  isConfirmed?: Boolean;
+export interface SupportFileUseUpdateInput {
+  name?: String;
 }
 
 export interface VideoFileUpdateManyInput {
@@ -2422,24 +2505,53 @@ export interface VideoFileUpdateManyInput {
     | VideoFileUpdateManyWithWhereNestedInput;
 }
 
-export interface UserCreatepermissionsInput {
-  set?: Permission[] | Permission;
+export interface SupportFileUseUpdateManyMutationInput {
+  name?: String;
+}
+
+export type VideoUnitWhereUniqueInput = AtLeastOne<{
+  id: ID_Input;
+}>;
+
+export interface TagCreateInput {
+  translations?: LanguageTranslationCreateManyInput;
+}
+
+export interface VideoUnitUpdateManyInput {
+  create?: VideoUnitCreateInput[] | VideoUnitCreateInput;
+  update?:
+    | VideoUnitUpdateWithWhereUniqueNestedInput[]
+    | VideoUnitUpdateWithWhereUniqueNestedInput;
+  upsert?:
+    | VideoUnitUpsertWithWhereUniqueNestedInput[]
+    | VideoUnitUpsertWithWhereUniqueNestedInput;
+  delete?: VideoUnitWhereUniqueInput[] | VideoUnitWhereUniqueInput;
+  connect?: VideoUnitWhereUniqueInput[] | VideoUnitWhereUniqueInput;
+  disconnect?: VideoUnitWhereUniqueInput[] | VideoUnitWhereUniqueInput;
+  deleteMany?: VideoUnitScalarWhereInput[] | VideoUnitScalarWhereInput;
+  updateMany?:
+    | VideoUnitUpdateManyWithWhereNestedInput[]
+    | VideoUnitUpdateManyWithWhereNestedInput;
+}
+
+export interface TagUpdateInput {
+  translations?: LanguageTranslationUpdateManyInput;
 }
 
 export type VideoUseWhereUniqueInput = AtLeastOne<{
   id: ID_Input;
+  name?: String;
 }>;
 
-export interface TeamCreatecontentTypesInput {
-  set?: ContentType[] | ContentType;
+export interface TeamCreateInput {
+  name: String;
+  organization: String;
+  members?: UserCreateManyWithoutTeamInput;
+  contentTypes?: TeamCreatecontentTypesInput;
+  isConfirmed?: Boolean;
 }
 
-export interface VideoUnitUpdateWithWhereUniqueNestedInput {
-  where: VideoUnitWhereUniqueInput;
-  data: VideoUnitUpdateDataInput;
-}
-
-export interface TeamUpdateInput {
+export interface TeamUpdateDataInput {
   name?: String;
   organization?: String;
   members?: UserUpdateManyWithoutTeamInput;
@@ -2447,32 +2559,41 @@ export interface TeamUpdateInput {
   isConfirmed?: Boolean;
 }
 
-export interface VideoStreamSubscriptionWhereInput {
-  mutation_in?: MutationType[] | MutationType;
-  updatedFields_contains?: String;
-  updatedFields_contains_every?: String[] | String;
-  updatedFields_contains_some?: String[] | String;
-  node?: VideoStreamWhereInput;
-  AND?: VideoStreamSubscriptionWhereInput[] | VideoStreamSubscriptionWhereInput;
-  OR?: VideoStreamSubscriptionWhereInput[] | VideoStreamSubscriptionWhereInput;
-  NOT?: VideoStreamSubscriptionWhereInput[] | VideoStreamSubscriptionWhereInput;
+export interface UserCreateManyWithoutTeamInput {
+  create?: UserCreateWithoutTeamInput[] | UserCreateWithoutTeamInput;
+  connect?: UserWhereUniqueInput[] | UserWhereUniqueInput;
 }
 
-export interface UserUpdateManyWithoutTeamInput {
-  create?: UserCreateWithoutTeamInput[] | UserCreateWithoutTeamInput;
-  delete?: UserWhereUniqueInput[] | UserWhereUniqueInput;
-  connect?: UserWhereUniqueInput[] | UserWhereUniqueInput;
-  disconnect?: UserWhereUniqueInput[] | UserWhereUniqueInput;
-  update?:
-    | UserUpdateWithWhereUniqueWithoutTeamInput[]
-    | UserUpdateWithWhereUniqueWithoutTeamInput;
-  upsert?:
-    | UserUpsertWithWhereUniqueWithoutTeamInput[]
-    | UserUpsertWithWhereUniqueWithoutTeamInput;
-  deleteMany?: UserScalarWhereInput[] | UserScalarWhereInput;
-  updateMany?:
-    | UserUpdateManyWithWhereNestedInput[]
-    | UserUpdateManyWithWhereNestedInput;
+export interface VideoProjectUpdateInput {
+  projectType?: String;
+  projectTitle?: String;
+  descPublic?: String;
+  descInternal?: String;
+  author?: String;
+  team?: TeamUpdateOneInput;
+  status?: ProjectPublishStatus;
+  visibility?: ProjectVisibility;
+  protectImages?: Boolean;
+  units?: VideoUnitUpdateManyInput;
+  supportFiles?: SupportFileUpdateManyInput;
+  thumbnails?: ImageFileUpdateManyInput;
+  categories?: CategoryUpdateManyInput;
+  tags?: TagUpdateManyInput;
+}
+
+export interface UserCreateWithoutTeamInput {
+  firstName: String;
+  lastName: String;
+  email: String;
+  password?: String;
+  tempToken?: String;
+  tempTokenExpiry?: Float;
+  jobTitle?: String;
+  country?: String;
+  city?: String;
+  howHeard?: String;
+  permissions?: UserCreatepermissionsInput;
+  isConfirmed?: Boolean;
 }
 
 export interface ImageUseWhereInput {
@@ -2507,22 +2628,6 @@ export interface ImageUseWhereInput {
   AND?: ImageUseWhereInput[] | ImageUseWhereInput;
   OR?: ImageUseWhereInput[] | ImageUseWhereInput;
   NOT?: ImageUseWhereInput[] | ImageUseWhereInput;
-}
-
-export interface UserUpdateWithWhereUniqueWithoutTeamInput {
-  where: UserWhereUniqueInput;
-  data: UserUpdateWithoutTeamDataInput;
-}
-
-export interface TeamSubscriptionWhereInput {
-  mutation_in?: MutationType[] | MutationType;
-  updatedFields_contains?: String;
-  updatedFields_contains_every?: String[] | String;
-  updatedFields_contains_some?: String[] | String;
-  node?: TeamWhereInput;
-  AND?: TeamSubscriptionWhereInput[] | TeamSubscriptionWhereInput;
-  OR?: TeamSubscriptionWhereInput[] | TeamSubscriptionWhereInput;
-  NOT?: TeamSubscriptionWhereInput[] | TeamSubscriptionWhereInput;
 }
 
 export interface ImageFileWhereInput {
@@ -2628,6 +2733,7 @@ export interface ImageFileWhereInput {
   filetype_not_starts_with?: String;
   filetype_ends_with?: String;
   filetype_not_ends_with?: String;
+  use?: ImageUseWhereInput;
   md5?: String;
   md5_not?: String;
   md5_in?: String[] | String;
@@ -2661,6 +2767,74 @@ export interface ImageFileWhereInput {
   NOT?: ImageFileWhereInput[] | ImageFileWhereInput;
 }
 
+export interface VideoProjectSubscriptionWhereInput {
+  mutation_in?: MutationType[] | MutationType;
+  updatedFields_contains?: String;
+  updatedFields_contains_every?: String[] | String;
+  updatedFields_contains_some?: String[] | String;
+  node?: VideoProjectWhereInput;
+  AND?:
+    | VideoProjectSubscriptionWhereInput[]
+    | VideoProjectSubscriptionWhereInput;
+  OR?:
+    | VideoProjectSubscriptionWhereInput[]
+    | VideoProjectSubscriptionWhereInput;
+  NOT?:
+    | VideoProjectSubscriptionWhereInput[]
+    | VideoProjectSubscriptionWhereInput;
+}
+
+export interface TeamCreatecontentTypesInput {
+  set?: ContentType[] | ContentType;
+}
+
+export interface ThumbnailSubscriptionWhereInput {
+  mutation_in?: MutationType[] | MutationType;
+  updatedFields_contains?: String;
+  updatedFields_contains_every?: String[] | String;
+  updatedFields_contains_some?: String[] | String;
+  node?: ThumbnailWhereInput;
+  AND?: ThumbnailSubscriptionWhereInput[] | ThumbnailSubscriptionWhereInput;
+  OR?: ThumbnailSubscriptionWhereInput[] | ThumbnailSubscriptionWhereInput;
+  NOT?: ThumbnailSubscriptionWhereInput[] | ThumbnailSubscriptionWhereInput;
+}
+
+export interface TeamUpdateInput {
+  name?: String;
+  organization?: String;
+  members?: UserUpdateManyWithoutTeamInput;
+  contentTypes?: TeamUpdatecontentTypesInput;
+  isConfirmed?: Boolean;
+}
+
+export interface TagSubscriptionWhereInput {
+  mutation_in?: MutationType[] | MutationType;
+  updatedFields_contains?: String;
+  updatedFields_contains_every?: String[] | String;
+  updatedFields_contains_some?: String[] | String;
+  node?: TagWhereInput;
+  AND?: TagSubscriptionWhereInput[] | TagSubscriptionWhereInput;
+  OR?: TagSubscriptionWhereInput[] | TagSubscriptionWhereInput;
+  NOT?: TagSubscriptionWhereInput[] | TagSubscriptionWhereInput;
+}
+
+export interface UserUpdateManyWithoutTeamInput {
+  create?: UserCreateWithoutTeamInput[] | UserCreateWithoutTeamInput;
+  delete?: UserWhereUniqueInput[] | UserWhereUniqueInput;
+  connect?: UserWhereUniqueInput[] | UserWhereUniqueInput;
+  disconnect?: UserWhereUniqueInput[] | UserWhereUniqueInput;
+  update?:
+    | UserUpdateWithWhereUniqueWithoutTeamInput[]
+    | UserUpdateWithWhereUniqueWithoutTeamInput;
+  upsert?:
+    | UserUpsertWithWhereUniqueWithoutTeamInput[]
+    | UserUpsertWithWhereUniqueWithoutTeamInput;
+  deleteMany?: UserScalarWhereInput[] | UserScalarWhereInput;
+  updateMany?:
+    | UserUpdateManyWithWhereNestedInput[]
+    | UserUpdateManyWithWhereNestedInput;
+}
+
 export interface LanguageTranslationSubscriptionWhereInput {
   mutation_in?: MutationType[] | MutationType;
   updatedFields_contains?: String;
@@ -2678,8 +2852,9 @@ export interface LanguageTranslationSubscriptionWhereInput {
     | LanguageTranslationSubscriptionWhereInput;
 }
 
-export interface UserUpdatepermissionsInput {
-  set?: Permission[] | Permission;
+export interface UserUpdateWithWhereUniqueWithoutTeamInput {
+  where: UserWhereUniqueInput;
+  data: UserUpdateWithoutTeamDataInput;
 }
 
 export interface ImageFileSubscriptionWhereInput {
@@ -2693,14 +2868,84 @@ export interface ImageFileSubscriptionWhereInput {
   NOT?: ImageFileSubscriptionWhereInput[] | ImageFileSubscriptionWhereInput;
 }
 
+export interface UserUpdateWithoutTeamDataInput {
+  firstName?: String;
+  lastName?: String;
+  email?: String;
+  password?: String;
+  tempToken?: String;
+  tempTokenExpiry?: Float;
+  jobTitle?: String;
+  country?: String;
+  city?: String;
+  howHeard?: String;
+  permissions?: UserUpdatepermissionsInput;
+  isConfirmed?: Boolean;
+}
+
+export interface SupportFileUseWhereInput {
+  id?: ID_Input;
+  id_not?: ID_Input;
+  id_in?: ID_Input[] | ID_Input;
+  id_not_in?: ID_Input[] | ID_Input;
+  id_lt?: ID_Input;
+  id_lte?: ID_Input;
+  id_gt?: ID_Input;
+  id_gte?: ID_Input;
+  id_contains?: ID_Input;
+  id_not_contains?: ID_Input;
+  id_starts_with?: ID_Input;
+  id_not_starts_with?: ID_Input;
+  id_ends_with?: ID_Input;
+  id_not_ends_with?: ID_Input;
+  name?: String;
+  name_not?: String;
+  name_in?: String[] | String;
+  name_not_in?: String[] | String;
+  name_lt?: String;
+  name_lte?: String;
+  name_gt?: String;
+  name_gte?: String;
+  name_contains?: String;
+  name_not_contains?: String;
+  name_starts_with?: String;
+  name_not_starts_with?: String;
+  name_ends_with?: String;
+  name_not_ends_with?: String;
+  AND?: SupportFileUseWhereInput[] | SupportFileUseWhereInput;
+  OR?: SupportFileUseWhereInput[] | SupportFileUseWhereInput;
+  NOT?: SupportFileUseWhereInput[] | SupportFileUseWhereInput;
+}
+
+export interface UserUpdatepermissionsInput {
+  set?: Permission[] | Permission;
+}
+
+export interface VideoUnitUpdateInput {
+  language?: LanguageUpdateOneInput;
+  title?: String;
+  descPublic?: String;
+  files?: VideoFileUpdateManyInput;
+  tags?: TagUpdateManyInput;
+  categories?: CategoryUpdateManyInput;
+  thumbnails?: ThumbnailUpdateManyInput;
+}
+
 export interface UserUpsertWithWhereUniqueWithoutTeamInput {
   where: UserWhereUniqueInput;
   update: UserUpdateWithoutTeamDataInput;
   create: UserCreateWithoutTeamInput;
 }
 
-export interface VideoUseUpdateManyMutationInput {
-  name?: String;
+export interface VideoProjectUpdateManyMutationInput {
+  projectType?: String;
+  projectTitle?: String;
+  descPublic?: String;
+  descInternal?: String;
+  author?: String;
+  status?: ProjectPublishStatus;
+  visibility?: ProjectVisibility;
+  protectImages?: Boolean;
 }
 
 export interface UserScalarWhereInput {
@@ -2859,21 +3104,6 @@ export interface UserScalarWhereInput {
   NOT?: UserScalarWhereInput[] | UserScalarWhereInput;
 }
 
-export interface VideoUnitUpdateInput {
-  language?: LanguageUpdateOneInput;
-  title?: String;
-  descPublic?: String;
-  files?: VideoFileUpdateManyInput;
-  tags?: TagUpdateManyInput;
-  categories?: CategoryUpdateManyInput;
-  thumbnails?: ThumbnailUpdateManyInput;
-}
-
-export interface UserUpdateManyWithWhereNestedInput {
-  where: UserScalarWhereInput;
-  data: UserUpdateManyDataInput;
-}
-
 export interface TagWhereInput {
   id?: ID_Input;
   id_not?: ID_Input;
@@ -2897,6 +3127,28 @@ export interface TagWhereInput {
   NOT?: TagWhereInput[] | TagWhereInput;
 }
 
+export interface UserUpdateManyWithWhereNestedInput {
+  where: UserScalarWhereInput;
+  data: UserUpdateManyDataInput;
+}
+
+export interface ImageFileUpdateManyInput {
+  create?: ImageFileCreateInput[] | ImageFileCreateInput;
+  update?:
+    | ImageFileUpdateWithWhereUniqueNestedInput[]
+    | ImageFileUpdateWithWhereUniqueNestedInput;
+  upsert?:
+    | ImageFileUpsertWithWhereUniqueNestedInput[]
+    | ImageFileUpsertWithWhereUniqueNestedInput;
+  delete?: ImageFileWhereUniqueInput[] | ImageFileWhereUniqueInput;
+  connect?: ImageFileWhereUniqueInput[] | ImageFileWhereUniqueInput;
+  disconnect?: ImageFileWhereUniqueInput[] | ImageFileWhereUniqueInput;
+  deleteMany?: ImageFileScalarWhereInput[] | ImageFileScalarWhereInput;
+  updateMany?:
+    | ImageFileUpdateManyWithWhereNestedInput[]
+    | ImageFileUpdateManyWithWhereNestedInput;
+}
+
 export interface UserUpdateManyDataInput {
   firstName?: String;
   lastName?: String;
@@ -2910,144 +3162,6 @@ export interface UserUpdateManyDataInput {
   howHeard?: String;
   permissions?: UserUpdatepermissionsInput;
   isConfirmed?: Boolean;
-}
-
-export interface ImageFileScalarWhereInput {
-  id?: ID_Input;
-  id_not?: ID_Input;
-  id_in?: ID_Input[] | ID_Input;
-  id_not_in?: ID_Input[] | ID_Input;
-  id_lt?: ID_Input;
-  id_lte?: ID_Input;
-  id_gt?: ID_Input;
-  id_gte?: ID_Input;
-  id_contains?: ID_Input;
-  id_not_contains?: ID_Input;
-  id_starts_with?: ID_Input;
-  id_not_starts_with?: ID_Input;
-  id_ends_with?: ID_Input;
-  id_not_ends_with?: ID_Input;
-  createdAt?: DateTimeInput;
-  createdAt_not?: DateTimeInput;
-  createdAt_in?: DateTimeInput[] | DateTimeInput;
-  createdAt_not_in?: DateTimeInput[] | DateTimeInput;
-  createdAt_lt?: DateTimeInput;
-  createdAt_lte?: DateTimeInput;
-  createdAt_gt?: DateTimeInput;
-  createdAt_gte?: DateTimeInput;
-  updatedAt?: DateTimeInput;
-  updatedAt_not?: DateTimeInput;
-  updatedAt_in?: DateTimeInput[] | DateTimeInput;
-  updatedAt_not_in?: DateTimeInput[] | DateTimeInput;
-  updatedAt_lt?: DateTimeInput;
-  updatedAt_lte?: DateTimeInput;
-  updatedAt_gt?: DateTimeInput;
-  updatedAt_gte?: DateTimeInput;
-  alt?: String;
-  alt_not?: String;
-  alt_in?: String[] | String;
-  alt_not_in?: String[] | String;
-  alt_lt?: String;
-  alt_lte?: String;
-  alt_gt?: String;
-  alt_gte?: String;
-  alt_contains?: String;
-  alt_not_contains?: String;
-  alt_starts_with?: String;
-  alt_not_starts_with?: String;
-  alt_ends_with?: String;
-  alt_not_ends_with?: String;
-  longdesc?: String;
-  longdesc_not?: String;
-  longdesc_in?: String[] | String;
-  longdesc_not_in?: String[] | String;
-  longdesc_lt?: String;
-  longdesc_lte?: String;
-  longdesc_gt?: String;
-  longdesc_gte?: String;
-  longdesc_contains?: String;
-  longdesc_not_contains?: String;
-  longdesc_starts_with?: String;
-  longdesc_not_starts_with?: String;
-  longdesc_ends_with?: String;
-  longdesc_not_ends_with?: String;
-  caption?: String;
-  caption_not?: String;
-  caption_in?: String[] | String;
-  caption_not_in?: String[] | String;
-  caption_lt?: String;
-  caption_lte?: String;
-  caption_gt?: String;
-  caption_gte?: String;
-  caption_contains?: String;
-  caption_not_contains?: String;
-  caption_starts_with?: String;
-  caption_not_starts_with?: String;
-  caption_ends_with?: String;
-  caption_not_ends_with?: String;
-  filename?: String;
-  filename_not?: String;
-  filename_in?: String[] | String;
-  filename_not_in?: String[] | String;
-  filename_lt?: String;
-  filename_lte?: String;
-  filename_gt?: String;
-  filename_gte?: String;
-  filename_contains?: String;
-  filename_not_contains?: String;
-  filename_starts_with?: String;
-  filename_not_starts_with?: String;
-  filename_ends_with?: String;
-  filename_not_ends_with?: String;
-  filetype?: String;
-  filetype_not?: String;
-  filetype_in?: String[] | String;
-  filetype_not_in?: String[] | String;
-  filetype_lt?: String;
-  filetype_lte?: String;
-  filetype_gt?: String;
-  filetype_gte?: String;
-  filetype_contains?: String;
-  filetype_not_contains?: String;
-  filetype_starts_with?: String;
-  filetype_not_starts_with?: String;
-  filetype_ends_with?: String;
-  filetype_not_ends_with?: String;
-  md5?: String;
-  md5_not?: String;
-  md5_in?: String[] | String;
-  md5_not_in?: String[] | String;
-  md5_lt?: String;
-  md5_lte?: String;
-  md5_gt?: String;
-  md5_gte?: String;
-  md5_contains?: String;
-  md5_not_contains?: String;
-  md5_starts_with?: String;
-  md5_not_starts_with?: String;
-  md5_ends_with?: String;
-  md5_not_ends_with?: String;
-  url?: String;
-  url_not?: String;
-  url_in?: String[] | String;
-  url_not_in?: String[] | String;
-  url_lt?: String;
-  url_lte?: String;
-  url_gt?: String;
-  url_gte?: String;
-  url_contains?: String;
-  url_not_contains?: String;
-  url_starts_with?: String;
-  url_not_starts_with?: String;
-  url_ends_with?: String;
-  url_not_ends_with?: String;
-  AND?: ImageFileScalarWhereInput[] | ImageFileScalarWhereInput;
-  OR?: ImageFileScalarWhereInput[] | ImageFileScalarWhereInput;
-  NOT?: ImageFileScalarWhereInput[] | ImageFileScalarWhereInput;
-}
-
-export interface TeamUpdatecontentTypesInput {
-  set?: ContentType[] | ContentType;
 }
 
 export interface TeamWhereInput {
@@ -3103,6 +3217,14 @@ export interface TeamWhereInput {
   NOT?: TeamWhereInput[] | TeamWhereInput;
 }
 
+export interface TeamUpdatecontentTypesInput {
+  set?: ContentType[] | ContentType;
+}
+
+export type DimensionsWhereUniqueInput = AtLeastOne<{
+  id: ID_Input;
+}>;
+
 export interface TeamUpdateManyMutationInput {
   name?: String;
   organization?: String;
@@ -3110,24 +3232,26 @@ export interface TeamUpdateManyMutationInput {
   isConfirmed?: Boolean;
 }
 
-export type DimensionsWhereUniqueInput = AtLeastOne<{
-  id: ID_Input;
-}>;
+export interface SupportFileUpdateManyInput {
+  create?: SupportFileCreateInput[] | SupportFileCreateInput;
+  update?:
+    | SupportFileUpdateWithWhereUniqueNestedInput[]
+    | SupportFileUpdateWithWhereUniqueNestedInput;
+  upsert?:
+    | SupportFileUpsertWithWhereUniqueNestedInput[]
+    | SupportFileUpsertWithWhereUniqueNestedInput;
+  delete?: SupportFileWhereUniqueInput[] | SupportFileWhereUniqueInput;
+  connect?: SupportFileWhereUniqueInput[] | SupportFileWhereUniqueInput;
+  disconnect?: SupportFileWhereUniqueInput[] | SupportFileWhereUniqueInput;
+  deleteMany?: SupportFileScalarWhereInput[] | SupportFileScalarWhereInput;
+  updateMany?:
+    | SupportFileUpdateManyWithWhereNestedInput[]
+    | SupportFileUpdateManyWithWhereNestedInput;
+}
 
 export interface ThumbnailCreateInput {
   size?: ThumbnailSize;
   image?: ImageFileCreateOneInput;
-}
-
-export interface SupportFileUpsertWithWhereUniqueNestedInput {
-  where: SupportFileWhereUniqueInput;
-  update: SupportFileUpdateDataInput;
-  create: SupportFileCreateInput;
-}
-
-export interface ImageFileCreateOneInput {
-  create?: ImageFileCreateInput;
-  connect?: ImageFileWhereUniqueInput;
 }
 
 export interface ThumbnailWhereInput {
@@ -3155,57 +3279,24 @@ export interface ThumbnailWhereInput {
   NOT?: ThumbnailWhereInput[] | ThumbnailWhereInput;
 }
 
+export interface ImageFileCreateOneInput {
+  create?: ImageFileCreateInput;
+  connect?: ImageFileWhereUniqueInput;
+}
+
+export interface ThumbnailUpdateManyWithWhereNestedInput {
+  where: ThumbnailScalarWhereInput;
+  data: ThumbnailUpdateManyDataInput;
+}
+
 export interface ThumbnailUpdateInput {
   size?: ThumbnailSize;
   image?: ImageFileUpdateOneInput;
 }
 
-export interface VideoUnitScalarWhereInput {
-  id?: ID_Input;
-  id_not?: ID_Input;
-  id_in?: ID_Input[] | ID_Input;
-  id_not_in?: ID_Input[] | ID_Input;
-  id_lt?: ID_Input;
-  id_lte?: ID_Input;
-  id_gt?: ID_Input;
-  id_gte?: ID_Input;
-  id_contains?: ID_Input;
-  id_not_contains?: ID_Input;
-  id_starts_with?: ID_Input;
-  id_not_starts_with?: ID_Input;
-  id_ends_with?: ID_Input;
-  id_not_ends_with?: ID_Input;
-  title?: String;
-  title_not?: String;
-  title_in?: String[] | String;
-  title_not_in?: String[] | String;
-  title_lt?: String;
-  title_lte?: String;
-  title_gt?: String;
-  title_gte?: String;
-  title_contains?: String;
-  title_not_contains?: String;
-  title_starts_with?: String;
-  title_not_starts_with?: String;
-  title_ends_with?: String;
-  title_not_ends_with?: String;
-  descPublic?: String;
-  descPublic_not?: String;
-  descPublic_in?: String[] | String;
-  descPublic_not_in?: String[] | String;
-  descPublic_lt?: String;
-  descPublic_lte?: String;
-  descPublic_gt?: String;
-  descPublic_gte?: String;
-  descPublic_contains?: String;
-  descPublic_not_contains?: String;
-  descPublic_starts_with?: String;
-  descPublic_not_starts_with?: String;
-  descPublic_ends_with?: String;
-  descPublic_not_ends_with?: String;
-  AND?: VideoUnitScalarWhereInput[] | VideoUnitScalarWhereInput;
-  OR?: VideoUnitScalarWhereInput[] | VideoUnitScalarWhereInput;
-  NOT?: VideoUnitScalarWhereInput[] | VideoUnitScalarWhereInput;
+export interface ThumbnailUpdateDataInput {
+  size?: ThumbnailSize;
+  image?: ImageFileUpdateOneInput;
 }
 
 export interface ImageFileUpdateOneInput {
@@ -3217,34 +3308,7 @@ export interface ImageFileUpdateOneInput {
   connect?: ImageFileWhereUniqueInput;
 }
 
-export interface ThumbnailUpdateManyWithWhereNestedInput {
-  where: ThumbnailScalarWhereInput;
-  data: ThumbnailUpdateManyDataInput;
-}
-
-export interface ImageFileUpdateDataInput {
-  language?: LanguageUpdateOneInput;
-  dimensions?: DimensionsUpdateOneInput;
-  alt?: String;
-  longdesc?: String;
-  caption?: String;
-  filename?: String;
-  filetype?: String;
-  md5?: String;
-  url?: String;
-}
-
-export interface ThumbnailUpdateDataInput {
-  size?: ThumbnailSize;
-  image?: ImageFileUpdateOneInput;
-}
-
-export interface ImageFileUpsertNestedInput {
-  update: ImageFileUpdateDataInput;
-  create: ImageFileCreateInput;
-}
-
-export interface VideoUseWhereInput {
+export interface CategoryScalarWhereInput {
   id?: ID_Input;
   id_not?: ID_Input;
   id_in?: ID_Input[] | ID_Input;
@@ -3259,33 +3323,53 @@ export interface VideoUseWhereInput {
   id_not_starts_with?: ID_Input;
   id_ends_with?: ID_Input;
   id_not_ends_with?: ID_Input;
-  name?: String;
-  name_not?: String;
-  name_in?: String[] | String;
-  name_not_in?: String[] | String;
-  name_lt?: String;
-  name_lte?: String;
-  name_gt?: String;
-  name_gte?: String;
-  name_contains?: String;
-  name_not_contains?: String;
-  name_starts_with?: String;
-  name_not_starts_with?: String;
-  name_ends_with?: String;
-  name_not_ends_with?: String;
-  AND?: VideoUseWhereInput[] | VideoUseWhereInput;
-  OR?: VideoUseWhereInput[] | VideoUseWhereInput;
-  NOT?: VideoUseWhereInput[] | VideoUseWhereInput;
+  AND?: CategoryScalarWhereInput[] | CategoryScalarWhereInput;
+  OR?: CategoryScalarWhereInput[] | CategoryScalarWhereInput;
+  NOT?: CategoryScalarWhereInput[] | CategoryScalarWhereInput;
+}
+
+export interface ImageFileUpdateDataInput {
+  language?: LanguageUpdateOneInput;
+  dimensions?: DimensionsUpdateOneInput;
+  alt?: String;
+  longdesc?: String;
+  caption?: String;
+  filename?: String;
+  filetype?: String;
+  use?: ImageUseUpdateOneInput;
+  md5?: String;
+  url?: String;
+}
+
+export interface CategoryUpdateDataInput {
+  translations?: LanguageTranslationUpdateManyInput;
+}
+
+export interface ImageFileUpsertNestedInput {
+  update: ImageFileUpdateDataInput;
+  create: ImageFileCreateInput;
+}
+
+export interface CategoryUpdateManyInput {
+  create?: CategoryCreateInput[] | CategoryCreateInput;
+  update?:
+    | CategoryUpdateWithWhereUniqueNestedInput[]
+    | CategoryUpdateWithWhereUniqueNestedInput;
+  upsert?:
+    | CategoryUpsertWithWhereUniqueNestedInput[]
+    | CategoryUpsertWithWhereUniqueNestedInput;
+  delete?: CategoryWhereUniqueInput[] | CategoryWhereUniqueInput;
+  connect?: CategoryWhereUniqueInput[] | CategoryWhereUniqueInput;
+  disconnect?: CategoryWhereUniqueInput[] | CategoryWhereUniqueInput;
+  deleteMany?: CategoryScalarWhereInput[] | CategoryScalarWhereInput;
 }
 
 export interface ThumbnailUpdateManyMutationInput {
   size?: ThumbnailSize;
 }
 
-export interface CategoryUpsertWithWhereUniqueNestedInput {
-  where: CategoryWhereUniqueInput;
-  update: CategoryUpdateDataInput;
-  create: CategoryCreateInput;
+export interface TagUpdateDataInput {
+  translations?: LanguageTranslationUpdateManyInput;
 }
 
 export interface UserCreateInput {
@@ -3304,64 +3388,99 @@ export interface UserCreateInput {
   isConfirmed?: Boolean;
 }
 
-export interface CategoryUpdateManyInput {
-  create?: CategoryCreateInput[] | CategoryCreateInput;
-  update?:
-    | CategoryUpdateWithWhereUniqueNestedInput[]
-    | CategoryUpdateWithWhereUniqueNestedInput;
-  upsert?:
-    | CategoryUpsertWithWhereUniqueNestedInput[]
-    | CategoryUpsertWithWhereUniqueNestedInput;
-  delete?: CategoryWhereUniqueInput[] | CategoryWhereUniqueInput;
-  connect?: CategoryWhereUniqueInput[] | CategoryWhereUniqueInput;
-  disconnect?: CategoryWhereUniqueInput[] | CategoryWhereUniqueInput;
-  deleteMany?: CategoryScalarWhereInput[] | CategoryScalarWhereInput;
+export interface LanguageWhereInput {
+  id?: ID_Input;
+  id_not?: ID_Input;
+  id_in?: ID_Input[] | ID_Input;
+  id_not_in?: ID_Input[] | ID_Input;
+  id_lt?: ID_Input;
+  id_lte?: ID_Input;
+  id_gt?: ID_Input;
+  id_gte?: ID_Input;
+  id_contains?: ID_Input;
+  id_not_contains?: ID_Input;
+  id_starts_with?: ID_Input;
+  id_not_starts_with?: ID_Input;
+  id_ends_with?: ID_Input;
+  id_not_ends_with?: ID_Input;
+  languageCode?: String;
+  languageCode_not?: String;
+  languageCode_in?: String[] | String;
+  languageCode_not_in?: String[] | String;
+  languageCode_lt?: String;
+  languageCode_lte?: String;
+  languageCode_gt?: String;
+  languageCode_gte?: String;
+  languageCode_contains?: String;
+  languageCode_not_contains?: String;
+  languageCode_starts_with?: String;
+  languageCode_not_starts_with?: String;
+  languageCode_ends_with?: String;
+  languageCode_not_ends_with?: String;
+  locale?: String;
+  locale_not?: String;
+  locale_in?: String[] | String;
+  locale_not_in?: String[] | String;
+  locale_lt?: String;
+  locale_lte?: String;
+  locale_gt?: String;
+  locale_gte?: String;
+  locale_contains?: String;
+  locale_not_contains?: String;
+  locale_starts_with?: String;
+  locale_not_starts_with?: String;
+  locale_ends_with?: String;
+  locale_not_ends_with?: String;
+  textDirection?: String;
+  textDirection_not?: String;
+  textDirection_in?: String[] | String;
+  textDirection_not_in?: String[] | String;
+  textDirection_lt?: String;
+  textDirection_lte?: String;
+  textDirection_gt?: String;
+  textDirection_gte?: String;
+  textDirection_contains?: String;
+  textDirection_not_contains?: String;
+  textDirection_starts_with?: String;
+  textDirection_not_starts_with?: String;
+  textDirection_ends_with?: String;
+  textDirection_not_ends_with?: String;
+  displayName?: String;
+  displayName_not?: String;
+  displayName_in?: String[] | String;
+  displayName_not_in?: String[] | String;
+  displayName_lt?: String;
+  displayName_lte?: String;
+  displayName_gt?: String;
+  displayName_gte?: String;
+  displayName_contains?: String;
+  displayName_not_contains?: String;
+  displayName_starts_with?: String;
+  displayName_not_starts_with?: String;
+  displayName_ends_with?: String;
+  displayName_not_ends_with?: String;
+  nativeName?: String;
+  nativeName_not?: String;
+  nativeName_in?: String[] | String;
+  nativeName_not_in?: String[] | String;
+  nativeName_lt?: String;
+  nativeName_lte?: String;
+  nativeName_gt?: String;
+  nativeName_gte?: String;
+  nativeName_contains?: String;
+  nativeName_not_contains?: String;
+  nativeName_starts_with?: String;
+  nativeName_not_starts_with?: String;
+  nativeName_ends_with?: String;
+  nativeName_not_ends_with?: String;
+  AND?: LanguageWhereInput[] | LanguageWhereInput;
+  OR?: LanguageWhereInput[] | LanguageWhereInput;
+  NOT?: LanguageWhereInput[] | LanguageWhereInput;
 }
 
 export interface TeamCreateOneWithoutMembersInput {
   create?: TeamCreateWithoutMembersInput;
   connect?: TeamWhereUniqueInput;
-}
-
-export interface TagUpdateDataInput {
-  translations?: LanguageTranslationUpdateManyInput;
-}
-
-export interface TeamCreateWithoutMembersInput {
-  name: String;
-  organization: String;
-  contentTypes?: TeamCreatecontentTypesInput;
-  isConfirmed?: Boolean;
-}
-
-export interface TagUpdateManyInput {
-  create?: TagCreateInput[] | TagCreateInput;
-  update?:
-    | TagUpdateWithWhereUniqueNestedInput[]
-    | TagUpdateWithWhereUniqueNestedInput;
-  upsert?:
-    | TagUpsertWithWhereUniqueNestedInput[]
-    | TagUpsertWithWhereUniqueNestedInput;
-  delete?: TagWhereUniqueInput[] | TagWhereUniqueInput;
-  connect?: TagWhereUniqueInput[] | TagWhereUniqueInput;
-  disconnect?: TagWhereUniqueInput[] | TagWhereUniqueInput;
-  deleteMany?: TagScalarWhereInput[] | TagScalarWhereInput;
-}
-
-export interface UserUpdateInput {
-  firstName?: String;
-  lastName?: String;
-  email?: String;
-  password?: String;
-  tempToken?: String;
-  tempTokenExpiry?: Float;
-  jobTitle?: String;
-  country?: String;
-  city?: String;
-  howHeard?: String;
-  permissions?: UserUpdatepermissionsInput;
-  team?: TeamUpdateOneWithoutMembersInput;
-  isConfirmed?: Boolean;
 }
 
 export interface VideoFileScalarWhereInput {
@@ -3488,13 +3607,11 @@ export interface VideoFileScalarWhereInput {
   NOT?: VideoFileScalarWhereInput[] | VideoFileScalarWhereInput;
 }
 
-export interface TeamUpdateOneWithoutMembersInput {
-  create?: TeamCreateWithoutMembersInput;
-  update?: TeamUpdateWithoutMembersDataInput;
-  upsert?: TeamUpsertWithoutMembersInput;
-  delete?: Boolean;
-  disconnect?: Boolean;
-  connect?: TeamWhereUniqueInput;
+export interface TeamCreateWithoutMembersInput {
+  name: String;
+  organization: String;
+  contentTypes?: TeamCreatecontentTypesInput;
+  isConfirmed?: Boolean;
 }
 
 export interface VideoFileUpdateWithWhereUniqueNestedInput {
@@ -3502,11 +3619,34 @@ export interface VideoFileUpdateWithWhereUniqueNestedInput {
   data: VideoFileUpdateDataInput;
 }
 
-export interface TeamUpdateWithoutMembersDataInput {
-  name?: String;
-  organization?: String;
-  contentTypes?: TeamUpdatecontentTypesInput;
+export interface UserUpdateInput {
+  firstName?: String;
+  lastName?: String;
+  email?: String;
+  password?: String;
+  tempToken?: String;
+  tempTokenExpiry?: Float;
+  jobTitle?: String;
+  country?: String;
+  city?: String;
+  howHeard?: String;
+  permissions?: UserUpdatepermissionsInput;
+  team?: TeamUpdateOneWithoutMembersInput;
   isConfirmed?: Boolean;
+}
+
+export interface VideoUnitUpdateWithWhereUniqueNestedInput {
+  where: VideoUnitWhereUniqueInput;
+  data: VideoUnitUpdateDataInput;
+}
+
+export interface TeamUpdateOneWithoutMembersInput {
+  create?: TeamCreateWithoutMembersInput;
+  update?: TeamUpdateWithoutMembersDataInput;
+  upsert?: TeamUpsertWithoutMembersInput;
+  delete?: Boolean;
+  disconnect?: Boolean;
+  connect?: TeamWhereUniqueInput;
 }
 
 export interface LanguageTranslationWhereInput {
@@ -3544,14 +3684,39 @@ export interface LanguageTranslationWhereInput {
   NOT?: LanguageTranslationWhereInput[] | LanguageTranslationWhereInput;
 }
 
+export interface TeamUpdateWithoutMembersDataInput {
+  name?: String;
+  organization?: String;
+  contentTypes?: TeamUpdatecontentTypesInput;
+  isConfirmed?: Boolean;
+}
+
+export interface VideoFileSubscriptionWhereInput {
+  mutation_in?: MutationType[] | MutationType;
+  updatedFields_contains?: String;
+  updatedFields_contains_every?: String[] | String;
+  updatedFields_contains_some?: String[] | String;
+  node?: VideoFileWhereInput;
+  AND?: VideoFileSubscriptionWhereInput[] | VideoFileSubscriptionWhereInput;
+  OR?: VideoFileSubscriptionWhereInput[] | VideoFileSubscriptionWhereInput;
+  NOT?: VideoFileSubscriptionWhereInput[] | VideoFileSubscriptionWhereInput;
+}
+
 export interface TeamUpsertWithoutMembersInput {
   update: TeamUpdateWithoutMembersDataInput;
   create: TeamCreateWithoutMembersInput;
 }
 
-export type ImageUseWhereUniqueInput = AtLeastOne<{
-  id: ID_Input;
-}>;
+export interface SupportFileSubscriptionWhereInput {
+  mutation_in?: MutationType[] | MutationType;
+  updatedFields_contains?: String;
+  updatedFields_contains_every?: String[] | String;
+  updatedFields_contains_some?: String[] | String;
+  node?: SupportFileWhereInput;
+  AND?: SupportFileSubscriptionWhereInput[] | SupportFileSubscriptionWhereInput;
+  OR?: SupportFileSubscriptionWhereInput[] | SupportFileSubscriptionWhereInput;
+  NOT?: SupportFileSubscriptionWhereInput[] | SupportFileSubscriptionWhereInput;
+}
 
 export interface UserUpdateManyMutationInput {
   firstName?: String;
@@ -3568,15 +3733,15 @@ export interface UserUpdateManyMutationInput {
   isConfirmed?: Boolean;
 }
 
-export interface TagSubscriptionWhereInput {
+export interface CategorySubscriptionWhereInput {
   mutation_in?: MutationType[] | MutationType;
   updatedFields_contains?: String;
   updatedFields_contains_every?: String[] | String;
   updatedFields_contains_some?: String[] | String;
-  node?: TagWhereInput;
-  AND?: TagSubscriptionWhereInput[] | TagSubscriptionWhereInput;
-  OR?: TagSubscriptionWhereInput[] | TagSubscriptionWhereInput;
-  NOT?: TagSubscriptionWhereInput[] | TagSubscriptionWhereInput;
+  node?: CategoryWhereInput;
+  AND?: CategorySubscriptionWhereInput[] | CategorySubscriptionWhereInput;
+  OR?: CategorySubscriptionWhereInput[] | CategorySubscriptionWhereInput;
+  NOT?: CategorySubscriptionWhereInput[] | CategorySubscriptionWhereInput;
 }
 
 export interface VideoFileCreateInput {
@@ -3592,24 +3757,18 @@ export interface VideoFileCreateInput {
   bitrate?: Float;
   filesize?: Float;
   dimensions?: DimensionsCreateOneInput;
-  stream?: VideoStreamCreateOneInput;
+  stream?: VideoStreamCreateManyInput;
 }
 
-export type SupportFileWhereUniqueInput = AtLeastOne<{
-  id: ID_Input;
-}>;
+export interface VideoStreamUpdateManyMutationInput {
+  site?: String;
+  url?: String;
+  embedUrl?: String;
+}
 
 export interface VideoUseCreateOneInput {
   create?: VideoUseCreateInput;
   connect?: VideoUseWhereUniqueInput;
-}
-
-export type TagWhereUniqueInput = AtLeastOne<{
-  id: ID_Input;
-}>;
-
-export interface VideoUseCreateInput {
-  name: String;
 }
 
 export interface ImageFileUpsertWithWhereUniqueNestedInput {
@@ -3618,9 +3777,8 @@ export interface ImageFileUpsertWithWhereUniqueNestedInput {
   create: ImageFileCreateInput;
 }
 
-export interface VideoStreamCreateOneInput {
-  create?: VideoStreamCreateInput;
-  connect?: VideoStreamWhereUniqueInput;
+export interface VideoUseCreateInput {
+  name: String;
 }
 
 export interface SupportFileUpdateManyWithWhereNestedInput {
@@ -3628,10 +3786,9 @@ export interface SupportFileUpdateManyWithWhereNestedInput {
   data: SupportFileUpdateManyDataInput;
 }
 
-export interface VideoStreamCreateInput {
-  site?: String;
-  url?: String;
-  embedUrl?: String;
+export interface VideoStreamCreateManyInput {
+  create?: VideoStreamCreateInput[] | VideoStreamCreateInput;
+  connect?: VideoStreamWhereUniqueInput[] | VideoStreamWhereUniqueInput;
 }
 
 export interface VideoUnitUpdateManyDataInput {
@@ -3639,20 +3796,10 @@ export interface VideoUnitUpdateManyDataInput {
   descPublic?: String;
 }
 
-export interface VideoFileUpdateInput {
-  language?: LanguageUpdateOneInput;
-  filetype?: String;
-  filename?: String;
-  use?: VideoUseUpdateOneInput;
-  quality?: VideoQuality;
-  videoBurnedInStatus?: VideoBurnedInStatus;
+export interface VideoStreamCreateInput {
+  site?: String;
   url?: String;
-  md5?: String;
-  duration?: Float;
-  bitrate?: Float;
-  filesize?: Float;
-  dimensions?: DimensionsUpdateOneInput;
-  stream?: VideoStreamUpdateOneInput;
+  embedUrl?: String;
 }
 
 export interface ThumbnailScalarWhereInput {
@@ -3679,6 +3826,84 @@ export interface ThumbnailScalarWhereInput {
   NOT?: ThumbnailScalarWhereInput[] | ThumbnailScalarWhereInput;
 }
 
+export interface VideoFileUpdateInput {
+  language?: LanguageUpdateOneInput;
+  filetype?: String;
+  filename?: String;
+  use?: VideoUseUpdateOneInput;
+  quality?: VideoQuality;
+  videoBurnedInStatus?: VideoBurnedInStatus;
+  url?: String;
+  md5?: String;
+  duration?: Float;
+  bitrate?: Float;
+  filesize?: Float;
+  dimensions?: DimensionsUpdateOneInput;
+  stream?: VideoStreamUpdateManyInput;
+}
+
+export interface VideoStreamWhereInput {
+  id?: ID_Input;
+  id_not?: ID_Input;
+  id_in?: ID_Input[] | ID_Input;
+  id_not_in?: ID_Input[] | ID_Input;
+  id_lt?: ID_Input;
+  id_lte?: ID_Input;
+  id_gt?: ID_Input;
+  id_gte?: ID_Input;
+  id_contains?: ID_Input;
+  id_not_contains?: ID_Input;
+  id_starts_with?: ID_Input;
+  id_not_starts_with?: ID_Input;
+  id_ends_with?: ID_Input;
+  id_not_ends_with?: ID_Input;
+  site?: String;
+  site_not?: String;
+  site_in?: String[] | String;
+  site_not_in?: String[] | String;
+  site_lt?: String;
+  site_lte?: String;
+  site_gt?: String;
+  site_gte?: String;
+  site_contains?: String;
+  site_not_contains?: String;
+  site_starts_with?: String;
+  site_not_starts_with?: String;
+  site_ends_with?: String;
+  site_not_ends_with?: String;
+  url?: String;
+  url_not?: String;
+  url_in?: String[] | String;
+  url_not_in?: String[] | String;
+  url_lt?: String;
+  url_lte?: String;
+  url_gt?: String;
+  url_gte?: String;
+  url_contains?: String;
+  url_not_contains?: String;
+  url_starts_with?: String;
+  url_not_starts_with?: String;
+  url_ends_with?: String;
+  url_not_ends_with?: String;
+  embedUrl?: String;
+  embedUrl_not?: String;
+  embedUrl_in?: String[] | String;
+  embedUrl_not_in?: String[] | String;
+  embedUrl_lt?: String;
+  embedUrl_lte?: String;
+  embedUrl_gt?: String;
+  embedUrl_gte?: String;
+  embedUrl_contains?: String;
+  embedUrl_not_contains?: String;
+  embedUrl_starts_with?: String;
+  embedUrl_not_starts_with?: String;
+  embedUrl_ends_with?: String;
+  embedUrl_not_ends_with?: String;
+  AND?: VideoStreamWhereInput[] | VideoStreamWhereInput;
+  OR?: VideoStreamWhereInput[] | VideoStreamWhereInput;
+  NOT?: VideoStreamWhereInput[] | VideoStreamWhereInput;
+}
+
 export interface VideoUseUpdateOneInput {
   create?: VideoUseCreateInput;
   update?: VideoUseUpdateDataInput;
@@ -3688,34 +3913,17 @@ export interface VideoUseUpdateOneInput {
   connect?: VideoUseWhereUniqueInput;
 }
 
-export interface CategoryWhereInput {
-  id?: ID_Input;
-  id_not?: ID_Input;
-  id_in?: ID_Input[] | ID_Input;
-  id_not_in?: ID_Input[] | ID_Input;
-  id_lt?: ID_Input;
-  id_lte?: ID_Input;
-  id_gt?: ID_Input;
-  id_gte?: ID_Input;
-  id_contains?: ID_Input;
-  id_not_contains?: ID_Input;
-  id_starts_with?: ID_Input;
-  id_not_starts_with?: ID_Input;
-  id_ends_with?: ID_Input;
-  id_not_ends_with?: ID_Input;
-  translations_every?: LanguageTranslationWhereInput;
-  translations_some?: LanguageTranslationWhereInput;
-  translations_none?: LanguageTranslationWhereInput;
-  AND?: CategoryWhereInput[] | CategoryWhereInput;
-  OR?: CategoryWhereInput[] | CategoryWhereInput;
-  NOT?: CategoryWhereInput[] | CategoryWhereInput;
+export interface TagUpsertWithWhereUniqueNestedInput {
+  where: TagWhereUniqueInput;
+  update: TagUpdateDataInput;
+  create: TagCreateInput;
 }
 
 export interface VideoUseUpdateDataInput {
   name?: String;
 }
 
-export interface VideoUnitWhereInput {
+export interface VideoProjectWhereInput {
   id?: ID_Input;
   id_not?: ID_Input;
   id_in?: ID_Input[] | ID_Input;
@@ -3730,21 +3938,50 @@ export interface VideoUnitWhereInput {
   id_not_starts_with?: ID_Input;
   id_ends_with?: ID_Input;
   id_not_ends_with?: ID_Input;
-  language?: LanguageWhereInput;
-  title?: String;
-  title_not?: String;
-  title_in?: String[] | String;
-  title_not_in?: String[] | String;
-  title_lt?: String;
-  title_lte?: String;
-  title_gt?: String;
-  title_gte?: String;
-  title_contains?: String;
-  title_not_contains?: String;
-  title_starts_with?: String;
-  title_not_starts_with?: String;
-  title_ends_with?: String;
-  title_not_ends_with?: String;
+  createdAt?: DateTimeInput;
+  createdAt_not?: DateTimeInput;
+  createdAt_in?: DateTimeInput[] | DateTimeInput;
+  createdAt_not_in?: DateTimeInput[] | DateTimeInput;
+  createdAt_lt?: DateTimeInput;
+  createdAt_lte?: DateTimeInput;
+  createdAt_gt?: DateTimeInput;
+  createdAt_gte?: DateTimeInput;
+  updatedAt?: DateTimeInput;
+  updatedAt_not?: DateTimeInput;
+  updatedAt_in?: DateTimeInput[] | DateTimeInput;
+  updatedAt_not_in?: DateTimeInput[] | DateTimeInput;
+  updatedAt_lt?: DateTimeInput;
+  updatedAt_lte?: DateTimeInput;
+  updatedAt_gt?: DateTimeInput;
+  updatedAt_gte?: DateTimeInput;
+  projectType?: String;
+  projectType_not?: String;
+  projectType_in?: String[] | String;
+  projectType_not_in?: String[] | String;
+  projectType_lt?: String;
+  projectType_lte?: String;
+  projectType_gt?: String;
+  projectType_gte?: String;
+  projectType_contains?: String;
+  projectType_not_contains?: String;
+  projectType_starts_with?: String;
+  projectType_not_starts_with?: String;
+  projectType_ends_with?: String;
+  projectType_not_ends_with?: String;
+  projectTitle?: String;
+  projectTitle_not?: String;
+  projectTitle_in?: String[] | String;
+  projectTitle_not_in?: String[] | String;
+  projectTitle_lt?: String;
+  projectTitle_lte?: String;
+  projectTitle_gt?: String;
+  projectTitle_gte?: String;
+  projectTitle_contains?: String;
+  projectTitle_not_contains?: String;
+  projectTitle_starts_with?: String;
+  projectTitle_not_starts_with?: String;
+  projectTitle_ends_with?: String;
+  projectTitle_not_ends_with?: String;
   descPublic?: String;
   descPublic_not?: String;
   descPublic_in?: String[] | String;
@@ -3759,39 +3996,68 @@ export interface VideoUnitWhereInput {
   descPublic_not_starts_with?: String;
   descPublic_ends_with?: String;
   descPublic_not_ends_with?: String;
-  files_every?: VideoFileWhereInput;
-  files_some?: VideoFileWhereInput;
-  files_none?: VideoFileWhereInput;
-  tags_every?: TagWhereInput;
-  tags_some?: TagWhereInput;
-  tags_none?: TagWhereInput;
+  descInternal?: String;
+  descInternal_not?: String;
+  descInternal_in?: String[] | String;
+  descInternal_not_in?: String[] | String;
+  descInternal_lt?: String;
+  descInternal_lte?: String;
+  descInternal_gt?: String;
+  descInternal_gte?: String;
+  descInternal_contains?: String;
+  descInternal_not_contains?: String;
+  descInternal_starts_with?: String;
+  descInternal_not_starts_with?: String;
+  descInternal_ends_with?: String;
+  descInternal_not_ends_with?: String;
+  author?: String;
+  author_not?: String;
+  author_in?: String[] | String;
+  author_not_in?: String[] | String;
+  author_lt?: String;
+  author_lte?: String;
+  author_gt?: String;
+  author_gte?: String;
+  author_contains?: String;
+  author_not_contains?: String;
+  author_starts_with?: String;
+  author_not_starts_with?: String;
+  author_ends_with?: String;
+  author_not_ends_with?: String;
+  team?: TeamWhereInput;
+  status?: ProjectPublishStatus;
+  status_not?: ProjectPublishStatus;
+  status_in?: ProjectPublishStatus[] | ProjectPublishStatus;
+  status_not_in?: ProjectPublishStatus[] | ProjectPublishStatus;
+  visibility?: ProjectVisibility;
+  visibility_not?: ProjectVisibility;
+  visibility_in?: ProjectVisibility[] | ProjectVisibility;
+  visibility_not_in?: ProjectVisibility[] | ProjectVisibility;
+  protectImages?: Boolean;
+  protectImages_not?: Boolean;
+  units_every?: VideoUnitWhereInput;
+  units_some?: VideoUnitWhereInput;
+  units_none?: VideoUnitWhereInput;
+  supportFiles_every?: SupportFileWhereInput;
+  supportFiles_some?: SupportFileWhereInput;
+  supportFiles_none?: SupportFileWhereInput;
+  thumbnails_every?: ImageFileWhereInput;
+  thumbnails_some?: ImageFileWhereInput;
+  thumbnails_none?: ImageFileWhereInput;
   categories_every?: CategoryWhereInput;
   categories_some?: CategoryWhereInput;
   categories_none?: CategoryWhereInput;
-  thumbnails_every?: ThumbnailWhereInput;
-  thumbnails_some?: ThumbnailWhereInput;
-  thumbnails_none?: ThumbnailWhereInput;
-  AND?: VideoUnitWhereInput[] | VideoUnitWhereInput;
-  OR?: VideoUnitWhereInput[] | VideoUnitWhereInput;
-  NOT?: VideoUnitWhereInput[] | VideoUnitWhereInput;
+  tags_every?: TagWhereInput;
+  tags_some?: TagWhereInput;
+  tags_none?: TagWhereInput;
+  AND?: VideoProjectWhereInput[] | VideoProjectWhereInput;
+  OR?: VideoProjectWhereInput[] | VideoProjectWhereInput;
+  NOT?: VideoProjectWhereInput[] | VideoProjectWhereInput;
 }
 
 export interface VideoUseUpsertNestedInput {
   update: VideoUseUpdateDataInput;
   create: VideoUseCreateInput;
-}
-
-export type VideoStreamWhereUniqueInput = AtLeastOne<{
-  id: ID_Input;
-}>;
-
-export interface VideoStreamUpdateOneInput {
-  create?: VideoStreamCreateInput;
-  update?: VideoStreamUpdateDataInput;
-  upsert?: VideoStreamUpsertNestedInput;
-  delete?: Boolean;
-  disconnect?: Boolean;
-  connect?: VideoStreamWhereUniqueInput;
 }
 
 export interface VideoUnitUpdateDataInput {
@@ -3804,30 +4070,193 @@ export interface VideoUnitUpdateDataInput {
   thumbnails?: ThumbnailUpdateManyInput;
 }
 
+export interface VideoStreamUpdateManyInput {
+  create?: VideoStreamCreateInput[] | VideoStreamCreateInput;
+  update?:
+    | VideoStreamUpdateWithWhereUniqueNestedInput[]
+    | VideoStreamUpdateWithWhereUniqueNestedInput;
+  upsert?:
+    | VideoStreamUpsertWithWhereUniqueNestedInput[]
+    | VideoStreamUpsertWithWhereUniqueNestedInput;
+  delete?: VideoStreamWhereUniqueInput[] | VideoStreamWhereUniqueInput;
+  connect?: VideoStreamWhereUniqueInput[] | VideoStreamWhereUniqueInput;
+  disconnect?: VideoStreamWhereUniqueInput[] | VideoStreamWhereUniqueInput;
+  deleteMany?: VideoStreamScalarWhereInput[] | VideoStreamScalarWhereInput;
+  updateMany?:
+    | VideoStreamUpdateManyWithWhereNestedInput[]
+    | VideoStreamUpdateManyWithWhereNestedInput;
+}
+
+export interface TeamUpdateOneInput {
+  create?: TeamCreateInput;
+  update?: TeamUpdateDataInput;
+  upsert?: TeamUpsertNestedInput;
+  delete?: Boolean;
+  disconnect?: Boolean;
+  connect?: TeamWhereUniqueInput;
+}
+
+export interface VideoStreamUpdateWithWhereUniqueNestedInput {
+  where: VideoStreamWhereUniqueInput;
+  data: VideoStreamUpdateDataInput;
+}
+
+export type LanguageWhereUniqueInput = AtLeastOne<{
+  id: ID_Input;
+  locale?: String;
+}>;
+
 export interface VideoStreamUpdateDataInput {
   site?: String;
   url?: String;
   embedUrl?: String;
 }
 
-export interface UserSubscriptionWhereInput {
-  mutation_in?: MutationType[] | MutationType;
-  updatedFields_contains?: String;
-  updatedFields_contains_every?: String[] | String;
-  updatedFields_contains_some?: String[] | String;
-  node?: UserWhereInput;
-  AND?: UserSubscriptionWhereInput[] | UserSubscriptionWhereInput;
-  OR?: UserSubscriptionWhereInput[] | UserSubscriptionWhereInput;
-  NOT?: UserSubscriptionWhereInput[] | UserSubscriptionWhereInput;
+export interface VideoUseUpdateInput {
+  name?: String;
 }
 
-export interface VideoStreamUpsertNestedInput {
+export interface VideoStreamUpsertWithWhereUniqueNestedInput {
+  where: VideoStreamWhereUniqueInput;
   update: VideoStreamUpdateDataInput;
   create: VideoStreamCreateInput;
 }
 
-export interface VideoUseUpdateInput {
+export interface SupportFileUpdateManyDataInput {
+  url?: String;
+  md5?: String;
+  filename?: String;
+  filetype?: String;
+  filesize?: Float;
+}
+
+export interface VideoStreamScalarWhereInput {
+  id?: ID_Input;
+  id_not?: ID_Input;
+  id_in?: ID_Input[] | ID_Input;
+  id_not_in?: ID_Input[] | ID_Input;
+  id_lt?: ID_Input;
+  id_lte?: ID_Input;
+  id_gt?: ID_Input;
+  id_gte?: ID_Input;
+  id_contains?: ID_Input;
+  id_not_contains?: ID_Input;
+  id_starts_with?: ID_Input;
+  id_not_starts_with?: ID_Input;
+  id_ends_with?: ID_Input;
+  id_not_ends_with?: ID_Input;
+  site?: String;
+  site_not?: String;
+  site_in?: String[] | String;
+  site_not_in?: String[] | String;
+  site_lt?: String;
+  site_lte?: String;
+  site_gt?: String;
+  site_gte?: String;
+  site_contains?: String;
+  site_not_contains?: String;
+  site_starts_with?: String;
+  site_not_starts_with?: String;
+  site_ends_with?: String;
+  site_not_ends_with?: String;
+  url?: String;
+  url_not?: String;
+  url_in?: String[] | String;
+  url_not_in?: String[] | String;
+  url_lt?: String;
+  url_lte?: String;
+  url_gt?: String;
+  url_gte?: String;
+  url_contains?: String;
+  url_not_contains?: String;
+  url_starts_with?: String;
+  url_not_starts_with?: String;
+  url_ends_with?: String;
+  url_not_ends_with?: String;
+  embedUrl?: String;
+  embedUrl_not?: String;
+  embedUrl_in?: String[] | String;
+  embedUrl_not_in?: String[] | String;
+  embedUrl_lt?: String;
+  embedUrl_lte?: String;
+  embedUrl_gt?: String;
+  embedUrl_gte?: String;
+  embedUrl_contains?: String;
+  embedUrl_not_contains?: String;
+  embedUrl_starts_with?: String;
+  embedUrl_not_starts_with?: String;
+  embedUrl_ends_with?: String;
+  embedUrl_not_ends_with?: String;
+  AND?: VideoStreamScalarWhereInput[] | VideoStreamScalarWhereInput;
+  OR?: VideoStreamScalarWhereInput[] | VideoStreamScalarWhereInput;
+  NOT?: VideoStreamScalarWhereInput[] | VideoStreamScalarWhereInput;
+}
+
+export interface VideoUnitUpsertWithWhereUniqueNestedInput {
+  where: VideoUnitWhereUniqueInput;
+  update: VideoUnitUpdateDataInput;
+  create: VideoUnitCreateInput;
+}
+
+export interface VideoStreamUpdateManyWithWhereNestedInput {
+  where: VideoStreamScalarWhereInput;
+  data: VideoStreamUpdateManyDataInput;
+}
+
+export interface VideoUseWhereInput {
+  id?: ID_Input;
+  id_not?: ID_Input;
+  id_in?: ID_Input[] | ID_Input;
+  id_not_in?: ID_Input[] | ID_Input;
+  id_lt?: ID_Input;
+  id_lte?: ID_Input;
+  id_gt?: ID_Input;
+  id_gte?: ID_Input;
+  id_contains?: ID_Input;
+  id_not_contains?: ID_Input;
+  id_starts_with?: ID_Input;
+  id_not_starts_with?: ID_Input;
+  id_ends_with?: ID_Input;
+  id_not_ends_with?: ID_Input;
   name?: String;
+  name_not?: String;
+  name_in?: String[] | String;
+  name_not_in?: String[] | String;
+  name_lt?: String;
+  name_lte?: String;
+  name_gt?: String;
+  name_gte?: String;
+  name_contains?: String;
+  name_not_contains?: String;
+  name_starts_with?: String;
+  name_not_starts_with?: String;
+  name_ends_with?: String;
+  name_not_ends_with?: String;
+  AND?: VideoUseWhereInput[] | VideoUseWhereInput;
+  OR?: VideoUseWhereInput[] | VideoUseWhereInput;
+  NOT?: VideoUseWhereInput[] | VideoUseWhereInput;
+}
+
+export interface VideoStreamUpdateManyDataInput {
+  site?: String;
+  url?: String;
+  embedUrl?: String;
+}
+
+export interface VideoFileUpdateDataInput {
+  language?: LanguageUpdateOneInput;
+  filetype?: String;
+  filename?: String;
+  use?: VideoUseUpdateOneInput;
+  quality?: VideoQuality;
+  videoBurnedInStatus?: VideoBurnedInStatus;
+  url?: String;
+  md5?: String;
+  duration?: Float;
+  bitrate?: Float;
+  filesize?: Float;
+  dimensions?: DimensionsUpdateOneInput;
+  stream?: VideoStreamUpdateManyInput;
 }
 
 export interface VideoFileUpdateManyMutationInput {
@@ -3842,9 +4271,15 @@ export interface VideoFileUpdateManyMutationInput {
   filesize?: Float;
 }
 
-export interface ImageFileUpdateWithWhereUniqueNestedInput {
-  where: ImageFileWhereUniqueInput;
-  data: ImageFileUpdateDataInput;
+export interface VideoUnitSubscriptionWhereInput {
+  mutation_in?: MutationType[] | MutationType;
+  updatedFields_contains?: String;
+  updatedFields_contains_every?: String[] | String;
+  updatedFields_contains_some?: String[] | String;
+  node?: VideoUnitWhereInput;
+  AND?: VideoUnitSubscriptionWhereInput[] | VideoUnitSubscriptionWhereInput;
+  OR?: VideoUnitSubscriptionWhereInput[] | VideoUnitSubscriptionWhereInput;
+  NOT?: VideoUnitSubscriptionWhereInput[] | VideoUnitSubscriptionWhereInput;
 }
 
 export interface VideoProjectCreateInput {
@@ -3864,40 +4299,28 @@ export interface VideoProjectCreateInput {
   tags?: TagCreateManyInput;
 }
 
-export interface VideoUnitUpsertWithWhereUniqueNestedInput {
-  where: VideoUnitWhereUniqueInput;
-  update: VideoUnitUpdateDataInput;
-  create: VideoUnitCreateInput;
-}
+export type TagWhereUniqueInput = AtLeastOne<{
+  id: ID_Input;
+}>;
 
 export interface TeamCreateOneInput {
   create?: TeamCreateInput;
   connect?: TeamWhereUniqueInput;
 }
 
-export type VideoProjectWhereUniqueInput = AtLeastOne<{
-  id: ID_Input;
-}>;
-
-export interface VideoUnitCreateManyInput {
-  create?: VideoUnitCreateInput[] | VideoUnitCreateInput;
-  connect?: VideoUnitWhereUniqueInput[] | VideoUnitWhereUniqueInput;
+export interface ThumbnailUpdateWithWhereUniqueNestedInput {
+  where: ThumbnailWhereUniqueInput;
+  data: ThumbnailUpdateDataInput;
 }
 
-export interface VideoFileUpdateDataInput {
-  language?: LanguageUpdateOneInput;
-  filetype?: String;
-  filename?: String;
-  use?: VideoUseUpdateOneInput;
-  quality?: VideoQuality;
-  videoBurnedInStatus?: VideoBurnedInStatus;
-  url?: String;
-  md5?: String;
-  duration?: Float;
-  bitrate?: Float;
-  filesize?: Float;
-  dimensions?: DimensionsUpdateOneInput;
-  stream?: VideoStreamUpdateOneInput;
+export interface TagCreateManyInput {
+  create?: TagCreateInput[] | TagCreateInput;
+  connect?: TagWhereUniqueInput[] | TagWhereUniqueInput;
+}
+
+export interface VideoFileCreateManyInput {
+  create?: VideoFileCreateInput[] | VideoFileCreateInput;
+  connect?: VideoFileWhereUniqueInput[] | VideoFileWhereUniqueInput;
 }
 
 export interface VideoUnitCreateInput {
@@ -3910,13 +4333,23 @@ export interface VideoUnitCreateInput {
   thumbnails?: ThumbnailCreateManyInput;
 }
 
-export type LanguageTranslationWhereUniqueInput = AtLeastOne<{
-  id: ID_Input;
-}>;
+export interface VideoUnitCreateManyInput {
+  create?: VideoUnitCreateInput[] | VideoUnitCreateInput;
+  connect?: VideoUnitWhereUniqueInput[] | VideoUnitWhereUniqueInput;
+}
 
-export interface VideoFileCreateManyInput {
-  create?: VideoFileCreateInput[] | VideoFileCreateInput;
-  connect?: VideoFileWhereUniqueInput[] | VideoFileWhereUniqueInput;
+export interface TagUpdateManyInput {
+  create?: TagCreateInput[] | TagCreateInput;
+  update?:
+    | TagUpdateWithWhereUniqueNestedInput[]
+    | TagUpdateWithWhereUniqueNestedInput;
+  upsert?:
+    | TagUpsertWithWhereUniqueNestedInput[]
+    | TagUpsertWithWhereUniqueNestedInput;
+  delete?: TagWhereUniqueInput[] | TagWhereUniqueInput;
+  connect?: TagWhereUniqueInput[] | TagWhereUniqueInput;
+  disconnect?: TagWhereUniqueInput[] | TagWhereUniqueInput;
+  deleteMany?: TagScalarWhereInput[] | TagScalarWhereInput;
 }
 
 export interface SupportFileUpdateDataInput {
@@ -3926,154 +4359,23 @@ export interface SupportFileUpdateDataInput {
   filename?: String;
   filetype?: String;
   filesize?: Float;
+  use?: SupportFileUseUpdateOneInput;
 }
 
-export interface SupportFileCreateManyInput {
-  create?: SupportFileCreateInput[] | SupportFileCreateInput;
-  connect?: SupportFileWhereUniqueInput[] | SupportFileWhereUniqueInput;
-}
-
-export interface ThumbnailCreateManyInput {
-  create?: ThumbnailCreateInput[] | ThumbnailCreateInput;
-  connect?: ThumbnailWhereUniqueInput[] | ThumbnailWhereUniqueInput;
-}
-
-export interface CategoryCreateManyInput {
-  create?: CategoryCreateInput[] | CategoryCreateInput;
-  connect?: CategoryWhereUniqueInput[] | CategoryWhereUniqueInput;
-}
-
-export interface TagCreateManyInput {
-  create?: TagCreateInput[] | TagCreateInput;
-  connect?: TagWhereUniqueInput[] | TagWhereUniqueInput;
-}
-
-export interface ThumbnailUpdateManyInput {
-  create?: ThumbnailCreateInput[] | ThumbnailCreateInput;
-  update?:
-    | ThumbnailUpdateWithWhereUniqueNestedInput[]
-    | ThumbnailUpdateWithWhereUniqueNestedInput;
-  upsert?:
-    | ThumbnailUpsertWithWhereUniqueNestedInput[]
-    | ThumbnailUpsertWithWhereUniqueNestedInput;
-  delete?: ThumbnailWhereUniqueInput[] | ThumbnailWhereUniqueInput;
-  connect?: ThumbnailWhereUniqueInput[] | ThumbnailWhereUniqueInput;
-  disconnect?: ThumbnailWhereUniqueInput[] | ThumbnailWhereUniqueInput;
-  deleteMany?: ThumbnailScalarWhereInput[] | ThumbnailScalarWhereInput;
-  updateMany?:
-    | ThumbnailUpdateManyWithWhereNestedInput[]
-    | ThumbnailUpdateManyWithWhereNestedInput;
-}
-
-export interface ImageFileUpdateManyDataInput {
-  alt?: String;
-  longdesc?: String;
-  caption?: String;
-  filename?: String;
-  filetype?: String;
-  md5?: String;
-  url?: String;
-}
-
-export interface VideoUseSubscriptionWhereInput {
+export interface ImageUseSubscriptionWhereInput {
   mutation_in?: MutationType[] | MutationType;
   updatedFields_contains?: String;
   updatedFields_contains_every?: String[] | String;
   updatedFields_contains_some?: String[] | String;
-  node?: VideoUseWhereInput;
-  AND?: VideoUseSubscriptionWhereInput[] | VideoUseSubscriptionWhereInput;
-  OR?: VideoUseSubscriptionWhereInput[] | VideoUseSubscriptionWhereInput;
-  NOT?: VideoUseSubscriptionWhereInput[] | VideoUseSubscriptionWhereInput;
+  node?: ImageUseWhereInput;
+  AND?: ImageUseSubscriptionWhereInput[] | ImageUseSubscriptionWhereInput;
+  OR?: ImageUseSubscriptionWhereInput[] | ImageUseSubscriptionWhereInput;
+  NOT?: ImageUseSubscriptionWhereInput[] | ImageUseSubscriptionWhereInput;
 }
 
-export interface LanguageWhereInput {
-  id?: ID_Input;
-  id_not?: ID_Input;
-  id_in?: ID_Input[] | ID_Input;
-  id_not_in?: ID_Input[] | ID_Input;
-  id_lt?: ID_Input;
-  id_lte?: ID_Input;
-  id_gt?: ID_Input;
-  id_gte?: ID_Input;
-  id_contains?: ID_Input;
-  id_not_contains?: ID_Input;
-  id_starts_with?: ID_Input;
-  id_not_starts_with?: ID_Input;
-  id_ends_with?: ID_Input;
-  id_not_ends_with?: ID_Input;
-  languageCode?: String;
-  languageCode_not?: String;
-  languageCode_in?: String[] | String;
-  languageCode_not_in?: String[] | String;
-  languageCode_lt?: String;
-  languageCode_lte?: String;
-  languageCode_gt?: String;
-  languageCode_gte?: String;
-  languageCode_contains?: String;
-  languageCode_not_contains?: String;
-  languageCode_starts_with?: String;
-  languageCode_not_starts_with?: String;
-  languageCode_ends_with?: String;
-  languageCode_not_ends_with?: String;
-  locale?: String;
-  locale_not?: String;
-  locale_in?: String[] | String;
-  locale_not_in?: String[] | String;
-  locale_lt?: String;
-  locale_lte?: String;
-  locale_gt?: String;
-  locale_gte?: String;
-  locale_contains?: String;
-  locale_not_contains?: String;
-  locale_starts_with?: String;
-  locale_not_starts_with?: String;
-  locale_ends_with?: String;
-  locale_not_ends_with?: String;
-  textDirection?: String;
-  textDirection_not?: String;
-  textDirection_in?: String[] | String;
-  textDirection_not_in?: String[] | String;
-  textDirection_lt?: String;
-  textDirection_lte?: String;
-  textDirection_gt?: String;
-  textDirection_gte?: String;
-  textDirection_contains?: String;
-  textDirection_not_contains?: String;
-  textDirection_starts_with?: String;
-  textDirection_not_starts_with?: String;
-  textDirection_ends_with?: String;
-  textDirection_not_ends_with?: String;
-  displayName?: String;
-  displayName_not?: String;
-  displayName_in?: String[] | String;
-  displayName_not_in?: String[] | String;
-  displayName_lt?: String;
-  displayName_lte?: String;
-  displayName_gt?: String;
-  displayName_gte?: String;
-  displayName_contains?: String;
-  displayName_not_contains?: String;
-  displayName_starts_with?: String;
-  displayName_not_starts_with?: String;
-  displayName_ends_with?: String;
-  displayName_not_ends_with?: String;
-  nativeName?: String;
-  nativeName_not?: String;
-  nativeName_in?: String[] | String;
-  nativeName_not_in?: String[] | String;
-  nativeName_lt?: String;
-  nativeName_lte?: String;
-  nativeName_gt?: String;
-  nativeName_gte?: String;
-  nativeName_contains?: String;
-  nativeName_not_contains?: String;
-  nativeName_starts_with?: String;
-  nativeName_not_starts_with?: String;
-  nativeName_ends_with?: String;
-  nativeName_not_ends_with?: String;
-  AND?: LanguageWhereInput[] | LanguageWhereInput;
-  OR?: LanguageWhereInput[] | LanguageWhereInput;
-  NOT?: LanguageWhereInput[] | LanguageWhereInput;
+export interface TeamUpsertNestedInput {
+  update: TeamUpdateDataInput;
+  create: TeamCreateInput;
 }
 
 export interface NodeNode {
@@ -4099,79 +4401,40 @@ export interface VideoUsePreviousValuesSubscription
   name: () => Promise<AsyncIterator<String>>;
 }
 
-export interface Tag {
+export interface SupportFileEdge {
+  node: SupportFile;
+  cursor: String;
+}
+
+export interface SupportFileEdgePromise
+  extends Promise<SupportFileEdge>,
+    Fragmentable {
+  node: <T = SupportFilePromise>() => T;
+  cursor: () => Promise<String>;
+}
+
+export interface SupportFileEdgeSubscription
+  extends Promise<AsyncIterator<SupportFileEdge>>,
+    Fragmentable {
+  node: <T = SupportFileSubscription>() => T;
+  cursor: () => Promise<AsyncIterator<String>>;
+}
+
+export interface ImageUse {
   id: ID_Output;
+  name: String;
 }
 
-export interface TagPromise extends Promise<Tag>, Fragmentable {
+export interface ImageUsePromise extends Promise<ImageUse>, Fragmentable {
   id: () => Promise<ID_Output>;
-  translations: <T = FragmentableArray<LanguageTranslation>>(args?: {
-    where?: LanguageTranslationWhereInput;
-    orderBy?: LanguageTranslationOrderByInput;
-    skip?: Int;
-    after?: String;
-    before?: String;
-    first?: Int;
-    last?: Int;
-  }) => T;
+  name: () => Promise<String>;
 }
 
-export interface TagSubscription
-  extends Promise<AsyncIterator<Tag>>,
+export interface ImageUseSubscription
+  extends Promise<AsyncIterator<ImageUse>>,
     Fragmentable {
   id: () => Promise<AsyncIterator<ID_Output>>;
-  translations: <
-    T = Promise<AsyncIterator<LanguageTranslationSubscription>>
-  >(args?: {
-    where?: LanguageTranslationWhereInput;
-    orderBy?: LanguageTranslationOrderByInput;
-    skip?: Int;
-    after?: String;
-    before?: String;
-    first?: Int;
-    last?: Int;
-  }) => T;
-}
-
-export interface VideoStreamPreviousValues {
-  id: ID_Output;
-  site?: String;
-  url?: String;
-  embedUrl?: String;
-}
-
-export interface VideoStreamPreviousValuesPromise
-  extends Promise<VideoStreamPreviousValues>,
-    Fragmentable {
-  id: () => Promise<ID_Output>;
-  site: () => Promise<String>;
-  url: () => Promise<String>;
-  embedUrl: () => Promise<String>;
-}
-
-export interface VideoStreamPreviousValuesSubscription
-  extends Promise<AsyncIterator<VideoStreamPreviousValues>>,
-    Fragmentable {
-  id: () => Promise<AsyncIterator<ID_Output>>;
-  site: () => Promise<AsyncIterator<String>>;
-  url: () => Promise<AsyncIterator<String>>;
-  embedUrl: () => Promise<AsyncIterator<String>>;
-}
-
-export interface AggregateSupportFile {
-  count: Int;
-}
-
-export interface AggregateSupportFilePromise
-  extends Promise<AggregateSupportFile>,
-    Fragmentable {
-  count: () => Promise<Int>;
-}
-
-export interface AggregateSupportFileSubscription
-  extends Promise<AsyncIterator<AggregateSupportFile>>,
-    Fragmentable {
-  count: () => Promise<AsyncIterator<Int>>;
+  name: () => Promise<AsyncIterator<String>>;
 }
 
 export interface SupportFileConnection {
@@ -4195,218 +4458,90 @@ export interface SupportFileConnectionSubscription
   aggregate: <T = AggregateSupportFileSubscription>() => T;
 }
 
-export interface SupportFileEdge {
-  node: SupportFile;
-  cursor: String;
+export interface BatchPayload {
+  count: Long;
 }
 
-export interface SupportFileEdgePromise
-  extends Promise<SupportFileEdge>,
+export interface BatchPayloadPromise
+  extends Promise<BatchPayload>,
     Fragmentable {
-  node: <T = SupportFilePromise>() => T;
-  cursor: () => Promise<String>;
+  count: () => Promise<Long>;
 }
 
-export interface SupportFileEdgeSubscription
-  extends Promise<AsyncIterator<SupportFileEdge>>,
+export interface BatchPayloadSubscription
+  extends Promise<AsyncIterator<BatchPayload>>,
     Fragmentable {
-  node: <T = SupportFileSubscription>() => T;
-  cursor: () => Promise<AsyncIterator<String>>;
+  count: () => Promise<AsyncIterator<Long>>;
 }
 
-export interface AggregateVideoUse {
+export interface AggregateDimensions {
   count: Int;
 }
 
-export interface AggregateVideoUsePromise
-  extends Promise<AggregateVideoUse>,
+export interface AggregateDimensionsPromise
+  extends Promise<AggregateDimensions>,
     Fragmentable {
   count: () => Promise<Int>;
 }
 
-export interface AggregateVideoUseSubscription
-  extends Promise<AsyncIterator<AggregateVideoUse>>,
+export interface AggregateDimensionsSubscription
+  extends Promise<AsyncIterator<AggregateDimensions>>,
     Fragmentable {
   count: () => Promise<AsyncIterator<Int>>;
 }
 
-export interface VideoUnitSubscriptionPayload {
-  mutation: MutationType;
-  node: VideoUnit;
-  updatedFields: String[];
-  previousValues: VideoUnitPreviousValues;
-}
-
-export interface VideoUnitSubscriptionPayloadPromise
-  extends Promise<VideoUnitSubscriptionPayload>,
-    Fragmentable {
-  mutation: () => Promise<MutationType>;
-  node: <T = VideoUnitPromise>() => T;
-  updatedFields: () => Promise<String[]>;
-  previousValues: <T = VideoUnitPreviousValuesPromise>() => T;
-}
-
-export interface VideoUnitSubscriptionPayloadSubscription
-  extends Promise<AsyncIterator<VideoUnitSubscriptionPayload>>,
-    Fragmentable {
-  mutation: () => Promise<AsyncIterator<MutationType>>;
-  node: <T = VideoUnitSubscription>() => T;
-  updatedFields: () => Promise<AsyncIterator<String[]>>;
-  previousValues: <T = VideoUnitPreviousValuesSubscription>() => T;
-}
-
-export interface VideoUseConnection {
-  pageInfo: PageInfo;
-  edges: VideoUseEdge[];
-}
-
-export interface VideoUseConnectionPromise
-  extends Promise<VideoUseConnection>,
-    Fragmentable {
-  pageInfo: <T = PageInfoPromise>() => T;
-  edges: <T = FragmentableArray<VideoUseEdge>>() => T;
-  aggregate: <T = AggregateVideoUsePromise>() => T;
-}
-
-export interface VideoUseConnectionSubscription
-  extends Promise<AsyncIterator<VideoUseConnection>>,
-    Fragmentable {
-  pageInfo: <T = PageInfoSubscription>() => T;
-  edges: <T = Promise<AsyncIterator<VideoUseEdgeSubscription>>>() => T;
-  aggregate: <T = AggregateVideoUseSubscription>() => T;
-}
-
-export interface DimensionsEdge {
-  node: Dimensions;
+export interface VideoUseEdge {
+  node: VideoUse;
   cursor: String;
 }
 
-export interface DimensionsEdgePromise
-  extends Promise<DimensionsEdge>,
+export interface VideoUseEdgePromise
+  extends Promise<VideoUseEdge>,
     Fragmentable {
-  node: <T = DimensionsPromise>() => T;
+  node: <T = VideoUsePromise>() => T;
   cursor: () => Promise<String>;
 }
 
-export interface DimensionsEdgeSubscription
-  extends Promise<AsyncIterator<DimensionsEdge>>,
+export interface VideoUseEdgeSubscription
+  extends Promise<AsyncIterator<VideoUseEdge>>,
     Fragmentable {
-  node: <T = DimensionsSubscription>() => T;
+  node: <T = VideoUseSubscription>() => T;
   cursor: () => Promise<AsyncIterator<String>>;
 }
 
-export interface VideoUnitEdge {
-  node: VideoUnit;
-  cursor: String;
-}
-
-export interface VideoUnitEdgePromise
-  extends Promise<VideoUnitEdge>,
-    Fragmentable {
-  node: <T = VideoUnitPromise>() => T;
-  cursor: () => Promise<String>;
-}
-
-export interface VideoUnitEdgeSubscription
-  extends Promise<AsyncIterator<VideoUnitEdge>>,
-    Fragmentable {
-  node: <T = VideoUnitSubscription>() => T;
-  cursor: () => Promise<AsyncIterator<String>>;
-}
-
-export interface ImageFileConnection {
-  pageInfo: PageInfo;
-  edges: ImageFileEdge[];
-}
-
-export interface ImageFileConnectionPromise
-  extends Promise<ImageFileConnection>,
-    Fragmentable {
-  pageInfo: <T = PageInfoPromise>() => T;
-  edges: <T = FragmentableArray<ImageFileEdge>>() => T;
-  aggregate: <T = AggregateImageFilePromise>() => T;
-}
-
-export interface ImageFileConnectionSubscription
-  extends Promise<AsyncIterator<ImageFileConnection>>,
-    Fragmentable {
-  pageInfo: <T = PageInfoSubscription>() => T;
-  edges: <T = Promise<AsyncIterator<ImageFileEdgeSubscription>>>() => T;
-  aggregate: <T = AggregateImageFileSubscription>() => T;
-}
-
-export interface AggregateVideoStream {
-  count: Int;
-}
-
-export interface AggregateVideoStreamPromise
-  extends Promise<AggregateVideoStream>,
-    Fragmentable {
-  count: () => Promise<Int>;
-}
-
-export interface AggregateVideoStreamSubscription
-  extends Promise<AsyncIterator<AggregateVideoStream>>,
-    Fragmentable {
-  count: () => Promise<AsyncIterator<Int>>;
-}
-
-export interface SupportFile {
+export interface SupportFileUse {
   id: ID_Output;
-  createdAt: DateTimeOutput;
-  updatedAt: DateTimeOutput;
-  url?: String;
-  md5?: String;
-  filename?: String;
-  filetype?: String;
-  filesize?: Float;
+  name: String;
 }
 
-export interface SupportFilePromise extends Promise<SupportFile>, Fragmentable {
+export interface SupportFileUsePromise
+  extends Promise<SupportFileUse>,
+    Fragmentable {
   id: () => Promise<ID_Output>;
-  createdAt: () => Promise<DateTimeOutput>;
-  updatedAt: () => Promise<DateTimeOutput>;
-  language: <T = LanguagePromise>() => T;
-  url: () => Promise<String>;
-  md5: () => Promise<String>;
-  filename: () => Promise<String>;
-  filetype: () => Promise<String>;
-  filesize: () => Promise<Float>;
+  name: () => Promise<String>;
 }
 
-export interface SupportFileSubscription
-  extends Promise<AsyncIterator<SupportFile>>,
+export interface SupportFileUseSubscription
+  extends Promise<AsyncIterator<SupportFileUse>>,
     Fragmentable {
   id: () => Promise<AsyncIterator<ID_Output>>;
-  createdAt: () => Promise<AsyncIterator<DateTimeOutput>>;
-  updatedAt: () => Promise<AsyncIterator<DateTimeOutput>>;
-  language: <T = LanguageSubscription>() => T;
-  url: () => Promise<AsyncIterator<String>>;
-  md5: () => Promise<AsyncIterator<String>>;
-  filename: () => Promise<AsyncIterator<String>>;
-  filetype: () => Promise<AsyncIterator<String>>;
-  filesize: () => Promise<AsyncIterator<Float>>;
+  name: () => Promise<AsyncIterator<String>>;
 }
 
-export interface VideoStreamConnection {
-  pageInfo: PageInfo;
-  edges: VideoStreamEdge[];
+export interface AggregateVideoUnit {
+  count: Int;
 }
 
-export interface VideoStreamConnectionPromise
-  extends Promise<VideoStreamConnection>,
+export interface AggregateVideoUnitPromise
+  extends Promise<AggregateVideoUnit>,
     Fragmentable {
-  pageInfo: <T = PageInfoPromise>() => T;
-  edges: <T = FragmentableArray<VideoStreamEdge>>() => T;
-  aggregate: <T = AggregateVideoStreamPromise>() => T;
+  count: () => Promise<Int>;
 }
 
-export interface VideoStreamConnectionSubscription
-  extends Promise<AsyncIterator<VideoStreamConnection>>,
+export interface AggregateVideoUnitSubscription
+  extends Promise<AsyncIterator<AggregateVideoUnit>>,
     Fragmentable {
-  pageInfo: <T = PageInfoSubscription>() => T;
-  edges: <T = Promise<AsyncIterator<VideoStreamEdgeSubscription>>>() => T;
-  aggregate: <T = AggregateVideoStreamSubscription>() => T;
+  count: () => Promise<AsyncIterator<Int>>;
 }
 
 export interface Category {
@@ -4443,20 +4578,25 @@ export interface CategorySubscription
   }) => T;
 }
 
-export interface AggregateVideoProject {
-  count: Int;
+export interface VideoUnitConnection {
+  pageInfo: PageInfo;
+  edges: VideoUnitEdge[];
 }
 
-export interface AggregateVideoProjectPromise
-  extends Promise<AggregateVideoProject>,
+export interface VideoUnitConnectionPromise
+  extends Promise<VideoUnitConnection>,
     Fragmentable {
-  count: () => Promise<Int>;
+  pageInfo: <T = PageInfoPromise>() => T;
+  edges: <T = FragmentableArray<VideoUnitEdge>>() => T;
+  aggregate: <T = AggregateVideoUnitPromise>() => T;
 }
 
-export interface AggregateVideoProjectSubscription
-  extends Promise<AsyncIterator<AggregateVideoProject>>,
+export interface VideoUnitConnectionSubscription
+  extends Promise<AsyncIterator<VideoUnitConnection>>,
     Fragmentable {
-  count: () => Promise<AsyncIterator<Int>>;
+  pageInfo: <T = PageInfoSubscription>() => T;
+  edges: <T = Promise<AsyncIterator<VideoUnitEdgeSubscription>>>() => T;
+  aggregate: <T = AggregateVideoUnitSubscription>() => T;
 }
 
 export interface CategorySubscriptionPayload {
@@ -4484,6 +4624,119 @@ export interface CategorySubscriptionPayloadSubscription
   previousValues: <T = CategoryPreviousValuesSubscription>() => T;
 }
 
+export interface VideoStreamEdge {
+  node: VideoStream;
+  cursor: String;
+}
+
+export interface VideoStreamEdgePromise
+  extends Promise<VideoStreamEdge>,
+    Fragmentable {
+  node: <T = VideoStreamPromise>() => T;
+  cursor: () => Promise<String>;
+}
+
+export interface VideoStreamEdgeSubscription
+  extends Promise<AsyncIterator<VideoStreamEdge>>,
+    Fragmentable {
+  node: <T = VideoStreamSubscription>() => T;
+  cursor: () => Promise<AsyncIterator<String>>;
+}
+
+export interface CategoryPreviousValues {
+  id: ID_Output;
+}
+
+export interface CategoryPreviousValuesPromise
+  extends Promise<CategoryPreviousValues>,
+    Fragmentable {
+  id: () => Promise<ID_Output>;
+}
+
+export interface CategoryPreviousValuesSubscription
+  extends Promise<AsyncIterator<CategoryPreviousValues>>,
+    Fragmentable {
+  id: () => Promise<AsyncIterator<ID_Output>>;
+}
+
+export interface AggregateVideoProject {
+  count: Int;
+}
+
+export interface AggregateVideoProjectPromise
+  extends Promise<AggregateVideoProject>,
+    Fragmentable {
+  count: () => Promise<Int>;
+}
+
+export interface AggregateVideoProjectSubscription
+  extends Promise<AsyncIterator<AggregateVideoProject>>,
+    Fragmentable {
+  count: () => Promise<AsyncIterator<Int>>;
+}
+
+export interface AggregateVideoStream {
+  count: Int;
+}
+
+export interface AggregateVideoStreamPromise
+  extends Promise<AggregateVideoStream>,
+    Fragmentable {
+  count: () => Promise<Int>;
+}
+
+export interface AggregateVideoStreamSubscription
+  extends Promise<AsyncIterator<AggregateVideoStream>>,
+    Fragmentable {
+  count: () => Promise<AsyncIterator<Int>>;
+}
+
+export interface VideoStreamPreviousValues {
+  id: ID_Output;
+  site?: String;
+  url?: String;
+  embedUrl?: String;
+}
+
+export interface VideoStreamPreviousValuesPromise
+  extends Promise<VideoStreamPreviousValues>,
+    Fragmentable {
+  id: () => Promise<ID_Output>;
+  site: () => Promise<String>;
+  url: () => Promise<String>;
+  embedUrl: () => Promise<String>;
+}
+
+export interface VideoStreamPreviousValuesSubscription
+  extends Promise<AsyncIterator<VideoStreamPreviousValues>>,
+    Fragmentable {
+  id: () => Promise<AsyncIterator<ID_Output>>;
+  site: () => Promise<AsyncIterator<String>>;
+  url: () => Promise<AsyncIterator<String>>;
+  embedUrl: () => Promise<AsyncIterator<String>>;
+}
+
+export interface VideoStreamConnection {
+  pageInfo: PageInfo;
+  edges: VideoStreamEdge[];
+}
+
+export interface VideoStreamConnectionPromise
+  extends Promise<VideoStreamConnection>,
+    Fragmentable {
+  pageInfo: <T = PageInfoPromise>() => T;
+  edges: <T = FragmentableArray<VideoStreamEdge>>() => T;
+  aggregate: <T = AggregateVideoStreamPromise>() => T;
+}
+
+export interface VideoStreamConnectionSubscription
+  extends Promise<AsyncIterator<VideoStreamConnection>>,
+    Fragmentable {
+  pageInfo: <T = PageInfoSubscription>() => T;
+  edges: <T = Promise<AsyncIterator<VideoStreamEdgeSubscription>>>() => T;
+  aggregate: <T = AggregateVideoStreamSubscription>() => T;
+}
+
 export interface VideoProjectConnection {
   pageInfo: PageInfo;
   edges: VideoProjectEdge[];
@@ -4505,892 +4758,6 @@ export interface VideoProjectConnectionSubscription
   aggregate: <T = AggregateVideoProjectSubscription>() => T;
 }
 
-export interface CategoryPreviousValues {
-  id: ID_Output;
-}
-
-export interface CategoryPreviousValuesPromise
-  extends Promise<CategoryPreviousValues>,
-    Fragmentable {
-  id: () => Promise<ID_Output>;
-}
-
-export interface CategoryPreviousValuesSubscription
-  extends Promise<AsyncIterator<CategoryPreviousValues>>,
-    Fragmentable {
-  id: () => Promise<AsyncIterator<ID_Output>>;
-}
-
-export interface ImageFile {
-  id: ID_Output;
-  createdAt: DateTimeOutput;
-  updatedAt: DateTimeOutput;
-  alt?: String;
-  longdesc?: String;
-  caption?: String;
-  filename?: String;
-  filetype?: String;
-  md5?: String;
-  url?: String;
-}
-
-export interface ImageFilePromise extends Promise<ImageFile>, Fragmentable {
-  id: () => Promise<ID_Output>;
-  createdAt: () => Promise<DateTimeOutput>;
-  updatedAt: () => Promise<DateTimeOutput>;
-  language: <T = LanguagePromise>() => T;
-  dimensions: <T = DimensionsPromise>() => T;
-  alt: () => Promise<String>;
-  longdesc: () => Promise<String>;
-  caption: () => Promise<String>;
-  filename: () => Promise<String>;
-  filetype: () => Promise<String>;
-  md5: () => Promise<String>;
-  url: () => Promise<String>;
-}
-
-export interface ImageFileSubscription
-  extends Promise<AsyncIterator<ImageFile>>,
-    Fragmentable {
-  id: () => Promise<AsyncIterator<ID_Output>>;
-  createdAt: () => Promise<AsyncIterator<DateTimeOutput>>;
-  updatedAt: () => Promise<AsyncIterator<DateTimeOutput>>;
-  language: <T = LanguageSubscription>() => T;
-  dimensions: <T = DimensionsSubscription>() => T;
-  alt: () => Promise<AsyncIterator<String>>;
-  longdesc: () => Promise<AsyncIterator<String>>;
-  caption: () => Promise<AsyncIterator<String>>;
-  filename: () => Promise<AsyncIterator<String>>;
-  filetype: () => Promise<AsyncIterator<String>>;
-  md5: () => Promise<AsyncIterator<String>>;
-  url: () => Promise<AsyncIterator<String>>;
-}
-
-export interface AggregateLanguageTranslation {
-  count: Int;
-}
-
-export interface AggregateLanguageTranslationPromise
-  extends Promise<AggregateLanguageTranslation>,
-    Fragmentable {
-  count: () => Promise<Int>;
-}
-
-export interface AggregateLanguageTranslationSubscription
-  extends Promise<AsyncIterator<AggregateLanguageTranslation>>,
-    Fragmentable {
-  count: () => Promise<AsyncIterator<Int>>;
-}
-
-export interface Language {
-  id: ID_Output;
-  languageCode: String;
-  locale: String;
-  textDirection: String;
-  displayName: String;
-  nativeName: String;
-}
-
-export interface LanguagePromise extends Promise<Language>, Fragmentable {
-  id: () => Promise<ID_Output>;
-  languageCode: () => Promise<String>;
-  locale: () => Promise<String>;
-  textDirection: () => Promise<String>;
-  displayName: () => Promise<String>;
-  nativeName: () => Promise<String>;
-}
-
-export interface LanguageSubscription
-  extends Promise<AsyncIterator<Language>>,
-    Fragmentable {
-  id: () => Promise<AsyncIterator<ID_Output>>;
-  languageCode: () => Promise<AsyncIterator<String>>;
-  locale: () => Promise<AsyncIterator<String>>;
-  textDirection: () => Promise<AsyncIterator<String>>;
-  displayName: () => Promise<AsyncIterator<String>>;
-  nativeName: () => Promise<AsyncIterator<String>>;
-}
-
-export interface DimensionsSubscriptionPayload {
-  mutation: MutationType;
-  node: Dimensions;
-  updatedFields: String[];
-  previousValues: DimensionsPreviousValues;
-}
-
-export interface DimensionsSubscriptionPayloadPromise
-  extends Promise<DimensionsSubscriptionPayload>,
-    Fragmentable {
-  mutation: () => Promise<MutationType>;
-  node: <T = DimensionsPromise>() => T;
-  updatedFields: () => Promise<String[]>;
-  previousValues: <T = DimensionsPreviousValuesPromise>() => T;
-}
-
-export interface DimensionsSubscriptionPayloadSubscription
-  extends Promise<AsyncIterator<DimensionsSubscriptionPayload>>,
-    Fragmentable {
-  mutation: () => Promise<AsyncIterator<MutationType>>;
-  node: <T = DimensionsSubscription>() => T;
-  updatedFields: () => Promise<AsyncIterator<String[]>>;
-  previousValues: <T = DimensionsPreviousValuesSubscription>() => T;
-}
-
-export interface AggregateVideoFile {
-  count: Int;
-}
-
-export interface AggregateVideoFilePromise
-  extends Promise<AggregateVideoFile>,
-    Fragmentable {
-  count: () => Promise<Int>;
-}
-
-export interface AggregateVideoFileSubscription
-  extends Promise<AsyncIterator<AggregateVideoFile>>,
-    Fragmentable {
-  count: () => Promise<AsyncIterator<Int>>;
-}
-
-export interface DimensionsPreviousValues {
-  id: ID_Output;
-  width?: Int;
-  height?: Int;
-}
-
-export interface DimensionsPreviousValuesPromise
-  extends Promise<DimensionsPreviousValues>,
-    Fragmentable {
-  id: () => Promise<ID_Output>;
-  width: () => Promise<Int>;
-  height: () => Promise<Int>;
-}
-
-export interface DimensionsPreviousValuesSubscription
-  extends Promise<AsyncIterator<DimensionsPreviousValues>>,
-    Fragmentable {
-  id: () => Promise<AsyncIterator<ID_Output>>;
-  width: () => Promise<AsyncIterator<Int>>;
-  height: () => Promise<AsyncIterator<Int>>;
-}
-
-export interface VideoFileConnection {
-  pageInfo: PageInfo;
-  edges: VideoFileEdge[];
-}
-
-export interface VideoFileConnectionPromise
-  extends Promise<VideoFileConnection>,
-    Fragmentable {
-  pageInfo: <T = PageInfoPromise>() => T;
-  edges: <T = FragmentableArray<VideoFileEdge>>() => T;
-  aggregate: <T = AggregateVideoFilePromise>() => T;
-}
-
-export interface VideoFileConnectionSubscription
-  extends Promise<AsyncIterator<VideoFileConnection>>,
-    Fragmentable {
-  pageInfo: <T = PageInfoSubscription>() => T;
-  edges: <T = Promise<AsyncIterator<VideoFileEdgeSubscription>>>() => T;
-  aggregate: <T = AggregateVideoFileSubscription>() => T;
-}
-
-export interface LanguageTranslationEdge {
-  node: LanguageTranslation;
-  cursor: String;
-}
-
-export interface LanguageTranslationEdgePromise
-  extends Promise<LanguageTranslationEdge>,
-    Fragmentable {
-  node: <T = LanguageTranslationPromise>() => T;
-  cursor: () => Promise<String>;
-}
-
-export interface LanguageTranslationEdgeSubscription
-  extends Promise<AsyncIterator<LanguageTranslationEdge>>,
-    Fragmentable {
-  node: <T = LanguageTranslationSubscription>() => T;
-  cursor: () => Promise<AsyncIterator<String>>;
-}
-
-export interface CategoryConnection {
-  pageInfo: PageInfo;
-  edges: CategoryEdge[];
-}
-
-export interface CategoryConnectionPromise
-  extends Promise<CategoryConnection>,
-    Fragmentable {
-  pageInfo: <T = PageInfoPromise>() => T;
-  edges: <T = FragmentableArray<CategoryEdge>>() => T;
-  aggregate: <T = AggregateCategoryPromise>() => T;
-}
-
-export interface CategoryConnectionSubscription
-  extends Promise<AsyncIterator<CategoryConnection>>,
-    Fragmentable {
-  pageInfo: <T = PageInfoSubscription>() => T;
-  edges: <T = Promise<AsyncIterator<CategoryEdgeSubscription>>>() => T;
-  aggregate: <T = AggregateCategorySubscription>() => T;
-}
-
-export interface ImageFileSubscriptionPayload {
-  mutation: MutationType;
-  node: ImageFile;
-  updatedFields: String[];
-  previousValues: ImageFilePreviousValues;
-}
-
-export interface ImageFileSubscriptionPayloadPromise
-  extends Promise<ImageFileSubscriptionPayload>,
-    Fragmentable {
-  mutation: () => Promise<MutationType>;
-  node: <T = ImageFilePromise>() => T;
-  updatedFields: () => Promise<String[]>;
-  previousValues: <T = ImageFilePreviousValuesPromise>() => T;
-}
-
-export interface ImageFileSubscriptionPayloadSubscription
-  extends Promise<AsyncIterator<ImageFileSubscriptionPayload>>,
-    Fragmentable {
-  mutation: () => Promise<AsyncIterator<MutationType>>;
-  node: <T = ImageFileSubscription>() => T;
-  updatedFields: () => Promise<AsyncIterator<String[]>>;
-  previousValues: <T = ImageFilePreviousValuesSubscription>() => T;
-}
-
-export interface VideoUse {
-  id: ID_Output;
-  name: String;
-}
-
-export interface VideoUsePromise extends Promise<VideoUse>, Fragmentable {
-  id: () => Promise<ID_Output>;
-  name: () => Promise<String>;
-}
-
-export interface VideoUseSubscription
-  extends Promise<AsyncIterator<VideoUse>>,
-    Fragmentable {
-  id: () => Promise<AsyncIterator<ID_Output>>;
-  name: () => Promise<AsyncIterator<String>>;
-}
-
-export interface ImageFilePreviousValues {
-  id: ID_Output;
-  createdAt: DateTimeOutput;
-  updatedAt: DateTimeOutput;
-  alt?: String;
-  longdesc?: String;
-  caption?: String;
-  filename?: String;
-  filetype?: String;
-  md5?: String;
-  url?: String;
-}
-
-export interface ImageFilePreviousValuesPromise
-  extends Promise<ImageFilePreviousValues>,
-    Fragmentable {
-  id: () => Promise<ID_Output>;
-  createdAt: () => Promise<DateTimeOutput>;
-  updatedAt: () => Promise<DateTimeOutput>;
-  alt: () => Promise<String>;
-  longdesc: () => Promise<String>;
-  caption: () => Promise<String>;
-  filename: () => Promise<String>;
-  filetype: () => Promise<String>;
-  md5: () => Promise<String>;
-  url: () => Promise<String>;
-}
-
-export interface ImageFilePreviousValuesSubscription
-  extends Promise<AsyncIterator<ImageFilePreviousValues>>,
-    Fragmentable {
-  id: () => Promise<AsyncIterator<ID_Output>>;
-  createdAt: () => Promise<AsyncIterator<DateTimeOutput>>;
-  updatedAt: () => Promise<AsyncIterator<DateTimeOutput>>;
-  alt: () => Promise<AsyncIterator<String>>;
-  longdesc: () => Promise<AsyncIterator<String>>;
-  caption: () => Promise<AsyncIterator<String>>;
-  filename: () => Promise<AsyncIterator<String>>;
-  filetype: () => Promise<AsyncIterator<String>>;
-  md5: () => Promise<AsyncIterator<String>>;
-  url: () => Promise<AsyncIterator<String>>;
-}
-
-export interface AggregateUser {
-  count: Int;
-}
-
-export interface AggregateUserPromise
-  extends Promise<AggregateUser>,
-    Fragmentable {
-  count: () => Promise<Int>;
-}
-
-export interface AggregateUserSubscription
-  extends Promise<AsyncIterator<AggregateUser>>,
-    Fragmentable {
-  count: () => Promise<AsyncIterator<Int>>;
-}
-
-export interface LanguageTranslationConnection {
-  pageInfo: PageInfo;
-  edges: LanguageTranslationEdge[];
-}
-
-export interface LanguageTranslationConnectionPromise
-  extends Promise<LanguageTranslationConnection>,
-    Fragmentable {
-  pageInfo: <T = PageInfoPromise>() => T;
-  edges: <T = FragmentableArray<LanguageTranslationEdge>>() => T;
-  aggregate: <T = AggregateLanguageTranslationPromise>() => T;
-}
-
-export interface LanguageTranslationConnectionSubscription
-  extends Promise<AsyncIterator<LanguageTranslationConnection>>,
-    Fragmentable {
-  pageInfo: <T = PageInfoSubscription>() => T;
-  edges: <
-    T = Promise<AsyncIterator<LanguageTranslationEdgeSubscription>>
-  >() => T;
-  aggregate: <T = AggregateLanguageTranslationSubscription>() => T;
-}
-
-export interface UserConnection {
-  pageInfo: PageInfo;
-  edges: UserEdge[];
-}
-
-export interface UserConnectionPromise
-  extends Promise<UserConnection>,
-    Fragmentable {
-  pageInfo: <T = PageInfoPromise>() => T;
-  edges: <T = FragmentableArray<UserEdge>>() => T;
-  aggregate: <T = AggregateUserPromise>() => T;
-}
-
-export interface UserConnectionSubscription
-  extends Promise<AsyncIterator<UserConnection>>,
-    Fragmentable {
-  pageInfo: <T = PageInfoSubscription>() => T;
-  edges: <T = Promise<AsyncIterator<UserEdgeSubscription>>>() => T;
-  aggregate: <T = AggregateUserSubscription>() => T;
-}
-
-export interface ImageUseSubscriptionPayload {
-  mutation: MutationType;
-  node: ImageUse;
-  updatedFields: String[];
-  previousValues: ImageUsePreviousValues;
-}
-
-export interface ImageUseSubscriptionPayloadPromise
-  extends Promise<ImageUseSubscriptionPayload>,
-    Fragmentable {
-  mutation: () => Promise<MutationType>;
-  node: <T = ImageUsePromise>() => T;
-  updatedFields: () => Promise<String[]>;
-  previousValues: <T = ImageUsePreviousValuesPromise>() => T;
-}
-
-export interface ImageUseSubscriptionPayloadSubscription
-  extends Promise<AsyncIterator<ImageUseSubscriptionPayload>>,
-    Fragmentable {
-  mutation: () => Promise<AsyncIterator<MutationType>>;
-  node: <T = ImageUseSubscription>() => T;
-  updatedFields: () => Promise<AsyncIterator<String[]>>;
-  previousValues: <T = ImageUsePreviousValuesSubscription>() => T;
-}
-
-export interface ThumbnailEdge {
-  node: Thumbnail;
-  cursor: String;
-}
-
-export interface ThumbnailEdgePromise
-  extends Promise<ThumbnailEdge>,
-    Fragmentable {
-  node: <T = ThumbnailPromise>() => T;
-  cursor: () => Promise<String>;
-}
-
-export interface ThumbnailEdgeSubscription
-  extends Promise<AsyncIterator<ThumbnailEdge>>,
-    Fragmentable {
-  node: <T = ThumbnailSubscription>() => T;
-  cursor: () => Promise<AsyncIterator<String>>;
-}
-
-export interface ImageUsePreviousValues {
-  id: ID_Output;
-  name: String;
-}
-
-export interface ImageUsePreviousValuesPromise
-  extends Promise<ImageUsePreviousValues>,
-    Fragmentable {
-  id: () => Promise<ID_Output>;
-  name: () => Promise<String>;
-}
-
-export interface ImageUsePreviousValuesSubscription
-  extends Promise<AsyncIterator<ImageUsePreviousValues>>,
-    Fragmentable {
-  id: () => Promise<AsyncIterator<ID_Output>>;
-  name: () => Promise<AsyncIterator<String>>;
-}
-
-export interface VideoUnitPreviousValues {
-  id: ID_Output;
-  title: String;
-  descPublic?: String;
-}
-
-export interface VideoUnitPreviousValuesPromise
-  extends Promise<VideoUnitPreviousValues>,
-    Fragmentable {
-  id: () => Promise<ID_Output>;
-  title: () => Promise<String>;
-  descPublic: () => Promise<String>;
-}
-
-export interface VideoUnitPreviousValuesSubscription
-  extends Promise<AsyncIterator<VideoUnitPreviousValues>>,
-    Fragmentable {
-  id: () => Promise<AsyncIterator<ID_Output>>;
-  title: () => Promise<AsyncIterator<String>>;
-  descPublic: () => Promise<AsyncIterator<String>>;
-}
-
-export interface AggregateLanguage {
-  count: Int;
-}
-
-export interface AggregateLanguagePromise
-  extends Promise<AggregateLanguage>,
-    Fragmentable {
-  count: () => Promise<Int>;
-}
-
-export interface AggregateLanguageSubscription
-  extends Promise<AsyncIterator<AggregateLanguage>>,
-    Fragmentable {
-  count: () => Promise<AsyncIterator<Int>>;
-}
-
-export interface Thumbnail {
-  id: ID_Output;
-  size?: ThumbnailSize;
-}
-
-export interface ThumbnailPromise extends Promise<Thumbnail>, Fragmentable {
-  id: () => Promise<ID_Output>;
-  size: () => Promise<ThumbnailSize>;
-  image: <T = ImageFilePromise>() => T;
-}
-
-export interface ThumbnailSubscription
-  extends Promise<AsyncIterator<Thumbnail>>,
-    Fragmentable {
-  id: () => Promise<AsyncIterator<ID_Output>>;
-  size: () => Promise<AsyncIterator<ThumbnailSize>>;
-  image: <T = ImageFileSubscription>() => T;
-}
-
-export interface LanguageSubscriptionPayload {
-  mutation: MutationType;
-  node: Language;
-  updatedFields: String[];
-  previousValues: LanguagePreviousValues;
-}
-
-export interface LanguageSubscriptionPayloadPromise
-  extends Promise<LanguageSubscriptionPayload>,
-    Fragmentable {
-  mutation: () => Promise<MutationType>;
-  node: <T = LanguagePromise>() => T;
-  updatedFields: () => Promise<String[]>;
-  previousValues: <T = LanguagePreviousValuesPromise>() => T;
-}
-
-export interface LanguageSubscriptionPayloadSubscription
-  extends Promise<AsyncIterator<LanguageSubscriptionPayload>>,
-    Fragmentable {
-  mutation: () => Promise<AsyncIterator<MutationType>>;
-  node: <T = LanguageSubscription>() => T;
-  updatedFields: () => Promise<AsyncIterator<String[]>>;
-  previousValues: <T = LanguagePreviousValuesSubscription>() => T;
-}
-
-export interface TeamEdge {
-  node: Team;
-  cursor: String;
-}
-
-export interface TeamEdgePromise extends Promise<TeamEdge>, Fragmentable {
-  node: <T = TeamPromise>() => T;
-  cursor: () => Promise<String>;
-}
-
-export interface TeamEdgeSubscription
-  extends Promise<AsyncIterator<TeamEdge>>,
-    Fragmentable {
-  node: <T = TeamSubscription>() => T;
-  cursor: () => Promise<AsyncIterator<String>>;
-}
-
-export interface LanguagePreviousValues {
-  id: ID_Output;
-  languageCode: String;
-  locale: String;
-  textDirection: String;
-  displayName: String;
-  nativeName: String;
-}
-
-export interface LanguagePreviousValuesPromise
-  extends Promise<LanguagePreviousValues>,
-    Fragmentable {
-  id: () => Promise<ID_Output>;
-  languageCode: () => Promise<String>;
-  locale: () => Promise<String>;
-  textDirection: () => Promise<String>;
-  displayName: () => Promise<String>;
-  nativeName: () => Promise<String>;
-}
-
-export interface LanguagePreviousValuesSubscription
-  extends Promise<AsyncIterator<LanguagePreviousValues>>,
-    Fragmentable {
-  id: () => Promise<AsyncIterator<ID_Output>>;
-  languageCode: () => Promise<AsyncIterator<String>>;
-  locale: () => Promise<AsyncIterator<String>>;
-  textDirection: () => Promise<AsyncIterator<String>>;
-  displayName: () => Promise<AsyncIterator<String>>;
-  nativeName: () => Promise<AsyncIterator<String>>;
-}
-
-export interface AggregateCategory {
-  count: Int;
-}
-
-export interface AggregateCategoryPromise
-  extends Promise<AggregateCategory>,
-    Fragmentable {
-  count: () => Promise<Int>;
-}
-
-export interface AggregateCategorySubscription
-  extends Promise<AsyncIterator<AggregateCategory>>,
-    Fragmentable {
-  count: () => Promise<AsyncIterator<Int>>;
-}
-
-export interface LanguageEdge {
-  node: Language;
-  cursor: String;
-}
-
-export interface LanguageEdgePromise
-  extends Promise<LanguageEdge>,
-    Fragmentable {
-  node: <T = LanguagePromise>() => T;
-  cursor: () => Promise<String>;
-}
-
-export interface LanguageEdgeSubscription
-  extends Promise<AsyncIterator<LanguageEdge>>,
-    Fragmentable {
-  node: <T = LanguageSubscription>() => T;
-  cursor: () => Promise<AsyncIterator<String>>;
-}
-
-export interface User {
-  id: ID_Output;
-  firstName: String;
-  lastName: String;
-  email: String;
-  password?: String;
-  tempToken?: String;
-  tempTokenExpiry?: Float;
-  jobTitle?: String;
-  country?: String;
-  city?: String;
-  howHeard?: String;
-  permissions: Permission[];
-  isConfirmed: Boolean;
-}
-
-export interface UserPromise extends Promise<User>, Fragmentable {
-  id: () => Promise<ID_Output>;
-  firstName: () => Promise<String>;
-  lastName: () => Promise<String>;
-  email: () => Promise<String>;
-  password: () => Promise<String>;
-  tempToken: () => Promise<String>;
-  tempTokenExpiry: () => Promise<Float>;
-  jobTitle: () => Promise<String>;
-  country: () => Promise<String>;
-  city: () => Promise<String>;
-  howHeard: () => Promise<String>;
-  permissions: () => Promise<Permission[]>;
-  team: <T = TeamPromise>() => T;
-  isConfirmed: () => Promise<Boolean>;
-}
-
-export interface UserSubscription
-  extends Promise<AsyncIterator<User>>,
-    Fragmentable {
-  id: () => Promise<AsyncIterator<ID_Output>>;
-  firstName: () => Promise<AsyncIterator<String>>;
-  lastName: () => Promise<AsyncIterator<String>>;
-  email: () => Promise<AsyncIterator<String>>;
-  password: () => Promise<AsyncIterator<String>>;
-  tempToken: () => Promise<AsyncIterator<String>>;
-  tempTokenExpiry: () => Promise<AsyncIterator<Float>>;
-  jobTitle: () => Promise<AsyncIterator<String>>;
-  country: () => Promise<AsyncIterator<String>>;
-  city: () => Promise<AsyncIterator<String>>;
-  howHeard: () => Promise<AsyncIterator<String>>;
-  permissions: () => Promise<AsyncIterator<Permission[]>>;
-  team: <T = TeamSubscription>() => T;
-  isConfirmed: () => Promise<AsyncIterator<Boolean>>;
-}
-
-export interface LanguageTranslationSubscriptionPayload {
-  mutation: MutationType;
-  node: LanguageTranslation;
-  updatedFields: String[];
-  previousValues: LanguageTranslationPreviousValues;
-}
-
-export interface LanguageTranslationSubscriptionPayloadPromise
-  extends Promise<LanguageTranslationSubscriptionPayload>,
-    Fragmentable {
-  mutation: () => Promise<MutationType>;
-  node: <T = LanguageTranslationPromise>() => T;
-  updatedFields: () => Promise<String[]>;
-  previousValues: <T = LanguageTranslationPreviousValuesPromise>() => T;
-}
-
-export interface LanguageTranslationSubscriptionPayloadSubscription
-  extends Promise<AsyncIterator<LanguageTranslationSubscriptionPayload>>,
-    Fragmentable {
-  mutation: () => Promise<AsyncIterator<MutationType>>;
-  node: <T = LanguageTranslationSubscription>() => T;
-  updatedFields: () => Promise<AsyncIterator<String[]>>;
-  previousValues: <T = LanguageTranslationPreviousValuesSubscription>() => T;
-}
-
-export interface AggregateTag {
-  count: Int;
-}
-
-export interface AggregateTagPromise
-  extends Promise<AggregateTag>,
-    Fragmentable {
-  count: () => Promise<Int>;
-}
-
-export interface AggregateTagSubscription
-  extends Promise<AsyncIterator<AggregateTag>>,
-    Fragmentable {
-  count: () => Promise<AsyncIterator<Int>>;
-}
-
-export interface LanguageTranslationPreviousValues {
-  id: ID_Output;
-  name: String;
-}
-
-export interface LanguageTranslationPreviousValuesPromise
-  extends Promise<LanguageTranslationPreviousValues>,
-    Fragmentable {
-  id: () => Promise<ID_Output>;
-  name: () => Promise<String>;
-}
-
-export interface LanguageTranslationPreviousValuesSubscription
-  extends Promise<AsyncIterator<LanguageTranslationPreviousValues>>,
-    Fragmentable {
-  id: () => Promise<AsyncIterator<ID_Output>>;
-  name: () => Promise<AsyncIterator<String>>;
-}
-
-export interface TagConnection {
-  pageInfo: PageInfo;
-  edges: TagEdge[];
-}
-
-export interface TagConnectionPromise
-  extends Promise<TagConnection>,
-    Fragmentable {
-  pageInfo: <T = PageInfoPromise>() => T;
-  edges: <T = FragmentableArray<TagEdge>>() => T;
-  aggregate: <T = AggregateTagPromise>() => T;
-}
-
-export interface TagConnectionSubscription
-  extends Promise<AsyncIterator<TagConnection>>,
-    Fragmentable {
-  pageInfo: <T = PageInfoSubscription>() => T;
-  edges: <T = Promise<AsyncIterator<TagEdgeSubscription>>>() => T;
-  aggregate: <T = AggregateTagSubscription>() => T;
-}
-
-export interface LanguageConnection {
-  pageInfo: PageInfo;
-  edges: LanguageEdge[];
-}
-
-export interface LanguageConnectionPromise
-  extends Promise<LanguageConnection>,
-    Fragmentable {
-  pageInfo: <T = PageInfoPromise>() => T;
-  edges: <T = FragmentableArray<LanguageEdge>>() => T;
-  aggregate: <T = AggregateLanguagePromise>() => T;
-}
-
-export interface LanguageConnectionSubscription
-  extends Promise<AsyncIterator<LanguageConnection>>,
-    Fragmentable {
-  pageInfo: <T = PageInfoSubscription>() => T;
-  edges: <T = Promise<AsyncIterator<LanguageEdgeSubscription>>>() => T;
-  aggregate: <T = AggregateLanguageSubscription>() => T;
-}
-
-export interface BatchPayload {
-  count: Long;
-}
-
-export interface BatchPayloadPromise
-  extends Promise<BatchPayload>,
-    Fragmentable {
-  count: () => Promise<Long>;
-}
-
-export interface BatchPayloadSubscription
-  extends Promise<AsyncIterator<BatchPayload>>,
-    Fragmentable {
-  count: () => Promise<AsyncIterator<Long>>;
-}
-
-export interface SupportFileSubscriptionPayload {
-  mutation: MutationType;
-  node: SupportFile;
-  updatedFields: String[];
-  previousValues: SupportFilePreviousValues;
-}
-
-export interface SupportFileSubscriptionPayloadPromise
-  extends Promise<SupportFileSubscriptionPayload>,
-    Fragmentable {
-  mutation: () => Promise<MutationType>;
-  node: <T = SupportFilePromise>() => T;
-  updatedFields: () => Promise<String[]>;
-  previousValues: <T = SupportFilePreviousValuesPromise>() => T;
-}
-
-export interface SupportFileSubscriptionPayloadSubscription
-  extends Promise<AsyncIterator<SupportFileSubscriptionPayload>>,
-    Fragmentable {
-  mutation: () => Promise<AsyncIterator<MutationType>>;
-  node: <T = SupportFileSubscription>() => T;
-  updatedFields: () => Promise<AsyncIterator<String[]>>;
-  previousValues: <T = SupportFilePreviousValuesSubscription>() => T;
-}
-
-export interface AggregateVideoUnit {
-  count: Int;
-}
-
-export interface AggregateVideoUnitPromise
-  extends Promise<AggregateVideoUnit>,
-    Fragmentable {
-  count: () => Promise<Int>;
-}
-
-export interface AggregateVideoUnitSubscription
-  extends Promise<AsyncIterator<AggregateVideoUnit>>,
-    Fragmentable {
-  count: () => Promise<AsyncIterator<Int>>;
-}
-
-export interface SupportFilePreviousValues {
-  id: ID_Output;
-  createdAt: DateTimeOutput;
-  updatedAt: DateTimeOutput;
-  url?: String;
-  md5?: String;
-  filename?: String;
-  filetype?: String;
-  filesize?: Float;
-}
-
-export interface SupportFilePreviousValuesPromise
-  extends Promise<SupportFilePreviousValues>,
-    Fragmentable {
-  id: () => Promise<ID_Output>;
-  createdAt: () => Promise<DateTimeOutput>;
-  updatedAt: () => Promise<DateTimeOutput>;
-  url: () => Promise<String>;
-  md5: () => Promise<String>;
-  filename: () => Promise<String>;
-  filetype: () => Promise<String>;
-  filesize: () => Promise<Float>;
-}
-
-export interface SupportFilePreviousValuesSubscription
-  extends Promise<AsyncIterator<SupportFilePreviousValues>>,
-    Fragmentable {
-  id: () => Promise<AsyncIterator<ID_Output>>;
-  createdAt: () => Promise<AsyncIterator<DateTimeOutput>>;
-  updatedAt: () => Promise<AsyncIterator<DateTimeOutput>>;
-  url: () => Promise<AsyncIterator<String>>;
-  md5: () => Promise<AsyncIterator<String>>;
-  filename: () => Promise<AsyncIterator<String>>;
-  filetype: () => Promise<AsyncIterator<String>>;
-  filesize: () => Promise<AsyncIterator<Float>>;
-}
-
-export interface VideoStreamEdge {
-  node: VideoStream;
-  cursor: String;
-}
-
-export interface VideoStreamEdgePromise
-  extends Promise<VideoStreamEdge>,
-    Fragmentable {
-  node: <T = VideoStreamPromise>() => T;
-  cursor: () => Promise<String>;
-}
-
-export interface VideoStreamEdgeSubscription
-  extends Promise<AsyncIterator<VideoStreamEdge>>,
-    Fragmentable {
-  node: <T = VideoStreamSubscription>() => T;
-  cursor: () => Promise<AsyncIterator<String>>;
-}
-
-export interface AggregateDimensions {
-  count: Int;
-}
-
-export interface AggregateDimensionsPromise
-  extends Promise<AggregateDimensions>,
-    Fragmentable {
-  count: () => Promise<Int>;
-}
-
-export interface AggregateDimensionsSubscription
-  extends Promise<AsyncIterator<AggregateDimensions>>,
-    Fragmentable {
-  count: () => Promise<AsyncIterator<Int>>;
-}
-
 export interface VideoProjectEdge {
   node: VideoProject;
   cursor: String;
@@ -5408,398 +4775,6 @@ export interface VideoProjectEdgeSubscription
     Fragmentable {
   node: <T = VideoProjectSubscription>() => T;
   cursor: () => Promise<AsyncIterator<String>>;
-}
-
-export interface TagSubscriptionPayload {
-  mutation: MutationType;
-  node: Tag;
-  updatedFields: String[];
-  previousValues: TagPreviousValues;
-}
-
-export interface TagSubscriptionPayloadPromise
-  extends Promise<TagSubscriptionPayload>,
-    Fragmentable {
-  mutation: () => Promise<MutationType>;
-  node: <T = TagPromise>() => T;
-  updatedFields: () => Promise<String[]>;
-  previousValues: <T = TagPreviousValuesPromise>() => T;
-}
-
-export interface TagSubscriptionPayloadSubscription
-  extends Promise<AsyncIterator<TagSubscriptionPayload>>,
-    Fragmentable {
-  mutation: () => Promise<AsyncIterator<MutationType>>;
-  node: <T = TagSubscription>() => T;
-  updatedFields: () => Promise<AsyncIterator<String[]>>;
-  previousValues: <T = TagPreviousValuesSubscription>() => T;
-}
-
-export interface LanguageTranslation {
-  id: ID_Output;
-  name: String;
-}
-
-export interface LanguageTranslationPromise
-  extends Promise<LanguageTranslation>,
-    Fragmentable {
-  id: () => Promise<ID_Output>;
-  name: () => Promise<String>;
-  language: <T = LanguagePromise>() => T;
-}
-
-export interface LanguageTranslationSubscription
-  extends Promise<AsyncIterator<LanguageTranslation>>,
-    Fragmentable {
-  id: () => Promise<AsyncIterator<ID_Output>>;
-  name: () => Promise<AsyncIterator<String>>;
-  language: <T = LanguageSubscription>() => T;
-}
-
-export interface TagPreviousValues {
-  id: ID_Output;
-}
-
-export interface TagPreviousValuesPromise
-  extends Promise<TagPreviousValues>,
-    Fragmentable {
-  id: () => Promise<ID_Output>;
-}
-
-export interface TagPreviousValuesSubscription
-  extends Promise<AsyncIterator<TagPreviousValues>>,
-    Fragmentable {
-  id: () => Promise<AsyncIterator<ID_Output>>;
-}
-
-export interface VideoFileEdge {
-  node: VideoFile;
-  cursor: String;
-}
-
-export interface VideoFileEdgePromise
-  extends Promise<VideoFileEdge>,
-    Fragmentable {
-  node: <T = VideoFilePromise>() => T;
-  cursor: () => Promise<String>;
-}
-
-export interface VideoFileEdgeSubscription
-  extends Promise<AsyncIterator<VideoFileEdge>>,
-    Fragmentable {
-  node: <T = VideoFileSubscription>() => T;
-  cursor: () => Promise<AsyncIterator<String>>;
-}
-
-export interface AggregateImageUse {
-  count: Int;
-}
-
-export interface AggregateImageUsePromise
-  extends Promise<AggregateImageUse>,
-    Fragmentable {
-  count: () => Promise<Int>;
-}
-
-export interface AggregateImageUseSubscription
-  extends Promise<AsyncIterator<AggregateImageUse>>,
-    Fragmentable {
-  count: () => Promise<AsyncIterator<Int>>;
-}
-
-export interface PageInfo {
-  hasNextPage: Boolean;
-  hasPreviousPage: Boolean;
-  startCursor?: String;
-  endCursor?: String;
-}
-
-export interface PageInfoPromise extends Promise<PageInfo>, Fragmentable {
-  hasNextPage: () => Promise<Boolean>;
-  hasPreviousPage: () => Promise<Boolean>;
-  startCursor: () => Promise<String>;
-  endCursor: () => Promise<String>;
-}
-
-export interface PageInfoSubscription
-  extends Promise<AsyncIterator<PageInfo>>,
-    Fragmentable {
-  hasNextPage: () => Promise<AsyncIterator<Boolean>>;
-  hasPreviousPage: () => Promise<AsyncIterator<Boolean>>;
-  startCursor: () => Promise<AsyncIterator<String>>;
-  endCursor: () => Promise<AsyncIterator<String>>;
-}
-
-export interface TeamSubscriptionPayload {
-  mutation: MutationType;
-  node: Team;
-  updatedFields: String[];
-  previousValues: TeamPreviousValues;
-}
-
-export interface TeamSubscriptionPayloadPromise
-  extends Promise<TeamSubscriptionPayload>,
-    Fragmentable {
-  mutation: () => Promise<MutationType>;
-  node: <T = TeamPromise>() => T;
-  updatedFields: () => Promise<String[]>;
-  previousValues: <T = TeamPreviousValuesPromise>() => T;
-}
-
-export interface TeamSubscriptionPayloadSubscription
-  extends Promise<AsyncIterator<TeamSubscriptionPayload>>,
-    Fragmentable {
-  mutation: () => Promise<AsyncIterator<MutationType>>;
-  node: <T = TeamSubscription>() => T;
-  updatedFields: () => Promise<AsyncIterator<String[]>>;
-  previousValues: <T = TeamPreviousValuesSubscription>() => T;
-}
-
-export interface UserEdge {
-  node: User;
-  cursor: String;
-}
-
-export interface UserEdgePromise extends Promise<UserEdge>, Fragmentable {
-  node: <T = UserPromise>() => T;
-  cursor: () => Promise<String>;
-}
-
-export interface UserEdgeSubscription
-  extends Promise<AsyncIterator<UserEdge>>,
-    Fragmentable {
-  node: <T = UserSubscription>() => T;
-  cursor: () => Promise<AsyncIterator<String>>;
-}
-
-export interface TeamPreviousValues {
-  id: ID_Output;
-  name: String;
-  organization: String;
-  contentTypes: ContentType[];
-  isConfirmed: Boolean;
-}
-
-export interface TeamPreviousValuesPromise
-  extends Promise<TeamPreviousValues>,
-    Fragmentable {
-  id: () => Promise<ID_Output>;
-  name: () => Promise<String>;
-  organization: () => Promise<String>;
-  contentTypes: () => Promise<ContentType[]>;
-  isConfirmed: () => Promise<Boolean>;
-}
-
-export interface TeamPreviousValuesSubscription
-  extends Promise<AsyncIterator<TeamPreviousValues>>,
-    Fragmentable {
-  id: () => Promise<AsyncIterator<ID_Output>>;
-  name: () => Promise<AsyncIterator<String>>;
-  organization: () => Promise<AsyncIterator<String>>;
-  contentTypes: () => Promise<AsyncIterator<ContentType[]>>;
-  isConfirmed: () => Promise<AsyncIterator<Boolean>>;
-}
-
-export interface ThumbnailConnection {
-  pageInfo: PageInfo;
-  edges: ThumbnailEdge[];
-}
-
-export interface ThumbnailConnectionPromise
-  extends Promise<ThumbnailConnection>,
-    Fragmentable {
-  pageInfo: <T = PageInfoPromise>() => T;
-  edges: <T = FragmentableArray<ThumbnailEdge>>() => T;
-  aggregate: <T = AggregateThumbnailPromise>() => T;
-}
-
-export interface ThumbnailConnectionSubscription
-  extends Promise<AsyncIterator<ThumbnailConnection>>,
-    Fragmentable {
-  pageInfo: <T = PageInfoSubscription>() => T;
-  edges: <T = Promise<AsyncIterator<ThumbnailEdgeSubscription>>>() => T;
-  aggregate: <T = AggregateThumbnailSubscription>() => T;
-}
-
-export interface ImageUseEdge {
-  node: ImageUse;
-  cursor: String;
-}
-
-export interface ImageUseEdgePromise
-  extends Promise<ImageUseEdge>,
-    Fragmentable {
-  node: <T = ImageUsePromise>() => T;
-  cursor: () => Promise<String>;
-}
-
-export interface ImageUseEdgeSubscription
-  extends Promise<AsyncIterator<ImageUseEdge>>,
-    Fragmentable {
-  node: <T = ImageUseSubscription>() => T;
-  cursor: () => Promise<AsyncIterator<String>>;
-}
-
-export interface AggregateTeam {
-  count: Int;
-}
-
-export interface AggregateTeamPromise
-  extends Promise<AggregateTeam>,
-    Fragmentable {
-  count: () => Promise<Int>;
-}
-
-export interface AggregateTeamSubscription
-  extends Promise<AsyncIterator<AggregateTeam>>,
-    Fragmentable {
-  count: () => Promise<AsyncIterator<Int>>;
-}
-
-export interface ThumbnailSubscriptionPayload {
-  mutation: MutationType;
-  node: Thumbnail;
-  updatedFields: String[];
-  previousValues: ThumbnailPreviousValues;
-}
-
-export interface ThumbnailSubscriptionPayloadPromise
-  extends Promise<ThumbnailSubscriptionPayload>,
-    Fragmentable {
-  mutation: () => Promise<MutationType>;
-  node: <T = ThumbnailPromise>() => T;
-  updatedFields: () => Promise<String[]>;
-  previousValues: <T = ThumbnailPreviousValuesPromise>() => T;
-}
-
-export interface ThumbnailSubscriptionPayloadSubscription
-  extends Promise<AsyncIterator<ThumbnailSubscriptionPayload>>,
-    Fragmentable {
-  mutation: () => Promise<AsyncIterator<MutationType>>;
-  node: <T = ThumbnailSubscription>() => T;
-  updatedFields: () => Promise<AsyncIterator<String[]>>;
-  previousValues: <T = ThumbnailPreviousValuesSubscription>() => T;
-}
-
-export interface Dimensions {
-  id: ID_Output;
-  width?: Int;
-  height?: Int;
-}
-
-export interface DimensionsPromise extends Promise<Dimensions>, Fragmentable {
-  id: () => Promise<ID_Output>;
-  width: () => Promise<Int>;
-  height: () => Promise<Int>;
-}
-
-export interface DimensionsSubscription
-  extends Promise<AsyncIterator<Dimensions>>,
-    Fragmentable {
-  id: () => Promise<AsyncIterator<ID_Output>>;
-  width: () => Promise<AsyncIterator<Int>>;
-  height: () => Promise<AsyncIterator<Int>>;
-}
-
-export interface ThumbnailPreviousValues {
-  id: ID_Output;
-  size?: ThumbnailSize;
-}
-
-export interface ThumbnailPreviousValuesPromise
-  extends Promise<ThumbnailPreviousValues>,
-    Fragmentable {
-  id: () => Promise<ID_Output>;
-  size: () => Promise<ThumbnailSize>;
-}
-
-export interface ThumbnailPreviousValuesSubscription
-  extends Promise<AsyncIterator<ThumbnailPreviousValues>>,
-    Fragmentable {
-  id: () => Promise<AsyncIterator<ID_Output>>;
-  size: () => Promise<AsyncIterator<ThumbnailSize>>;
-}
-
-export interface TagEdge {
-  node: Tag;
-  cursor: String;
-}
-
-export interface TagEdgePromise extends Promise<TagEdge>, Fragmentable {
-  node: <T = TagPromise>() => T;
-  cursor: () => Promise<String>;
-}
-
-export interface TagEdgeSubscription
-  extends Promise<AsyncIterator<TagEdge>>,
-    Fragmentable {
-  node: <T = TagSubscription>() => T;
-  cursor: () => Promise<AsyncIterator<String>>;
-}
-
-export interface ImageUseConnection {
-  pageInfo: PageInfo;
-  edges: ImageUseEdge[];
-}
-
-export interface ImageUseConnectionPromise
-  extends Promise<ImageUseConnection>,
-    Fragmentable {
-  pageInfo: <T = PageInfoPromise>() => T;
-  edges: <T = FragmentableArray<ImageUseEdge>>() => T;
-  aggregate: <T = AggregateImageUsePromise>() => T;
-}
-
-export interface ImageUseConnectionSubscription
-  extends Promise<AsyncIterator<ImageUseConnection>>,
-    Fragmentable {
-  pageInfo: <T = PageInfoSubscription>() => T;
-  edges: <T = Promise<AsyncIterator<ImageUseEdgeSubscription>>>() => T;
-  aggregate: <T = AggregateImageUseSubscription>() => T;
-}
-
-export interface VideoUseEdge {
-  node: VideoUse;
-  cursor: String;
-}
-
-export interface VideoUseEdgePromise
-  extends Promise<VideoUseEdge>,
-    Fragmentable {
-  node: <T = VideoUsePromise>() => T;
-  cursor: () => Promise<String>;
-}
-
-export interface VideoUseEdgeSubscription
-  extends Promise<AsyncIterator<VideoUseEdge>>,
-    Fragmentable {
-  node: <T = VideoUseSubscription>() => T;
-  cursor: () => Promise<AsyncIterator<String>>;
-}
-
-export interface UserSubscriptionPayload {
-  mutation: MutationType;
-  node: User;
-  updatedFields: String[];
-  previousValues: UserPreviousValues;
-}
-
-export interface UserSubscriptionPayloadPromise
-  extends Promise<UserSubscriptionPayload>,
-    Fragmentable {
-  mutation: () => Promise<MutationType>;
-  node: <T = UserPromise>() => T;
-  updatedFields: () => Promise<String[]>;
-  previousValues: <T = UserPreviousValuesPromise>() => T;
-}
-
-export interface UserSubscriptionPayloadSubscription
-  extends Promise<AsyncIterator<UserSubscriptionPayload>>,
-    Fragmentable {
-  mutation: () => Promise<AsyncIterator<MutationType>>;
-  node: <T = UserSubscription>() => T;
-  updatedFields: () => Promise<AsyncIterator<String[]>>;
-  previousValues: <T = UserPreviousValuesSubscription>() => T;
 }
 
 export interface VideoUseSubscriptionPayload {
@@ -5827,56 +4802,25 @@ export interface VideoUseSubscriptionPayloadSubscription
   previousValues: <T = VideoUsePreviousValuesSubscription>() => T;
 }
 
-export interface UserPreviousValues {
-  id: ID_Output;
-  firstName: String;
-  lastName: String;
-  email: String;
-  password?: String;
-  tempToken?: String;
-  tempTokenExpiry?: Float;
-  jobTitle?: String;
-  country?: String;
-  city?: String;
-  howHeard?: String;
-  permissions: Permission[];
-  isConfirmed: Boolean;
+export interface ImageFileConnection {
+  pageInfo: PageInfo;
+  edges: ImageFileEdge[];
 }
 
-export interface UserPreviousValuesPromise
-  extends Promise<UserPreviousValues>,
+export interface ImageFileConnectionPromise
+  extends Promise<ImageFileConnection>,
     Fragmentable {
-  id: () => Promise<ID_Output>;
-  firstName: () => Promise<String>;
-  lastName: () => Promise<String>;
-  email: () => Promise<String>;
-  password: () => Promise<String>;
-  tempToken: () => Promise<String>;
-  tempTokenExpiry: () => Promise<Float>;
-  jobTitle: () => Promise<String>;
-  country: () => Promise<String>;
-  city: () => Promise<String>;
-  howHeard: () => Promise<String>;
-  permissions: () => Promise<Permission[]>;
-  isConfirmed: () => Promise<Boolean>;
+  pageInfo: <T = PageInfoPromise>() => T;
+  edges: <T = FragmentableArray<ImageFileEdge>>() => T;
+  aggregate: <T = AggregateImageFilePromise>() => T;
 }
 
-export interface UserPreviousValuesSubscription
-  extends Promise<AsyncIterator<UserPreviousValues>>,
+export interface ImageFileConnectionSubscription
+  extends Promise<AsyncIterator<ImageFileConnection>>,
     Fragmentable {
-  id: () => Promise<AsyncIterator<ID_Output>>;
-  firstName: () => Promise<AsyncIterator<String>>;
-  lastName: () => Promise<AsyncIterator<String>>;
-  email: () => Promise<AsyncIterator<String>>;
-  password: () => Promise<AsyncIterator<String>>;
-  tempToken: () => Promise<AsyncIterator<String>>;
-  tempTokenExpiry: () => Promise<AsyncIterator<Float>>;
-  jobTitle: () => Promise<AsyncIterator<String>>;
-  country: () => Promise<AsyncIterator<String>>;
-  city: () => Promise<AsyncIterator<String>>;
-  howHeard: () => Promise<AsyncIterator<String>>;
-  permissions: () => Promise<AsyncIterator<Permission[]>>;
-  isConfirmed: () => Promise<AsyncIterator<Boolean>>;
+  pageInfo: <T = PageInfoSubscription>() => T;
+  edges: <T = Promise<AsyncIterator<ImageFileEdgeSubscription>>>() => T;
+  aggregate: <T = AggregateImageFileSubscription>() => T;
 }
 
 export interface VideoProject {
@@ -6017,21 +4961,1131 @@ export interface VideoProjectSubscription
   }) => T;
 }
 
-export interface ImageUse {
+export interface DimensionsSubscriptionPayload {
+  mutation: MutationType;
+  node: Dimensions;
+  updatedFields: String[];
+  previousValues: DimensionsPreviousValues;
+}
+
+export interface DimensionsSubscriptionPayloadPromise
+  extends Promise<DimensionsSubscriptionPayload>,
+    Fragmentable {
+  mutation: () => Promise<MutationType>;
+  node: <T = DimensionsPromise>() => T;
+  updatedFields: () => Promise<String[]>;
+  previousValues: <T = DimensionsPreviousValuesPromise>() => T;
+}
+
+export interface DimensionsSubscriptionPayloadSubscription
+  extends Promise<AsyncIterator<DimensionsSubscriptionPayload>>,
+    Fragmentable {
+  mutation: () => Promise<AsyncIterator<MutationType>>;
+  node: <T = DimensionsSubscription>() => T;
+  updatedFields: () => Promise<AsyncIterator<String[]>>;
+  previousValues: <T = DimensionsPreviousValuesSubscription>() => T;
+}
+
+export interface VideoFileEdge {
+  node: VideoFile;
+  cursor: String;
+}
+
+export interface VideoFileEdgePromise
+  extends Promise<VideoFileEdge>,
+    Fragmentable {
+  node: <T = VideoFilePromise>() => T;
+  cursor: () => Promise<String>;
+}
+
+export interface VideoFileEdgeSubscription
+  extends Promise<AsyncIterator<VideoFileEdge>>,
+    Fragmentable {
+  node: <T = VideoFileSubscription>() => T;
+  cursor: () => Promise<AsyncIterator<String>>;
+}
+
+export interface DimensionsPreviousValues {
+  id: ID_Output;
+  width?: Int;
+  height?: Int;
+}
+
+export interface DimensionsPreviousValuesPromise
+  extends Promise<DimensionsPreviousValues>,
+    Fragmentable {
+  id: () => Promise<ID_Output>;
+  width: () => Promise<Int>;
+  height: () => Promise<Int>;
+}
+
+export interface DimensionsPreviousValuesSubscription
+  extends Promise<AsyncIterator<DimensionsPreviousValues>>,
+    Fragmentable {
+  id: () => Promise<AsyncIterator<ID_Output>>;
+  width: () => Promise<AsyncIterator<Int>>;
+  height: () => Promise<AsyncIterator<Int>>;
+}
+
+export interface Language {
+  id: ID_Output;
+  languageCode: String;
+  locale: String;
+  textDirection: String;
+  displayName: String;
+  nativeName: String;
+}
+
+export interface LanguagePromise extends Promise<Language>, Fragmentable {
+  id: () => Promise<ID_Output>;
+  languageCode: () => Promise<String>;
+  locale: () => Promise<String>;
+  textDirection: () => Promise<String>;
+  displayName: () => Promise<String>;
+  nativeName: () => Promise<String>;
+}
+
+export interface LanguageSubscription
+  extends Promise<AsyncIterator<Language>>,
+    Fragmentable {
+  id: () => Promise<AsyncIterator<ID_Output>>;
+  languageCode: () => Promise<AsyncIterator<String>>;
+  locale: () => Promise<AsyncIterator<String>>;
+  textDirection: () => Promise<AsyncIterator<String>>;
+  displayName: () => Promise<AsyncIterator<String>>;
+  nativeName: () => Promise<AsyncIterator<String>>;
+}
+
+export interface SupportFile {
+  id: ID_Output;
+  createdAt: DateTimeOutput;
+  updatedAt: DateTimeOutput;
+  url?: String;
+  md5?: String;
+  filename?: String;
+  filetype?: String;
+  filesize?: Float;
+}
+
+export interface SupportFilePromise extends Promise<SupportFile>, Fragmentable {
+  id: () => Promise<ID_Output>;
+  createdAt: () => Promise<DateTimeOutput>;
+  updatedAt: () => Promise<DateTimeOutput>;
+  language: <T = LanguagePromise>() => T;
+  url: () => Promise<String>;
+  md5: () => Promise<String>;
+  filename: () => Promise<String>;
+  filetype: () => Promise<String>;
+  filesize: () => Promise<Float>;
+  use: <T = SupportFileUsePromise>() => T;
+}
+
+export interface SupportFileSubscription
+  extends Promise<AsyncIterator<SupportFile>>,
+    Fragmentable {
+  id: () => Promise<AsyncIterator<ID_Output>>;
+  createdAt: () => Promise<AsyncIterator<DateTimeOutput>>;
+  updatedAt: () => Promise<AsyncIterator<DateTimeOutput>>;
+  language: <T = LanguageSubscription>() => T;
+  url: () => Promise<AsyncIterator<String>>;
+  md5: () => Promise<AsyncIterator<String>>;
+  filename: () => Promise<AsyncIterator<String>>;
+  filetype: () => Promise<AsyncIterator<String>>;
+  filesize: () => Promise<AsyncIterator<Float>>;
+  use: <T = SupportFileUseSubscription>() => T;
+}
+
+export interface CategoryConnection {
+  pageInfo: PageInfo;
+  edges: CategoryEdge[];
+}
+
+export interface CategoryConnectionPromise
+  extends Promise<CategoryConnection>,
+    Fragmentable {
+  pageInfo: <T = PageInfoPromise>() => T;
+  edges: <T = FragmentableArray<CategoryEdge>>() => T;
+  aggregate: <T = AggregateCategoryPromise>() => T;
+}
+
+export interface CategoryConnectionSubscription
+  extends Promise<AsyncIterator<CategoryConnection>>,
+    Fragmentable {
+  pageInfo: <T = PageInfoSubscription>() => T;
+  edges: <T = Promise<AsyncIterator<CategoryEdgeSubscription>>>() => T;
+  aggregate: <T = AggregateCategorySubscription>() => T;
+}
+
+export interface ImageFileSubscriptionPayload {
+  mutation: MutationType;
+  node: ImageFile;
+  updatedFields: String[];
+  previousValues: ImageFilePreviousValues;
+}
+
+export interface ImageFileSubscriptionPayloadPromise
+  extends Promise<ImageFileSubscriptionPayload>,
+    Fragmentable {
+  mutation: () => Promise<MutationType>;
+  node: <T = ImageFilePromise>() => T;
+  updatedFields: () => Promise<String[]>;
+  previousValues: <T = ImageFilePreviousValuesPromise>() => T;
+}
+
+export interface ImageFileSubscriptionPayloadSubscription
+  extends Promise<AsyncIterator<ImageFileSubscriptionPayload>>,
+    Fragmentable {
+  mutation: () => Promise<AsyncIterator<MutationType>>;
+  node: <T = ImageFileSubscription>() => T;
+  updatedFields: () => Promise<AsyncIterator<String[]>>;
+  previousValues: <T = ImageFilePreviousValuesSubscription>() => T;
+}
+
+export interface VideoUse {
   id: ID_Output;
   name: String;
 }
 
-export interface ImageUsePromise extends Promise<ImageUse>, Fragmentable {
+export interface VideoUsePromise extends Promise<VideoUse>, Fragmentable {
   id: () => Promise<ID_Output>;
   name: () => Promise<String>;
 }
 
-export interface ImageUseSubscription
-  extends Promise<AsyncIterator<ImageUse>>,
+export interface VideoUseSubscription
+  extends Promise<AsyncIterator<VideoUse>>,
     Fragmentable {
   id: () => Promise<AsyncIterator<ID_Output>>;
   name: () => Promise<AsyncIterator<String>>;
+}
+
+export interface ImageFilePreviousValues {
+  id: ID_Output;
+  createdAt: DateTimeOutput;
+  updatedAt: DateTimeOutput;
+  alt?: String;
+  longdesc?: String;
+  caption?: String;
+  filename?: String;
+  filetype?: String;
+  md5?: String;
+  url?: String;
+}
+
+export interface ImageFilePreviousValuesPromise
+  extends Promise<ImageFilePreviousValues>,
+    Fragmentable {
+  id: () => Promise<ID_Output>;
+  createdAt: () => Promise<DateTimeOutput>;
+  updatedAt: () => Promise<DateTimeOutput>;
+  alt: () => Promise<String>;
+  longdesc: () => Promise<String>;
+  caption: () => Promise<String>;
+  filename: () => Promise<String>;
+  filetype: () => Promise<String>;
+  md5: () => Promise<String>;
+  url: () => Promise<String>;
+}
+
+export interface ImageFilePreviousValuesSubscription
+  extends Promise<AsyncIterator<ImageFilePreviousValues>>,
+    Fragmentable {
+  id: () => Promise<AsyncIterator<ID_Output>>;
+  createdAt: () => Promise<AsyncIterator<DateTimeOutput>>;
+  updatedAt: () => Promise<AsyncIterator<DateTimeOutput>>;
+  alt: () => Promise<AsyncIterator<String>>;
+  longdesc: () => Promise<AsyncIterator<String>>;
+  caption: () => Promise<AsyncIterator<String>>;
+  filename: () => Promise<AsyncIterator<String>>;
+  filetype: () => Promise<AsyncIterator<String>>;
+  md5: () => Promise<AsyncIterator<String>>;
+  url: () => Promise<AsyncIterator<String>>;
+}
+
+export interface AggregateUser {
+  count: Int;
+}
+
+export interface AggregateUserPromise
+  extends Promise<AggregateUser>,
+    Fragmentable {
+  count: () => Promise<Int>;
+}
+
+export interface AggregateUserSubscription
+  extends Promise<AsyncIterator<AggregateUser>>,
+    Fragmentable {
+  count: () => Promise<AsyncIterator<Int>>;
+}
+
+export interface AggregateLanguageTranslation {
+  count: Int;
+}
+
+export interface AggregateLanguageTranslationPromise
+  extends Promise<AggregateLanguageTranslation>,
+    Fragmentable {
+  count: () => Promise<Int>;
+}
+
+export interface AggregateLanguageTranslationSubscription
+  extends Promise<AsyncIterator<AggregateLanguageTranslation>>,
+    Fragmentable {
+  count: () => Promise<AsyncIterator<Int>>;
+}
+
+export interface UserConnection {
+  pageInfo: PageInfo;
+  edges: UserEdge[];
+}
+
+export interface UserConnectionPromise
+  extends Promise<UserConnection>,
+    Fragmentable {
+  pageInfo: <T = PageInfoPromise>() => T;
+  edges: <T = FragmentableArray<UserEdge>>() => T;
+  aggregate: <T = AggregateUserPromise>() => T;
+}
+
+export interface UserConnectionSubscription
+  extends Promise<AsyncIterator<UserConnection>>,
+    Fragmentable {
+  pageInfo: <T = PageInfoSubscription>() => T;
+  edges: <T = Promise<AsyncIterator<UserEdgeSubscription>>>() => T;
+  aggregate: <T = AggregateUserSubscription>() => T;
+}
+
+export interface ImageUseSubscriptionPayload {
+  mutation: MutationType;
+  node: ImageUse;
+  updatedFields: String[];
+  previousValues: ImageUsePreviousValues;
+}
+
+export interface ImageUseSubscriptionPayloadPromise
+  extends Promise<ImageUseSubscriptionPayload>,
+    Fragmentable {
+  mutation: () => Promise<MutationType>;
+  node: <T = ImageUsePromise>() => T;
+  updatedFields: () => Promise<String[]>;
+  previousValues: <T = ImageUsePreviousValuesPromise>() => T;
+}
+
+export interface ImageUseSubscriptionPayloadSubscription
+  extends Promise<AsyncIterator<ImageUseSubscriptionPayload>>,
+    Fragmentable {
+  mutation: () => Promise<AsyncIterator<MutationType>>;
+  node: <T = ImageUseSubscription>() => T;
+  updatedFields: () => Promise<AsyncIterator<String[]>>;
+  previousValues: <T = ImageUsePreviousValuesSubscription>() => T;
+}
+
+export interface ThumbnailEdge {
+  node: Thumbnail;
+  cursor: String;
+}
+
+export interface ThumbnailEdgePromise
+  extends Promise<ThumbnailEdge>,
+    Fragmentable {
+  node: <T = ThumbnailPromise>() => T;
+  cursor: () => Promise<String>;
+}
+
+export interface ThumbnailEdgeSubscription
+  extends Promise<AsyncIterator<ThumbnailEdge>>,
+    Fragmentable {
+  node: <T = ThumbnailSubscription>() => T;
+  cursor: () => Promise<AsyncIterator<String>>;
+}
+
+export interface ImageUsePreviousValues {
+  id: ID_Output;
+  name: String;
+}
+
+export interface ImageUsePreviousValuesPromise
+  extends Promise<ImageUsePreviousValues>,
+    Fragmentable {
+  id: () => Promise<ID_Output>;
+  name: () => Promise<String>;
+}
+
+export interface ImageUsePreviousValuesSubscription
+  extends Promise<AsyncIterator<ImageUsePreviousValues>>,
+    Fragmentable {
+  id: () => Promise<AsyncIterator<ID_Output>>;
+  name: () => Promise<AsyncIterator<String>>;
+}
+
+export interface VideoUnitPreviousValues {
+  id: ID_Output;
+  createdAt: DateTimeOutput;
+  updatedAt: DateTimeOutput;
+  title: String;
+  descPublic?: String;
+}
+
+export interface VideoUnitPreviousValuesPromise
+  extends Promise<VideoUnitPreviousValues>,
+    Fragmentable {
+  id: () => Promise<ID_Output>;
+  createdAt: () => Promise<DateTimeOutput>;
+  updatedAt: () => Promise<DateTimeOutput>;
+  title: () => Promise<String>;
+  descPublic: () => Promise<String>;
+}
+
+export interface VideoUnitPreviousValuesSubscription
+  extends Promise<AsyncIterator<VideoUnitPreviousValues>>,
+    Fragmentable {
+  id: () => Promise<AsyncIterator<ID_Output>>;
+  createdAt: () => Promise<AsyncIterator<DateTimeOutput>>;
+  updatedAt: () => Promise<AsyncIterator<DateTimeOutput>>;
+  title: () => Promise<AsyncIterator<String>>;
+  descPublic: () => Promise<AsyncIterator<String>>;
+}
+
+export interface LanguageTranslationEdge {
+  node: LanguageTranslation;
+  cursor: String;
+}
+
+export interface LanguageTranslationEdgePromise
+  extends Promise<LanguageTranslationEdge>,
+    Fragmentable {
+  node: <T = LanguageTranslationPromise>() => T;
+  cursor: () => Promise<String>;
+}
+
+export interface LanguageTranslationEdgeSubscription
+  extends Promise<AsyncIterator<LanguageTranslationEdge>>,
+    Fragmentable {
+  node: <T = LanguageTranslationSubscription>() => T;
+  cursor: () => Promise<AsyncIterator<String>>;
+}
+
+export interface Thumbnail {
+  id: ID_Output;
+  size?: ThumbnailSize;
+}
+
+export interface ThumbnailPromise extends Promise<Thumbnail>, Fragmentable {
+  id: () => Promise<ID_Output>;
+  size: () => Promise<ThumbnailSize>;
+  image: <T = ImageFilePromise>() => T;
+}
+
+export interface ThumbnailSubscription
+  extends Promise<AsyncIterator<Thumbnail>>,
+    Fragmentable {
+  id: () => Promise<AsyncIterator<ID_Output>>;
+  size: () => Promise<AsyncIterator<ThumbnailSize>>;
+  image: <T = ImageFileSubscription>() => T;
+}
+
+export interface LanguageSubscriptionPayload {
+  mutation: MutationType;
+  node: Language;
+  updatedFields: String[];
+  previousValues: LanguagePreviousValues;
+}
+
+export interface LanguageSubscriptionPayloadPromise
+  extends Promise<LanguageSubscriptionPayload>,
+    Fragmentable {
+  mutation: () => Promise<MutationType>;
+  node: <T = LanguagePromise>() => T;
+  updatedFields: () => Promise<String[]>;
+  previousValues: <T = LanguagePreviousValuesPromise>() => T;
+}
+
+export interface LanguageSubscriptionPayloadSubscription
+  extends Promise<AsyncIterator<LanguageSubscriptionPayload>>,
+    Fragmentable {
+  mutation: () => Promise<AsyncIterator<MutationType>>;
+  node: <T = LanguageSubscription>() => T;
+  updatedFields: () => Promise<AsyncIterator<String[]>>;
+  previousValues: <T = LanguagePreviousValuesSubscription>() => T;
+}
+
+export interface TeamEdge {
+  node: Team;
+  cursor: String;
+}
+
+export interface TeamEdgePromise extends Promise<TeamEdge>, Fragmentable {
+  node: <T = TeamPromise>() => T;
+  cursor: () => Promise<String>;
+}
+
+export interface TeamEdgeSubscription
+  extends Promise<AsyncIterator<TeamEdge>>,
+    Fragmentable {
+  node: <T = TeamSubscription>() => T;
+  cursor: () => Promise<AsyncIterator<String>>;
+}
+
+export interface LanguagePreviousValues {
+  id: ID_Output;
+  languageCode: String;
+  locale: String;
+  textDirection: String;
+  displayName: String;
+  nativeName: String;
+}
+
+export interface LanguagePreviousValuesPromise
+  extends Promise<LanguagePreviousValues>,
+    Fragmentable {
+  id: () => Promise<ID_Output>;
+  languageCode: () => Promise<String>;
+  locale: () => Promise<String>;
+  textDirection: () => Promise<String>;
+  displayName: () => Promise<String>;
+  nativeName: () => Promise<String>;
+}
+
+export interface LanguagePreviousValuesSubscription
+  extends Promise<AsyncIterator<LanguagePreviousValues>>,
+    Fragmentable {
+  id: () => Promise<AsyncIterator<ID_Output>>;
+  languageCode: () => Promise<AsyncIterator<String>>;
+  locale: () => Promise<AsyncIterator<String>>;
+  textDirection: () => Promise<AsyncIterator<String>>;
+  displayName: () => Promise<AsyncIterator<String>>;
+  nativeName: () => Promise<AsyncIterator<String>>;
+}
+
+export interface AggregateCategory {
+  count: Int;
+}
+
+export interface AggregateCategoryPromise
+  extends Promise<AggregateCategory>,
+    Fragmentable {
+  count: () => Promise<Int>;
+}
+
+export interface AggregateCategorySubscription
+  extends Promise<AsyncIterator<AggregateCategory>>,
+    Fragmentable {
+  count: () => Promise<AsyncIterator<Int>>;
+}
+
+export interface LanguageTranslationConnection {
+  pageInfo: PageInfo;
+  edges: LanguageTranslationEdge[];
+}
+
+export interface LanguageTranslationConnectionPromise
+  extends Promise<LanguageTranslationConnection>,
+    Fragmentable {
+  pageInfo: <T = PageInfoPromise>() => T;
+  edges: <T = FragmentableArray<LanguageTranslationEdge>>() => T;
+  aggregate: <T = AggregateLanguageTranslationPromise>() => T;
+}
+
+export interface LanguageTranslationConnectionSubscription
+  extends Promise<AsyncIterator<LanguageTranslationConnection>>,
+    Fragmentable {
+  pageInfo: <T = PageInfoSubscription>() => T;
+  edges: <
+    T = Promise<AsyncIterator<LanguageTranslationEdgeSubscription>>
+  >() => T;
+  aggregate: <T = AggregateLanguageTranslationSubscription>() => T;
+}
+
+export interface User {
+  id: ID_Output;
+  firstName: String;
+  lastName: String;
+  email: String;
+  password?: String;
+  tempToken?: String;
+  tempTokenExpiry?: Float;
+  jobTitle?: String;
+  country?: String;
+  city?: String;
+  howHeard?: String;
+  permissions: Permission[];
+  isConfirmed: Boolean;
+}
+
+export interface UserPromise extends Promise<User>, Fragmentable {
+  id: () => Promise<ID_Output>;
+  firstName: () => Promise<String>;
+  lastName: () => Promise<String>;
+  email: () => Promise<String>;
+  password: () => Promise<String>;
+  tempToken: () => Promise<String>;
+  tempTokenExpiry: () => Promise<Float>;
+  jobTitle: () => Promise<String>;
+  country: () => Promise<String>;
+  city: () => Promise<String>;
+  howHeard: () => Promise<String>;
+  permissions: () => Promise<Permission[]>;
+  team: <T = TeamPromise>() => T;
+  isConfirmed: () => Promise<Boolean>;
+}
+
+export interface UserSubscription
+  extends Promise<AsyncIterator<User>>,
+    Fragmentable {
+  id: () => Promise<AsyncIterator<ID_Output>>;
+  firstName: () => Promise<AsyncIterator<String>>;
+  lastName: () => Promise<AsyncIterator<String>>;
+  email: () => Promise<AsyncIterator<String>>;
+  password: () => Promise<AsyncIterator<String>>;
+  tempToken: () => Promise<AsyncIterator<String>>;
+  tempTokenExpiry: () => Promise<AsyncIterator<Float>>;
+  jobTitle: () => Promise<AsyncIterator<String>>;
+  country: () => Promise<AsyncIterator<String>>;
+  city: () => Promise<AsyncIterator<String>>;
+  howHeard: () => Promise<AsyncIterator<String>>;
+  permissions: () => Promise<AsyncIterator<Permission[]>>;
+  team: <T = TeamSubscription>() => T;
+  isConfirmed: () => Promise<AsyncIterator<Boolean>>;
+}
+
+export interface LanguageTranslationSubscriptionPayload {
+  mutation: MutationType;
+  node: LanguageTranslation;
+  updatedFields: String[];
+  previousValues: LanguageTranslationPreviousValues;
+}
+
+export interface LanguageTranslationSubscriptionPayloadPromise
+  extends Promise<LanguageTranslationSubscriptionPayload>,
+    Fragmentable {
+  mutation: () => Promise<MutationType>;
+  node: <T = LanguageTranslationPromise>() => T;
+  updatedFields: () => Promise<String[]>;
+  previousValues: <T = LanguageTranslationPreviousValuesPromise>() => T;
+}
+
+export interface LanguageTranslationSubscriptionPayloadSubscription
+  extends Promise<AsyncIterator<LanguageTranslationSubscriptionPayload>>,
+    Fragmentable {
+  mutation: () => Promise<AsyncIterator<MutationType>>;
+  node: <T = LanguageTranslationSubscription>() => T;
+  updatedFields: () => Promise<AsyncIterator<String[]>>;
+  previousValues: <T = LanguageTranslationPreviousValuesSubscription>() => T;
+}
+
+export interface AggregateTag {
+  count: Int;
+}
+
+export interface AggregateTagPromise
+  extends Promise<AggregateTag>,
+    Fragmentable {
+  count: () => Promise<Int>;
+}
+
+export interface AggregateTagSubscription
+  extends Promise<AsyncIterator<AggregateTag>>,
+    Fragmentable {
+  count: () => Promise<AsyncIterator<Int>>;
+}
+
+export interface LanguageTranslationPreviousValues {
+  id: ID_Output;
+  name: String;
+}
+
+export interface LanguageTranslationPreviousValuesPromise
+  extends Promise<LanguageTranslationPreviousValues>,
+    Fragmentable {
+  id: () => Promise<ID_Output>;
+  name: () => Promise<String>;
+}
+
+export interface LanguageTranslationPreviousValuesSubscription
+  extends Promise<AsyncIterator<LanguageTranslationPreviousValues>>,
+    Fragmentable {
+  id: () => Promise<AsyncIterator<ID_Output>>;
+  name: () => Promise<AsyncIterator<String>>;
+}
+
+export interface TagConnection {
+  pageInfo: PageInfo;
+  edges: TagEdge[];
+}
+
+export interface TagConnectionPromise
+  extends Promise<TagConnection>,
+    Fragmentable {
+  pageInfo: <T = PageInfoPromise>() => T;
+  edges: <T = FragmentableArray<TagEdge>>() => T;
+  aggregate: <T = AggregateTagPromise>() => T;
+}
+
+export interface TagConnectionSubscription
+  extends Promise<AsyncIterator<TagConnection>>,
+    Fragmentable {
+  pageInfo: <T = PageInfoSubscription>() => T;
+  edges: <T = Promise<AsyncIterator<TagEdgeSubscription>>>() => T;
+  aggregate: <T = AggregateTagSubscription>() => T;
+}
+
+export interface AggregateLanguage {
+  count: Int;
+}
+
+export interface AggregateLanguagePromise
+  extends Promise<AggregateLanguage>,
+    Fragmentable {
+  count: () => Promise<Int>;
+}
+
+export interface AggregateLanguageSubscription
+  extends Promise<AsyncIterator<AggregateLanguage>>,
+    Fragmentable {
+  count: () => Promise<AsyncIterator<Int>>;
+}
+
+export interface Tag {
+  id: ID_Output;
+}
+
+export interface TagPromise extends Promise<Tag>, Fragmentable {
+  id: () => Promise<ID_Output>;
+  translations: <T = FragmentableArray<LanguageTranslation>>(args?: {
+    where?: LanguageTranslationWhereInput;
+    orderBy?: LanguageTranslationOrderByInput;
+    skip?: Int;
+    after?: String;
+    before?: String;
+    first?: Int;
+    last?: Int;
+  }) => T;
+}
+
+export interface TagSubscription
+  extends Promise<AsyncIterator<Tag>>,
+    Fragmentable {
+  id: () => Promise<AsyncIterator<ID_Output>>;
+  translations: <
+    T = Promise<AsyncIterator<LanguageTranslationSubscription>>
+  >(args?: {
+    where?: LanguageTranslationWhereInput;
+    orderBy?: LanguageTranslationOrderByInput;
+    skip?: Int;
+    after?: String;
+    before?: String;
+    first?: Int;
+    last?: Int;
+  }) => T;
+}
+
+export interface SupportFileSubscriptionPayload {
+  mutation: MutationType;
+  node: SupportFile;
+  updatedFields: String[];
+  previousValues: SupportFilePreviousValues;
+}
+
+export interface SupportFileSubscriptionPayloadPromise
+  extends Promise<SupportFileSubscriptionPayload>,
+    Fragmentable {
+  mutation: () => Promise<MutationType>;
+  node: <T = SupportFilePromise>() => T;
+  updatedFields: () => Promise<String[]>;
+  previousValues: <T = SupportFilePreviousValuesPromise>() => T;
+}
+
+export interface SupportFileSubscriptionPayloadSubscription
+  extends Promise<AsyncIterator<SupportFileSubscriptionPayload>>,
+    Fragmentable {
+  mutation: () => Promise<AsyncIterator<MutationType>>;
+  node: <T = SupportFileSubscription>() => T;
+  updatedFields: () => Promise<AsyncIterator<String[]>>;
+  previousValues: <T = SupportFilePreviousValuesSubscription>() => T;
+}
+
+export interface SupportFileUseEdge {
+  node: SupportFileUse;
+  cursor: String;
+}
+
+export interface SupportFileUseEdgePromise
+  extends Promise<SupportFileUseEdge>,
+    Fragmentable {
+  node: <T = SupportFileUsePromise>() => T;
+  cursor: () => Promise<String>;
+}
+
+export interface SupportFileUseEdgeSubscription
+  extends Promise<AsyncIterator<SupportFileUseEdge>>,
+    Fragmentable {
+  node: <T = SupportFileUseSubscription>() => T;
+  cursor: () => Promise<AsyncIterator<String>>;
+}
+
+export interface SupportFilePreviousValues {
+  id: ID_Output;
+  createdAt: DateTimeOutput;
+  updatedAt: DateTimeOutput;
+  url?: String;
+  md5?: String;
+  filename?: String;
+  filetype?: String;
+  filesize?: Float;
+}
+
+export interface SupportFilePreviousValuesPromise
+  extends Promise<SupportFilePreviousValues>,
+    Fragmentable {
+  id: () => Promise<ID_Output>;
+  createdAt: () => Promise<DateTimeOutput>;
+  updatedAt: () => Promise<DateTimeOutput>;
+  url: () => Promise<String>;
+  md5: () => Promise<String>;
+  filename: () => Promise<String>;
+  filetype: () => Promise<String>;
+  filesize: () => Promise<Float>;
+}
+
+export interface SupportFilePreviousValuesSubscription
+  extends Promise<AsyncIterator<SupportFilePreviousValues>>,
+    Fragmentable {
+  id: () => Promise<AsyncIterator<ID_Output>>;
+  createdAt: () => Promise<AsyncIterator<DateTimeOutput>>;
+  updatedAt: () => Promise<AsyncIterator<DateTimeOutput>>;
+  url: () => Promise<AsyncIterator<String>>;
+  md5: () => Promise<AsyncIterator<String>>;
+  filename: () => Promise<AsyncIterator<String>>;
+  filetype: () => Promise<AsyncIterator<String>>;
+  filesize: () => Promise<AsyncIterator<Float>>;
+}
+
+export interface DimensionsEdge {
+  node: Dimensions;
+  cursor: String;
+}
+
+export interface DimensionsEdgePromise
+  extends Promise<DimensionsEdge>,
+    Fragmentable {
+  node: <T = DimensionsPromise>() => T;
+  cursor: () => Promise<String>;
+}
+
+export interface DimensionsEdgeSubscription
+  extends Promise<AsyncIterator<DimensionsEdge>>,
+    Fragmentable {
+  node: <T = DimensionsSubscription>() => T;
+  cursor: () => Promise<AsyncIterator<String>>;
+}
+
+export interface LanguageEdge {
+  node: Language;
+  cursor: String;
+}
+
+export interface LanguageEdgePromise
+  extends Promise<LanguageEdge>,
+    Fragmentable {
+  node: <T = LanguagePromise>() => T;
+  cursor: () => Promise<String>;
+}
+
+export interface LanguageEdgeSubscription
+  extends Promise<AsyncIterator<LanguageEdge>>,
+    Fragmentable {
+  node: <T = LanguageSubscription>() => T;
+  cursor: () => Promise<AsyncIterator<String>>;
+}
+
+export interface VideoUnitSubscriptionPayload {
+  mutation: MutationType;
+  node: VideoUnit;
+  updatedFields: String[];
+  previousValues: VideoUnitPreviousValues;
+}
+
+export interface VideoUnitSubscriptionPayloadPromise
+  extends Promise<VideoUnitSubscriptionPayload>,
+    Fragmentable {
+  mutation: () => Promise<MutationType>;
+  node: <T = VideoUnitPromise>() => T;
+  updatedFields: () => Promise<String[]>;
+  previousValues: <T = VideoUnitPreviousValuesPromise>() => T;
+}
+
+export interface VideoUnitSubscriptionPayloadSubscription
+  extends Promise<AsyncIterator<VideoUnitSubscriptionPayload>>,
+    Fragmentable {
+  mutation: () => Promise<AsyncIterator<MutationType>>;
+  node: <T = VideoUnitSubscription>() => T;
+  updatedFields: () => Promise<AsyncIterator<String[]>>;
+  previousValues: <T = VideoUnitPreviousValuesSubscription>() => T;
+}
+
+export interface SupportFileUseSubscriptionPayload {
+  mutation: MutationType;
+  node: SupportFileUse;
+  updatedFields: String[];
+  previousValues: SupportFileUsePreviousValues;
+}
+
+export interface SupportFileUseSubscriptionPayloadPromise
+  extends Promise<SupportFileUseSubscriptionPayload>,
+    Fragmentable {
+  mutation: () => Promise<MutationType>;
+  node: <T = SupportFileUsePromise>() => T;
+  updatedFields: () => Promise<String[]>;
+  previousValues: <T = SupportFileUsePreviousValuesPromise>() => T;
+}
+
+export interface SupportFileUseSubscriptionPayloadSubscription
+  extends Promise<AsyncIterator<SupportFileUseSubscriptionPayload>>,
+    Fragmentable {
+  mutation: () => Promise<AsyncIterator<MutationType>>;
+  node: <T = SupportFileUseSubscription>() => T;
+  updatedFields: () => Promise<AsyncIterator<String[]>>;
+  previousValues: <T = SupportFileUsePreviousValuesSubscription>() => T;
+}
+
+export interface VideoUseConnection {
+  pageInfo: PageInfo;
+  edges: VideoUseEdge[];
+}
+
+export interface VideoUseConnectionPromise
+  extends Promise<VideoUseConnection>,
+    Fragmentable {
+  pageInfo: <T = PageInfoPromise>() => T;
+  edges: <T = FragmentableArray<VideoUseEdge>>() => T;
+  aggregate: <T = AggregateVideoUsePromise>() => T;
+}
+
+export interface VideoUseConnectionSubscription
+  extends Promise<AsyncIterator<VideoUseConnection>>,
+    Fragmentable {
+  pageInfo: <T = PageInfoSubscription>() => T;
+  edges: <T = Promise<AsyncIterator<VideoUseEdgeSubscription>>>() => T;
+  aggregate: <T = AggregateVideoUseSubscription>() => T;
+}
+
+export interface SupportFileUsePreviousValues {
+  id: ID_Output;
+  name: String;
+}
+
+export interface SupportFileUsePreviousValuesPromise
+  extends Promise<SupportFileUsePreviousValues>,
+    Fragmentable {
+  id: () => Promise<ID_Output>;
+  name: () => Promise<String>;
+}
+
+export interface SupportFileUsePreviousValuesSubscription
+  extends Promise<AsyncIterator<SupportFileUsePreviousValues>>,
+    Fragmentable {
+  id: () => Promise<AsyncIterator<ID_Output>>;
+  name: () => Promise<AsyncIterator<String>>;
+}
+
+export interface VideoUnit {
+  id: ID_Output;
+  createdAt: DateTimeOutput;
+  updatedAt: DateTimeOutput;
+  title: String;
+  descPublic?: String;
+}
+
+export interface VideoUnitPromise extends Promise<VideoUnit>, Fragmentable {
+  id: () => Promise<ID_Output>;
+  createdAt: () => Promise<DateTimeOutput>;
+  updatedAt: () => Promise<DateTimeOutput>;
+  language: <T = LanguagePromise>() => T;
+  title: () => Promise<String>;
+  descPublic: () => Promise<String>;
+  files: <T = FragmentableArray<VideoFile>>(args?: {
+    where?: VideoFileWhereInput;
+    orderBy?: VideoFileOrderByInput;
+    skip?: Int;
+    after?: String;
+    before?: String;
+    first?: Int;
+    last?: Int;
+  }) => T;
+  tags: <T = FragmentableArray<Tag>>(args?: {
+    where?: TagWhereInput;
+    orderBy?: TagOrderByInput;
+    skip?: Int;
+    after?: String;
+    before?: String;
+    first?: Int;
+    last?: Int;
+  }) => T;
+  categories: <T = FragmentableArray<Category>>(args?: {
+    where?: CategoryWhereInput;
+    orderBy?: CategoryOrderByInput;
+    skip?: Int;
+    after?: String;
+    before?: String;
+    first?: Int;
+    last?: Int;
+  }) => T;
+  thumbnails: <T = FragmentableArray<Thumbnail>>(args?: {
+    where?: ThumbnailWhereInput;
+    orderBy?: ThumbnailOrderByInput;
+    skip?: Int;
+    after?: String;
+    before?: String;
+    first?: Int;
+    last?: Int;
+  }) => T;
+}
+
+export interface VideoUnitSubscription
+  extends Promise<AsyncIterator<VideoUnit>>,
+    Fragmentable {
+  id: () => Promise<AsyncIterator<ID_Output>>;
+  createdAt: () => Promise<AsyncIterator<DateTimeOutput>>;
+  updatedAt: () => Promise<AsyncIterator<DateTimeOutput>>;
+  language: <T = LanguageSubscription>() => T;
+  title: () => Promise<AsyncIterator<String>>;
+  descPublic: () => Promise<AsyncIterator<String>>;
+  files: <T = Promise<AsyncIterator<VideoFileSubscription>>>(args?: {
+    where?: VideoFileWhereInput;
+    orderBy?: VideoFileOrderByInput;
+    skip?: Int;
+    after?: String;
+    before?: String;
+    first?: Int;
+    last?: Int;
+  }) => T;
+  tags: <T = Promise<AsyncIterator<TagSubscription>>>(args?: {
+    where?: TagWhereInput;
+    orderBy?: TagOrderByInput;
+    skip?: Int;
+    after?: String;
+    before?: String;
+    first?: Int;
+    last?: Int;
+  }) => T;
+  categories: <T = Promise<AsyncIterator<CategorySubscription>>>(args?: {
+    where?: CategoryWhereInput;
+    orderBy?: CategoryOrderByInput;
+    skip?: Int;
+    after?: String;
+    before?: String;
+    first?: Int;
+    last?: Int;
+  }) => T;
+  thumbnails: <T = Promise<AsyncIterator<ThumbnailSubscription>>>(args?: {
+    where?: ThumbnailWhereInput;
+    orderBy?: ThumbnailOrderByInput;
+    skip?: Int;
+    after?: String;
+    before?: String;
+    first?: Int;
+    last?: Int;
+  }) => T;
+}
+
+export interface LanguageConnection {
+  pageInfo: PageInfo;
+  edges: LanguageEdge[];
+}
+
+export interface LanguageConnectionPromise
+  extends Promise<LanguageConnection>,
+    Fragmentable {
+  pageInfo: <T = PageInfoPromise>() => T;
+  edges: <T = FragmentableArray<LanguageEdge>>() => T;
+  aggregate: <T = AggregateLanguagePromise>() => T;
+}
+
+export interface LanguageConnectionSubscription
+  extends Promise<AsyncIterator<LanguageConnection>>,
+    Fragmentable {
+  pageInfo: <T = PageInfoSubscription>() => T;
+  edges: <T = Promise<AsyncIterator<LanguageEdgeSubscription>>>() => T;
+  aggregate: <T = AggregateLanguageSubscription>() => T;
+}
+
+export interface AggregateVideoFile {
+  count: Int;
+}
+
+export interface AggregateVideoFilePromise
+  extends Promise<AggregateVideoFile>,
+    Fragmentable {
+  count: () => Promise<Int>;
+}
+
+export interface AggregateVideoFileSubscription
+  extends Promise<AsyncIterator<AggregateVideoFile>>,
+    Fragmentable {
+  count: () => Promise<AsyncIterator<Int>>;
+}
+
+export interface TagSubscriptionPayload {
+  mutation: MutationType;
+  node: Tag;
+  updatedFields: String[];
+  previousValues: TagPreviousValues;
+}
+
+export interface TagSubscriptionPayloadPromise
+  extends Promise<TagSubscriptionPayload>,
+    Fragmentable {
+  mutation: () => Promise<MutationType>;
+  node: <T = TagPromise>() => T;
+  updatedFields: () => Promise<String[]>;
+  previousValues: <T = TagPreviousValuesPromise>() => T;
+}
+
+export interface TagSubscriptionPayloadSubscription
+  extends Promise<AsyncIterator<TagSubscriptionPayload>>,
+    Fragmentable {
+  mutation: () => Promise<AsyncIterator<MutationType>>;
+  node: <T = TagSubscription>() => T;
+  updatedFields: () => Promise<AsyncIterator<String[]>>;
+  previousValues: <T = TagPreviousValuesSubscription>() => T;
+}
+
+export interface VideoStream {
+  id: ID_Output;
+  site?: String;
+  url?: String;
+  embedUrl?: String;
+}
+
+export interface VideoStreamPromise extends Promise<VideoStream>, Fragmentable {
+  id: () => Promise<ID_Output>;
+  site: () => Promise<String>;
+  url: () => Promise<String>;
+  embedUrl: () => Promise<String>;
+}
+
+export interface VideoStreamSubscription
+  extends Promise<AsyncIterator<VideoStream>>,
+    Fragmentable {
+  id: () => Promise<AsyncIterator<ID_Output>>;
+  site: () => Promise<AsyncIterator<String>>;
+  url: () => Promise<AsyncIterator<String>>;
+  embedUrl: () => Promise<AsyncIterator<String>>;
+}
+
+export interface TagPreviousValues {
+  id: ID_Output;
+}
+
+export interface TagPreviousValuesPromise
+  extends Promise<TagPreviousValues>,
+    Fragmentable {
+  id: () => Promise<ID_Output>;
+}
+
+export interface TagPreviousValuesSubscription
+  extends Promise<AsyncIterator<TagPreviousValues>>,
+    Fragmentable {
+  id: () => Promise<AsyncIterator<ID_Output>>;
 }
 
 export interface VideoFile {
@@ -6065,7 +6119,15 @@ export interface VideoFilePromise extends Promise<VideoFile>, Fragmentable {
   bitrate: () => Promise<Float>;
   filesize: () => Promise<Float>;
   dimensions: <T = DimensionsPromise>() => T;
-  stream: <T = VideoStreamPromise>() => T;
+  stream: <T = FragmentableArray<VideoStream>>(args?: {
+    where?: VideoStreamWhereInput;
+    orderBy?: VideoStreamOrderByInput;
+    skip?: Int;
+    after?: String;
+    before?: String;
+    first?: Int;
+    last?: Int;
+  }) => T;
 }
 
 export interface VideoFileSubscription
@@ -6086,7 +6148,515 @@ export interface VideoFileSubscription
   bitrate: () => Promise<AsyncIterator<Float>>;
   filesize: () => Promise<AsyncIterator<Float>>;
   dimensions: <T = DimensionsSubscription>() => T;
-  stream: <T = VideoStreamSubscription>() => T;
+  stream: <T = Promise<AsyncIterator<VideoStreamSubscription>>>(args?: {
+    where?: VideoStreamWhereInput;
+    orderBy?: VideoStreamOrderByInput;
+    skip?: Int;
+    after?: String;
+    before?: String;
+    first?: Int;
+    last?: Int;
+  }) => T;
+}
+
+export interface AggregateImageUse {
+  count: Int;
+}
+
+export interface AggregateImageUsePromise
+  extends Promise<AggregateImageUse>,
+    Fragmentable {
+  count: () => Promise<Int>;
+}
+
+export interface AggregateImageUseSubscription
+  extends Promise<AsyncIterator<AggregateImageUse>>,
+    Fragmentable {
+  count: () => Promise<AsyncIterator<Int>>;
+}
+
+export interface AggregateThumbnail {
+  count: Int;
+}
+
+export interface AggregateThumbnailPromise
+  extends Promise<AggregateThumbnail>,
+    Fragmentable {
+  count: () => Promise<Int>;
+}
+
+export interface AggregateThumbnailSubscription
+  extends Promise<AsyncIterator<AggregateThumbnail>>,
+    Fragmentable {
+  count: () => Promise<AsyncIterator<Int>>;
+}
+
+export interface TeamSubscriptionPayload {
+  mutation: MutationType;
+  node: Team;
+  updatedFields: String[];
+  previousValues: TeamPreviousValues;
+}
+
+export interface TeamSubscriptionPayloadPromise
+  extends Promise<TeamSubscriptionPayload>,
+    Fragmentable {
+  mutation: () => Promise<MutationType>;
+  node: <T = TeamPromise>() => T;
+  updatedFields: () => Promise<String[]>;
+  previousValues: <T = TeamPreviousValuesPromise>() => T;
+}
+
+export interface TeamSubscriptionPayloadSubscription
+  extends Promise<AsyncIterator<TeamSubscriptionPayload>>,
+    Fragmentable {
+  mutation: () => Promise<AsyncIterator<MutationType>>;
+  node: <T = TeamSubscription>() => T;
+  updatedFields: () => Promise<AsyncIterator<String[]>>;
+  previousValues: <T = TeamPreviousValuesSubscription>() => T;
+}
+
+export interface CategoryEdge {
+  node: Category;
+  cursor: String;
+}
+
+export interface CategoryEdgePromise
+  extends Promise<CategoryEdge>,
+    Fragmentable {
+  node: <T = CategoryPromise>() => T;
+  cursor: () => Promise<String>;
+}
+
+export interface CategoryEdgeSubscription
+  extends Promise<AsyncIterator<CategoryEdge>>,
+    Fragmentable {
+  node: <T = CategorySubscription>() => T;
+  cursor: () => Promise<AsyncIterator<String>>;
+}
+
+export interface TeamPreviousValues {
+  id: ID_Output;
+  name: String;
+  organization: String;
+  contentTypes: ContentType[];
+  isConfirmed: Boolean;
+}
+
+export interface TeamPreviousValuesPromise
+  extends Promise<TeamPreviousValues>,
+    Fragmentable {
+  id: () => Promise<ID_Output>;
+  name: () => Promise<String>;
+  organization: () => Promise<String>;
+  contentTypes: () => Promise<ContentType[]>;
+  isConfirmed: () => Promise<Boolean>;
+}
+
+export interface TeamPreviousValuesSubscription
+  extends Promise<AsyncIterator<TeamPreviousValues>>,
+    Fragmentable {
+  id: () => Promise<AsyncIterator<ID_Output>>;
+  name: () => Promise<AsyncIterator<String>>;
+  organization: () => Promise<AsyncIterator<String>>;
+  contentTypes: () => Promise<AsyncIterator<ContentType[]>>;
+  isConfirmed: () => Promise<AsyncIterator<Boolean>>;
+}
+
+export interface TeamConnection {
+  pageInfo: PageInfo;
+  edges: TeamEdge[];
+}
+
+export interface TeamConnectionPromise
+  extends Promise<TeamConnection>,
+    Fragmentable {
+  pageInfo: <T = PageInfoPromise>() => T;
+  edges: <T = FragmentableArray<TeamEdge>>() => T;
+  aggregate: <T = AggregateTeamPromise>() => T;
+}
+
+export interface TeamConnectionSubscription
+  extends Promise<AsyncIterator<TeamConnection>>,
+    Fragmentable {
+  pageInfo: <T = PageInfoSubscription>() => T;
+  edges: <T = Promise<AsyncIterator<TeamEdgeSubscription>>>() => T;
+  aggregate: <T = AggregateTeamSubscription>() => T;
+}
+
+export interface ImageUseEdge {
+  node: ImageUse;
+  cursor: String;
+}
+
+export interface ImageUseEdgePromise
+  extends Promise<ImageUseEdge>,
+    Fragmentable {
+  node: <T = ImageUsePromise>() => T;
+  cursor: () => Promise<String>;
+}
+
+export interface ImageUseEdgeSubscription
+  extends Promise<AsyncIterator<ImageUseEdge>>,
+    Fragmentable {
+  node: <T = ImageUseSubscription>() => T;
+  cursor: () => Promise<AsyncIterator<String>>;
+}
+
+export interface Team {
+  id: ID_Output;
+  name: String;
+  organization: String;
+  contentTypes: ContentType[];
+  isConfirmed: Boolean;
+}
+
+export interface TeamPromise extends Promise<Team>, Fragmentable {
+  id: () => Promise<ID_Output>;
+  name: () => Promise<String>;
+  organization: () => Promise<String>;
+  members: <T = FragmentableArray<User>>(args?: {
+    where?: UserWhereInput;
+    orderBy?: UserOrderByInput;
+    skip?: Int;
+    after?: String;
+    before?: String;
+    first?: Int;
+    last?: Int;
+  }) => T;
+  contentTypes: () => Promise<ContentType[]>;
+  isConfirmed: () => Promise<Boolean>;
+}
+
+export interface TeamSubscription
+  extends Promise<AsyncIterator<Team>>,
+    Fragmentable {
+  id: () => Promise<AsyncIterator<ID_Output>>;
+  name: () => Promise<AsyncIterator<String>>;
+  organization: () => Promise<AsyncIterator<String>>;
+  members: <T = Promise<AsyncIterator<UserSubscription>>>(args?: {
+    where?: UserWhereInput;
+    orderBy?: UserOrderByInput;
+    skip?: Int;
+    after?: String;
+    before?: String;
+    first?: Int;
+    last?: Int;
+  }) => T;
+  contentTypes: () => Promise<AsyncIterator<ContentType[]>>;
+  isConfirmed: () => Promise<AsyncIterator<Boolean>>;
+}
+
+export interface ThumbnailSubscriptionPayload {
+  mutation: MutationType;
+  node: Thumbnail;
+  updatedFields: String[];
+  previousValues: ThumbnailPreviousValues;
+}
+
+export interface ThumbnailSubscriptionPayloadPromise
+  extends Promise<ThumbnailSubscriptionPayload>,
+    Fragmentable {
+  mutation: () => Promise<MutationType>;
+  node: <T = ThumbnailPromise>() => T;
+  updatedFields: () => Promise<String[]>;
+  previousValues: <T = ThumbnailPreviousValuesPromise>() => T;
+}
+
+export interface ThumbnailSubscriptionPayloadSubscription
+  extends Promise<AsyncIterator<ThumbnailSubscriptionPayload>>,
+    Fragmentable {
+  mutation: () => Promise<AsyncIterator<MutationType>>;
+  node: <T = ThumbnailSubscription>() => T;
+  updatedFields: () => Promise<AsyncIterator<String[]>>;
+  previousValues: <T = ThumbnailPreviousValuesSubscription>() => T;
+}
+
+export interface DimensionsConnection {
+  pageInfo: PageInfo;
+  edges: DimensionsEdge[];
+}
+
+export interface DimensionsConnectionPromise
+  extends Promise<DimensionsConnection>,
+    Fragmentable {
+  pageInfo: <T = PageInfoPromise>() => T;
+  edges: <T = FragmentableArray<DimensionsEdge>>() => T;
+  aggregate: <T = AggregateDimensionsPromise>() => T;
+}
+
+export interface DimensionsConnectionSubscription
+  extends Promise<AsyncIterator<DimensionsConnection>>,
+    Fragmentable {
+  pageInfo: <T = PageInfoSubscription>() => T;
+  edges: <T = Promise<AsyncIterator<DimensionsEdgeSubscription>>>() => T;
+  aggregate: <T = AggregateDimensionsSubscription>() => T;
+}
+
+export interface ThumbnailPreviousValues {
+  id: ID_Output;
+  size?: ThumbnailSize;
+}
+
+export interface ThumbnailPreviousValuesPromise
+  extends Promise<ThumbnailPreviousValues>,
+    Fragmentable {
+  id: () => Promise<ID_Output>;
+  size: () => Promise<ThumbnailSize>;
+}
+
+export interface ThumbnailPreviousValuesSubscription
+  extends Promise<AsyncIterator<ThumbnailPreviousValues>>,
+    Fragmentable {
+  id: () => Promise<AsyncIterator<ID_Output>>;
+  size: () => Promise<AsyncIterator<ThumbnailSize>>;
+}
+
+export interface SupportFileUseConnection {
+  pageInfo: PageInfo;
+  edges: SupportFileUseEdge[];
+}
+
+export interface SupportFileUseConnectionPromise
+  extends Promise<SupportFileUseConnection>,
+    Fragmentable {
+  pageInfo: <T = PageInfoPromise>() => T;
+  edges: <T = FragmentableArray<SupportFileUseEdge>>() => T;
+  aggregate: <T = AggregateSupportFileUsePromise>() => T;
+}
+
+export interface SupportFileUseConnectionSubscription
+  extends Promise<AsyncIterator<SupportFileUseConnection>>,
+    Fragmentable {
+  pageInfo: <T = PageInfoSubscription>() => T;
+  edges: <T = Promise<AsyncIterator<SupportFileUseEdgeSubscription>>>() => T;
+  aggregate: <T = AggregateSupportFileUseSubscription>() => T;
+}
+
+export interface ImageUseConnection {
+  pageInfo: PageInfo;
+  edges: ImageUseEdge[];
+}
+
+export interface ImageUseConnectionPromise
+  extends Promise<ImageUseConnection>,
+    Fragmentable {
+  pageInfo: <T = PageInfoPromise>() => T;
+  edges: <T = FragmentableArray<ImageUseEdge>>() => T;
+  aggregate: <T = AggregateImageUsePromise>() => T;
+}
+
+export interface ImageUseConnectionSubscription
+  extends Promise<AsyncIterator<ImageUseConnection>>,
+    Fragmentable {
+  pageInfo: <T = PageInfoSubscription>() => T;
+  edges: <T = Promise<AsyncIterator<ImageUseEdgeSubscription>>>() => T;
+  aggregate: <T = AggregateImageUseSubscription>() => T;
+}
+
+export interface AggregateVideoUse {
+  count: Int;
+}
+
+export interface AggregateVideoUsePromise
+  extends Promise<AggregateVideoUse>,
+    Fragmentable {
+  count: () => Promise<Int>;
+}
+
+export interface AggregateVideoUseSubscription
+  extends Promise<AsyncIterator<AggregateVideoUse>>,
+    Fragmentable {
+  count: () => Promise<AsyncIterator<Int>>;
+}
+
+export interface UserSubscriptionPayload {
+  mutation: MutationType;
+  node: User;
+  updatedFields: String[];
+  previousValues: UserPreviousValues;
+}
+
+export interface UserSubscriptionPayloadPromise
+  extends Promise<UserSubscriptionPayload>,
+    Fragmentable {
+  mutation: () => Promise<MutationType>;
+  node: <T = UserPromise>() => T;
+  updatedFields: () => Promise<String[]>;
+  previousValues: <T = UserPreviousValuesPromise>() => T;
+}
+
+export interface UserSubscriptionPayloadSubscription
+  extends Promise<AsyncIterator<UserSubscriptionPayload>>,
+    Fragmentable {
+  mutation: () => Promise<AsyncIterator<MutationType>>;
+  node: <T = UserSubscription>() => T;
+  updatedFields: () => Promise<AsyncIterator<String[]>>;
+  previousValues: <T = UserPreviousValuesSubscription>() => T;
+}
+
+export interface LanguageTranslation {
+  id: ID_Output;
+  name: String;
+}
+
+export interface LanguageTranslationPromise
+  extends Promise<LanguageTranslation>,
+    Fragmentable {
+  id: () => Promise<ID_Output>;
+  name: () => Promise<String>;
+  language: <T = LanguagePromise>() => T;
+}
+
+export interface LanguageTranslationSubscription
+  extends Promise<AsyncIterator<LanguageTranslation>>,
+    Fragmentable {
+  id: () => Promise<AsyncIterator<ID_Output>>;
+  name: () => Promise<AsyncIterator<String>>;
+  language: <T = LanguageSubscription>() => T;
+}
+
+export interface UserPreviousValues {
+  id: ID_Output;
+  firstName: String;
+  lastName: String;
+  email: String;
+  password?: String;
+  tempToken?: String;
+  tempTokenExpiry?: Float;
+  jobTitle?: String;
+  country?: String;
+  city?: String;
+  howHeard?: String;
+  permissions: Permission[];
+  isConfirmed: Boolean;
+}
+
+export interface UserPreviousValuesPromise
+  extends Promise<UserPreviousValues>,
+    Fragmentable {
+  id: () => Promise<ID_Output>;
+  firstName: () => Promise<String>;
+  lastName: () => Promise<String>;
+  email: () => Promise<String>;
+  password: () => Promise<String>;
+  tempToken: () => Promise<String>;
+  tempTokenExpiry: () => Promise<Float>;
+  jobTitle: () => Promise<String>;
+  country: () => Promise<String>;
+  city: () => Promise<String>;
+  howHeard: () => Promise<String>;
+  permissions: () => Promise<Permission[]>;
+  isConfirmed: () => Promise<Boolean>;
+}
+
+export interface UserPreviousValuesSubscription
+  extends Promise<AsyncIterator<UserPreviousValues>>,
+    Fragmentable {
+  id: () => Promise<AsyncIterator<ID_Output>>;
+  firstName: () => Promise<AsyncIterator<String>>;
+  lastName: () => Promise<AsyncIterator<String>>;
+  email: () => Promise<AsyncIterator<String>>;
+  password: () => Promise<AsyncIterator<String>>;
+  tempToken: () => Promise<AsyncIterator<String>>;
+  tempTokenExpiry: () => Promise<AsyncIterator<Float>>;
+  jobTitle: () => Promise<AsyncIterator<String>>;
+  country: () => Promise<AsyncIterator<String>>;
+  city: () => Promise<AsyncIterator<String>>;
+  howHeard: () => Promise<AsyncIterator<String>>;
+  permissions: () => Promise<AsyncIterator<Permission[]>>;
+  isConfirmed: () => Promise<AsyncIterator<Boolean>>;
+}
+
+export interface PageInfo {
+  hasNextPage: Boolean;
+  hasPreviousPage: Boolean;
+  startCursor?: String;
+  endCursor?: String;
+}
+
+export interface PageInfoPromise extends Promise<PageInfo>, Fragmentable {
+  hasNextPage: () => Promise<Boolean>;
+  hasPreviousPage: () => Promise<Boolean>;
+  startCursor: () => Promise<String>;
+  endCursor: () => Promise<String>;
+}
+
+export interface PageInfoSubscription
+  extends Promise<AsyncIterator<PageInfo>>,
+    Fragmentable {
+  hasNextPage: () => Promise<AsyncIterator<Boolean>>;
+  hasPreviousPage: () => Promise<AsyncIterator<Boolean>>;
+  startCursor: () => Promise<AsyncIterator<String>>;
+  endCursor: () => Promise<AsyncIterator<String>>;
+}
+
+export interface ImageFile {
+  id: ID_Output;
+  createdAt: DateTimeOutput;
+  updatedAt: DateTimeOutput;
+  alt?: String;
+  longdesc?: String;
+  caption?: String;
+  filename?: String;
+  filetype?: String;
+  md5?: String;
+  url?: String;
+}
+
+export interface ImageFilePromise extends Promise<ImageFile>, Fragmentable {
+  id: () => Promise<ID_Output>;
+  createdAt: () => Promise<DateTimeOutput>;
+  updatedAt: () => Promise<DateTimeOutput>;
+  language: <T = LanguagePromise>() => T;
+  dimensions: <T = DimensionsPromise>() => T;
+  alt: () => Promise<String>;
+  longdesc: () => Promise<String>;
+  caption: () => Promise<String>;
+  filename: () => Promise<String>;
+  filetype: () => Promise<String>;
+  use: <T = ImageUsePromise>() => T;
+  md5: () => Promise<String>;
+  url: () => Promise<String>;
+}
+
+export interface ImageFileSubscription
+  extends Promise<AsyncIterator<ImageFile>>,
+    Fragmentable {
+  id: () => Promise<AsyncIterator<ID_Output>>;
+  createdAt: () => Promise<AsyncIterator<DateTimeOutput>>;
+  updatedAt: () => Promise<AsyncIterator<DateTimeOutput>>;
+  language: <T = LanguageSubscription>() => T;
+  dimensions: <T = DimensionsSubscription>() => T;
+  alt: () => Promise<AsyncIterator<String>>;
+  longdesc: () => Promise<AsyncIterator<String>>;
+  caption: () => Promise<AsyncIterator<String>>;
+  filename: () => Promise<AsyncIterator<String>>;
+  filetype: () => Promise<AsyncIterator<String>>;
+  use: <T = ImageUseSubscription>() => T;
+  md5: () => Promise<AsyncIterator<String>>;
+  url: () => Promise<AsyncIterator<String>>;
+}
+
+export interface ThumbnailConnection {
+  pageInfo: PageInfo;
+  edges: ThumbnailEdge[];
+}
+
+export interface ThumbnailConnectionPromise
+  extends Promise<ThumbnailConnection>,
+    Fragmentable {
+  pageInfo: <T = PageInfoPromise>() => T;
+  edges: <T = FragmentableArray<ThumbnailEdge>>() => T;
+  aggregate: <T = AggregateThumbnailPromise>() => T;
+}
+
+export interface ThumbnailConnectionSubscription
+  extends Promise<AsyncIterator<ThumbnailConnection>>,
+    Fragmentable {
+  pageInfo: <T = PageInfoSubscription>() => T;
+  edges: <T = Promise<AsyncIterator<ThumbnailEdgeSubscription>>>() => T;
+  aggregate: <T = AggregateThumbnailSubscription>() => T;
 }
 
 export interface VideoFileSubscriptionPayload {
@@ -6114,23 +6684,24 @@ export interface VideoFileSubscriptionPayloadSubscription
   previousValues: <T = VideoFilePreviousValuesSubscription>() => T;
 }
 
-export interface CategoryEdge {
-  node: Category;
-  cursor: String;
+export interface Dimensions {
+  id: ID_Output;
+  width?: Int;
+  height?: Int;
 }
 
-export interface CategoryEdgePromise
-  extends Promise<CategoryEdge>,
-    Fragmentable {
-  node: <T = CategoryPromise>() => T;
-  cursor: () => Promise<String>;
+export interface DimensionsPromise extends Promise<Dimensions>, Fragmentable {
+  id: () => Promise<ID_Output>;
+  width: () => Promise<Int>;
+  height: () => Promise<Int>;
 }
 
-export interface CategoryEdgeSubscription
-  extends Promise<AsyncIterator<CategoryEdge>>,
+export interface DimensionsSubscription
+  extends Promise<AsyncIterator<Dimensions>>,
     Fragmentable {
-  node: <T = CategorySubscription>() => T;
-  cursor: () => Promise<AsyncIterator<String>>;
+  id: () => Promise<AsyncIterator<ID_Output>>;
+  width: () => Promise<AsyncIterator<Int>>;
+  height: () => Promise<AsyncIterator<Int>>;
 }
 
 export interface VideoFilePreviousValues {
@@ -6182,48 +6753,20 @@ export interface VideoFilePreviousValuesSubscription
   filesize: () => Promise<AsyncIterator<Float>>;
 }
 
-export interface Team {
-  id: ID_Output;
-  name: String;
-  organization: String;
-  contentTypes: ContentType[];
-  isConfirmed: Boolean;
+export interface AggregateSupportFileUse {
+  count: Int;
 }
 
-export interface TeamPromise extends Promise<Team>, Fragmentable {
-  id: () => Promise<ID_Output>;
-  name: () => Promise<String>;
-  organization: () => Promise<String>;
-  members: <T = FragmentableArray<User>>(args?: {
-    where?: UserWhereInput;
-    orderBy?: UserOrderByInput;
-    skip?: Int;
-    after?: String;
-    before?: String;
-    first?: Int;
-    last?: Int;
-  }) => T;
-  contentTypes: () => Promise<ContentType[]>;
-  isConfirmed: () => Promise<Boolean>;
-}
-
-export interface TeamSubscription
-  extends Promise<AsyncIterator<Team>>,
+export interface AggregateSupportFileUsePromise
+  extends Promise<AggregateSupportFileUse>,
     Fragmentable {
-  id: () => Promise<AsyncIterator<ID_Output>>;
-  name: () => Promise<AsyncIterator<String>>;
-  organization: () => Promise<AsyncIterator<String>>;
-  members: <T = Promise<AsyncIterator<UserSubscription>>>(args?: {
-    where?: UserWhereInput;
-    orderBy?: UserOrderByInput;
-    skip?: Int;
-    after?: String;
-    before?: String;
-    first?: Int;
-    last?: Int;
-  }) => T;
-  contentTypes: () => Promise<AsyncIterator<ContentType[]>>;
-  isConfirmed: () => Promise<AsyncIterator<Boolean>>;
+  count: () => Promise<Int>;
+}
+
+export interface AggregateSupportFileUseSubscription
+  extends Promise<AsyncIterator<AggregateSupportFileUse>>,
+    Fragmentable {
+  count: () => Promise<AsyncIterator<Int>>;
 }
 
 export interface AggregateImageFile {
@@ -6242,48 +6785,40 @@ export interface AggregateImageFileSubscription
   count: () => Promise<AsyncIterator<Int>>;
 }
 
-export interface VideoUnitConnection {
-  pageInfo: PageInfo;
-  edges: VideoUnitEdge[];
+export interface VideoUnitEdge {
+  node: VideoUnit;
+  cursor: String;
 }
 
-export interface VideoUnitConnectionPromise
-  extends Promise<VideoUnitConnection>,
+export interface VideoUnitEdgePromise
+  extends Promise<VideoUnitEdge>,
     Fragmentable {
-  pageInfo: <T = PageInfoPromise>() => T;
-  edges: <T = FragmentableArray<VideoUnitEdge>>() => T;
-  aggregate: <T = AggregateVideoUnitPromise>() => T;
+  node: <T = VideoUnitPromise>() => T;
+  cursor: () => Promise<String>;
 }
 
-export interface VideoUnitConnectionSubscription
-  extends Promise<AsyncIterator<VideoUnitConnection>>,
+export interface VideoUnitEdgeSubscription
+  extends Promise<AsyncIterator<VideoUnitEdge>>,
     Fragmentable {
-  pageInfo: <T = PageInfoSubscription>() => T;
-  edges: <T = Promise<AsyncIterator<VideoUnitEdgeSubscription>>>() => T;
-  aggregate: <T = AggregateVideoUnitSubscription>() => T;
+  node: <T = VideoUnitSubscription>() => T;
+  cursor: () => Promise<AsyncIterator<String>>;
 }
 
-export interface VideoStream {
-  id: ID_Output;
-  site?: String;
-  url?: String;
-  embedUrl?: String;
+export interface UserEdge {
+  node: User;
+  cursor: String;
 }
 
-export interface VideoStreamPromise extends Promise<VideoStream>, Fragmentable {
-  id: () => Promise<ID_Output>;
-  site: () => Promise<String>;
-  url: () => Promise<String>;
-  embedUrl: () => Promise<String>;
+export interface UserEdgePromise extends Promise<UserEdge>, Fragmentable {
+  node: <T = UserPromise>() => T;
+  cursor: () => Promise<String>;
 }
 
-export interface VideoStreamSubscription
-  extends Promise<AsyncIterator<VideoStream>>,
+export interface UserEdgeSubscription
+  extends Promise<AsyncIterator<UserEdge>>,
     Fragmentable {
-  id: () => Promise<AsyncIterator<ID_Output>>;
-  site: () => Promise<AsyncIterator<String>>;
-  url: () => Promise<AsyncIterator<String>>;
-  embedUrl: () => Promise<AsyncIterator<String>>;
+  node: <T = UserSubscription>() => T;
+  cursor: () => Promise<AsyncIterator<String>>;
 }
 
 export interface VideoStreamSubscriptionPayload {
@@ -6401,157 +6936,91 @@ export interface VideoProjectSubscriptionPayloadSubscription
   previousValues: <T = VideoProjectPreviousValuesSubscription>() => T;
 }
 
-export interface AggregateThumbnail {
+export interface AggregateTeam {
   count: Int;
 }
 
-export interface AggregateThumbnailPromise
-  extends Promise<AggregateThumbnail>,
+export interface AggregateTeamPromise
+  extends Promise<AggregateTeam>,
     Fragmentable {
   count: () => Promise<Int>;
 }
 
-export interface AggregateThumbnailSubscription
-  extends Promise<AsyncIterator<AggregateThumbnail>>,
+export interface AggregateTeamSubscription
+  extends Promise<AsyncIterator<AggregateTeam>>,
     Fragmentable {
   count: () => Promise<AsyncIterator<Int>>;
 }
 
-export interface VideoUnit {
-  id: ID_Output;
-  title: String;
-  descPublic?: String;
-}
-
-export interface VideoUnitPromise extends Promise<VideoUnit>, Fragmentable {
-  id: () => Promise<ID_Output>;
-  language: <T = LanguagePromise>() => T;
-  title: () => Promise<String>;
-  descPublic: () => Promise<String>;
-  files: <T = FragmentableArray<VideoFile>>(args?: {
-    where?: VideoFileWhereInput;
-    orderBy?: VideoFileOrderByInput;
-    skip?: Int;
-    after?: String;
-    before?: String;
-    first?: Int;
-    last?: Int;
-  }) => T;
-  tags: <T = FragmentableArray<Tag>>(args?: {
-    where?: TagWhereInput;
-    orderBy?: TagOrderByInput;
-    skip?: Int;
-    after?: String;
-    before?: String;
-    first?: Int;
-    last?: Int;
-  }) => T;
-  categories: <T = FragmentableArray<Category>>(args?: {
-    where?: CategoryWhereInput;
-    orderBy?: CategoryOrderByInput;
-    skip?: Int;
-    after?: String;
-    before?: String;
-    first?: Int;
-    last?: Int;
-  }) => T;
-  thumbnails: <T = FragmentableArray<Thumbnail>>(args?: {
-    where?: ThumbnailWhereInput;
-    orderBy?: ThumbnailOrderByInput;
-    skip?: Int;
-    after?: String;
-    before?: String;
-    first?: Int;
-    last?: Int;
-  }) => T;
-}
-
-export interface VideoUnitSubscription
-  extends Promise<AsyncIterator<VideoUnit>>,
-    Fragmentable {
-  id: () => Promise<AsyncIterator<ID_Output>>;
-  language: <T = LanguageSubscription>() => T;
-  title: () => Promise<AsyncIterator<String>>;
-  descPublic: () => Promise<AsyncIterator<String>>;
-  files: <T = Promise<AsyncIterator<VideoFileSubscription>>>(args?: {
-    where?: VideoFileWhereInput;
-    orderBy?: VideoFileOrderByInput;
-    skip?: Int;
-    after?: String;
-    before?: String;
-    first?: Int;
-    last?: Int;
-  }) => T;
-  tags: <T = Promise<AsyncIterator<TagSubscription>>>(args?: {
-    where?: TagWhereInput;
-    orderBy?: TagOrderByInput;
-    skip?: Int;
-    after?: String;
-    before?: String;
-    first?: Int;
-    last?: Int;
-  }) => T;
-  categories: <T = Promise<AsyncIterator<CategorySubscription>>>(args?: {
-    where?: CategoryWhereInput;
-    orderBy?: CategoryOrderByInput;
-    skip?: Int;
-    after?: String;
-    before?: String;
-    first?: Int;
-    last?: Int;
-  }) => T;
-  thumbnails: <T = Promise<AsyncIterator<ThumbnailSubscription>>>(args?: {
-    where?: ThumbnailWhereInput;
-    orderBy?: ThumbnailOrderByInput;
-    skip?: Int;
-    after?: String;
-    before?: String;
-    first?: Int;
-    last?: Int;
-  }) => T;
-}
-
-export interface DimensionsConnection {
+export interface VideoFileConnection {
   pageInfo: PageInfo;
-  edges: DimensionsEdge[];
+  edges: VideoFileEdge[];
 }
 
-export interface DimensionsConnectionPromise
-  extends Promise<DimensionsConnection>,
+export interface VideoFileConnectionPromise
+  extends Promise<VideoFileConnection>,
     Fragmentable {
   pageInfo: <T = PageInfoPromise>() => T;
-  edges: <T = FragmentableArray<DimensionsEdge>>() => T;
-  aggregate: <T = AggregateDimensionsPromise>() => T;
+  edges: <T = FragmentableArray<VideoFileEdge>>() => T;
+  aggregate: <T = AggregateVideoFilePromise>() => T;
 }
 
-export interface DimensionsConnectionSubscription
-  extends Promise<AsyncIterator<DimensionsConnection>>,
+export interface VideoFileConnectionSubscription
+  extends Promise<AsyncIterator<VideoFileConnection>>,
     Fragmentable {
   pageInfo: <T = PageInfoSubscription>() => T;
-  edges: <T = Promise<AsyncIterator<DimensionsEdgeSubscription>>>() => T;
-  aggregate: <T = AggregateDimensionsSubscription>() => T;
+  edges: <T = Promise<AsyncIterator<VideoFileEdgeSubscription>>>() => T;
+  aggregate: <T = AggregateVideoFileSubscription>() => T;
 }
 
-export interface TeamConnection {
-  pageInfo: PageInfo;
-  edges: TeamEdge[];
+export interface AggregateSupportFile {
+  count: Int;
 }
 
-export interface TeamConnectionPromise
-  extends Promise<TeamConnection>,
+export interface AggregateSupportFilePromise
+  extends Promise<AggregateSupportFile>,
     Fragmentable {
-  pageInfo: <T = PageInfoPromise>() => T;
-  edges: <T = FragmentableArray<TeamEdge>>() => T;
-  aggregate: <T = AggregateTeamPromise>() => T;
+  count: () => Promise<Int>;
 }
 
-export interface TeamConnectionSubscription
-  extends Promise<AsyncIterator<TeamConnection>>,
+export interface AggregateSupportFileSubscription
+  extends Promise<AsyncIterator<AggregateSupportFile>>,
     Fragmentable {
-  pageInfo: <T = PageInfoSubscription>() => T;
-  edges: <T = Promise<AsyncIterator<TeamEdgeSubscription>>>() => T;
-  aggregate: <T = AggregateTeamSubscription>() => T;
+  count: () => Promise<AsyncIterator<Int>>;
 }
+
+export interface TagEdge {
+  node: Tag;
+  cursor: String;
+}
+
+export interface TagEdgePromise extends Promise<TagEdge>, Fragmentable {
+  node: <T = TagPromise>() => T;
+  cursor: () => Promise<String>;
+}
+
+export interface TagEdgeSubscription
+  extends Promise<AsyncIterator<TagEdge>>,
+    Fragmentable {
+  node: <T = TagSubscription>() => T;
+  cursor: () => Promise<AsyncIterator<String>>;
+}
+
+/*
+The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](https://en.wikipedia.org/wiki/IEEE_floating_point). 
+*/
+export type Float = number;
+
+/*
+The `ID` scalar type represents a unique identifier, often used to refetch an object or as key for a cache. The ID type appears in a JSON response as a String; however, it is not intended to be human-readable. When expected as an input type, any string (such as `"4"`) or integer (such as `4`) input value will be accepted as an ID.
+*/
+export type ID_Input = string | number;
+export type ID_Output = string;
+
+/*
+The `Int` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1. 
+*/
+export type Int = number;
 
 /*
 DateTime scalar input type, allowing Date
@@ -6564,22 +7033,6 @@ DateTime scalar output type, which is always a string
 export type DateTimeOutput = string;
 
 /*
-The `ID` scalar type represents a unique identifier, often used to refetch an object or as key for a cache. The ID type appears in a JSON response as a String; however, it is not intended to be human-readable. When expected as an input type, any string (such as `"4"`) or integer (such as `4`) input value will be accepted as an ID.
-*/
-export type ID_Input = string | number;
-export type ID_Output = string;
-
-/*
-The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text.
-*/
-export type String = string;
-
-/*
-The `Int` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1. 
-*/
-export type Int = number;
-
-/*
 The `Boolean` scalar type represents `true` or `false`.
 */
 export type Boolean = boolean;
@@ -6587,9 +7040,9 @@ export type Boolean = boolean;
 export type Long = string;
 
 /*
-The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](https://en.wikipedia.org/wiki/IEEE_floating_point). 
+The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text.
 */
-export type Float = number;
+export type String = string;
 
 /**
  * Model Metadata
@@ -6642,6 +7095,10 @@ export const models: Model[] = [
   },
   {
     name: "SupportFile",
+    embedded: false
+  },
+  {
+    name: "SupportFileUse",
     embedded: false
   },
   {

--- a/src/schema/generated/prisma-client/index.js
+++ b/src/schema/generated/prisma-client/index.js
@@ -53,6 +53,10 @@ var models = [
     embedded: false
   },
   {
+    name: "SupportFileUse",
+    embedded: false
+  },
+  {
     name: "Tag",
     embedded: false
   },

--- a/src/schema/generated/prisma-client/prisma-schema.js
+++ b/src/schema/generated/prisma-client/prisma-schema.js
@@ -207,6 +207,8 @@ enum ContentType {
   TEACHING_MATERIAL
 }
 
+scalar DateTime
+
 type Dimensions {
   id: ID!
   width: Int
@@ -342,6 +344,8 @@ input DimensionsWhereUniqueInput {
 
 type ImageFile {
   id: ID!
+  createdAt: DateTime!
+  updatedAt: DateTime!
   language: Language
   dimensions: Dimensions
   alt: String
@@ -389,6 +393,10 @@ type ImageFileEdge {
 enum ImageFileOrderByInput {
   id_ASC
   id_DESC
+  createdAt_ASC
+  createdAt_DESC
+  updatedAt_ASC
+  updatedAt_DESC
   alt_ASC
   alt_DESC
   longdesc_ASC
@@ -403,14 +411,12 @@ enum ImageFileOrderByInput {
   md5_DESC
   url_ASC
   url_DESC
-  createdAt_ASC
-  createdAt_DESC
-  updatedAt_ASC
-  updatedAt_DESC
 }
 
 type ImageFilePreviousValues {
   id: ID!
+  createdAt: DateTime!
+  updatedAt: DateTime!
   alt: String
   longdesc: String
   caption: String
@@ -435,6 +441,22 @@ input ImageFileScalarWhereInput {
   id_not_starts_with: ID
   id_ends_with: ID
   id_not_ends_with: ID
+  createdAt: DateTime
+  createdAt_not: DateTime
+  createdAt_in: [DateTime!]
+  createdAt_not_in: [DateTime!]
+  createdAt_lt: DateTime
+  createdAt_lte: DateTime
+  createdAt_gt: DateTime
+  createdAt_gte: DateTime
+  updatedAt: DateTime
+  updatedAt_not: DateTime
+  updatedAt_in: [DateTime!]
+  updatedAt_not_in: [DateTime!]
+  updatedAt_lt: DateTime
+  updatedAt_lte: DateTime
+  updatedAt_gt: DateTime
+  updatedAt_gte: DateTime
   alt: String
   alt_not: String
   alt_in: [String!]
@@ -656,6 +678,22 @@ input ImageFileWhereInput {
   id_not_starts_with: ID
   id_ends_with: ID
   id_not_ends_with: ID
+  createdAt: DateTime
+  createdAt_not: DateTime
+  createdAt_in: [DateTime!]
+  createdAt_not_in: [DateTime!]
+  createdAt_lt: DateTime
+  createdAt_lte: DateTime
+  createdAt_gt: DateTime
+  createdAt_gte: DateTime
+  updatedAt: DateTime
+  updatedAt_not: DateTime
+  updatedAt_in: [DateTime!]
+  updatedAt_not_in: [DateTime!]
+  updatedAt_lt: DateTime
+  updatedAt_lte: DateTime
+  updatedAt_gt: DateTime
+  updatedAt_gte: DateTime
   language: LanguageWhereInput
   dimensions: DimensionsWhereInput
   alt: String
@@ -1471,6 +1509,8 @@ type Subscription {
 
 type SupportFile {
   id: ID!
+  createdAt: DateTime!
+  updatedAt: DateTime!
   language: Language!
   url: String
   md5: String
@@ -1507,6 +1547,10 @@ type SupportFileEdge {
 enum SupportFileOrderByInput {
   id_ASC
   id_DESC
+  createdAt_ASC
+  createdAt_DESC
+  updatedAt_ASC
+  updatedAt_DESC
   url_ASC
   url_DESC
   md5_ASC
@@ -1517,14 +1561,12 @@ enum SupportFileOrderByInput {
   filetype_DESC
   filesize_ASC
   filesize_DESC
-  createdAt_ASC
-  createdAt_DESC
-  updatedAt_ASC
-  updatedAt_DESC
 }
 
 type SupportFilePreviousValues {
   id: ID!
+  createdAt: DateTime!
+  updatedAt: DateTime!
   url: String
   md5: String
   filename: String
@@ -1547,6 +1589,22 @@ input SupportFileScalarWhereInput {
   id_not_starts_with: ID
   id_ends_with: ID
   id_not_ends_with: ID
+  createdAt: DateTime
+  createdAt_not: DateTime
+  createdAt_in: [DateTime!]
+  createdAt_not_in: [DateTime!]
+  createdAt_lt: DateTime
+  createdAt_lte: DateTime
+  createdAt_gt: DateTime
+  createdAt_gte: DateTime
+  updatedAt: DateTime
+  updatedAt_not: DateTime
+  updatedAt_in: [DateTime!]
+  updatedAt_not_in: [DateTime!]
+  updatedAt_lt: DateTime
+  updatedAt_lte: DateTime
+  updatedAt_gt: DateTime
+  updatedAt_gte: DateTime
   url: String
   url_not: String
   url_in: [String!]
@@ -1710,6 +1768,22 @@ input SupportFileWhereInput {
   id_not_starts_with: ID
   id_ends_with: ID
   id_not_ends_with: ID
+  createdAt: DateTime
+  createdAt_not: DateTime
+  createdAt_in: [DateTime!]
+  createdAt_not_in: [DateTime!]
+  createdAt_lt: DateTime
+  createdAt_lte: DateTime
+  createdAt_gt: DateTime
+  createdAt_gte: DateTime
+  updatedAt: DateTime
+  updatedAt_not: DateTime
+  updatedAt_in: [DateTime!]
+  updatedAt_not_in: [DateTime!]
+  updatedAt_lt: DateTime
+  updatedAt_lte: DateTime
+  updatedAt_gt: DateTime
+  updatedAt_gte: DateTime
   language: LanguageWhereInput
   url: String
   url_not: String
@@ -2843,6 +2917,8 @@ enum VideoBurnedInStatus {
 
 type VideoFile {
   id: ID!
+  createdAt: DateTime!
+  updatedAt: DateTime!
   language: Language
   filetype: String
   filename: String
@@ -2893,6 +2969,10 @@ type VideoFileEdge {
 enum VideoFileOrderByInput {
   id_ASC
   id_DESC
+  createdAt_ASC
+  createdAt_DESC
+  updatedAt_ASC
+  updatedAt_DESC
   filetype_ASC
   filetype_DESC
   filename_ASC
@@ -2911,14 +2991,12 @@ enum VideoFileOrderByInput {
   bitrate_DESC
   filesize_ASC
   filesize_DESC
-  createdAt_ASC
-  createdAt_DESC
-  updatedAt_ASC
-  updatedAt_DESC
 }
 
 type VideoFilePreviousValues {
   id: ID!
+  createdAt: DateTime!
+  updatedAt: DateTime!
   filetype: String
   filename: String
   quality: VideoQuality
@@ -2945,6 +3023,22 @@ input VideoFileScalarWhereInput {
   id_not_starts_with: ID
   id_ends_with: ID
   id_not_ends_with: ID
+  createdAt: DateTime
+  createdAt_not: DateTime
+  createdAt_in: [DateTime!]
+  createdAt_not_in: [DateTime!]
+  createdAt_lt: DateTime
+  createdAt_lte: DateTime
+  createdAt_gt: DateTime
+  createdAt_gte: DateTime
+  updatedAt: DateTime
+  updatedAt_not: DateTime
+  updatedAt_in: [DateTime!]
+  updatedAt_not_in: [DateTime!]
+  updatedAt_lt: DateTime
+  updatedAt_lte: DateTime
+  updatedAt_gt: DateTime
+  updatedAt_gte: DateTime
   filetype: String
   filetype_not: String
   filetype_in: [String!]
@@ -3154,6 +3248,22 @@ input VideoFileWhereInput {
   id_not_starts_with: ID
   id_ends_with: ID
   id_not_ends_with: ID
+  createdAt: DateTime
+  createdAt_not: DateTime
+  createdAt_in: [DateTime!]
+  createdAt_not_in: [DateTime!]
+  createdAt_lt: DateTime
+  createdAt_lte: DateTime
+  createdAt_gt: DateTime
+  createdAt_gte: DateTime
+  updatedAt: DateTime
+  updatedAt_not: DateTime
+  updatedAt_in: [DateTime!]
+  updatedAt_not_in: [DateTime!]
+  updatedAt_lt: DateTime
+  updatedAt_lte: DateTime
+  updatedAt_gt: DateTime
+  updatedAt_gte: DateTime
   language: LanguageWhereInput
   filetype: String
   filetype_not: String
@@ -3257,6 +3367,8 @@ input VideoFileWhereUniqueInput {
 
 type VideoProject {
   id: ID!
+  createdAt: DateTime!
+  updatedAt: DateTime!
   projectType: String!
   projectTitle: String!
   descPublic: String
@@ -3302,6 +3414,10 @@ type VideoProjectEdge {
 enum VideoProjectOrderByInput {
   id_ASC
   id_DESC
+  createdAt_ASC
+  createdAt_DESC
+  updatedAt_ASC
+  updatedAt_DESC
   projectType_ASC
   projectType_DESC
   projectTitle_ASC
@@ -3316,14 +3432,12 @@ enum VideoProjectOrderByInput {
   status_DESC
   visibility_ASC
   visibility_DESC
-  createdAt_ASC
-  createdAt_DESC
-  updatedAt_ASC
-  updatedAt_DESC
 }
 
 type VideoProjectPreviousValues {
   id: ID!
+  createdAt: DateTime!
+  updatedAt: DateTime!
   projectType: String!
   projectTitle: String!
   descPublic: String
@@ -3392,6 +3506,22 @@ input VideoProjectWhereInput {
   id_not_starts_with: ID
   id_ends_with: ID
   id_not_ends_with: ID
+  createdAt: DateTime
+  createdAt_not: DateTime
+  createdAt_in: [DateTime!]
+  createdAt_not_in: [DateTime!]
+  createdAt_lt: DateTime
+  createdAt_lte: DateTime
+  createdAt_gt: DateTime
+  createdAt_gte: DateTime
+  updatedAt: DateTime
+  updatedAt_not: DateTime
+  updatedAt_in: [DateTime!]
+  updatedAt_not_in: [DateTime!]
+  updatedAt_lt: DateTime
+  updatedAt_lte: DateTime
+  updatedAt_gt: DateTime
+  updatedAt_gte: DateTime
   projectType: String
   projectType_not: String
   projectType_in: [String!]

--- a/src/schema/generated/prisma-client/prisma-schema.js
+++ b/src/schema/generated/prisma-client/prisma-schema.js
@@ -3377,6 +3377,7 @@ type VideoProject {
   team: Team
   status: ProjectPublishStatus
   visibility: ProjectVisibility
+  protectImages: Boolean
   units(where: VideoUnitWhereInput, orderBy: VideoUnitOrderByInput, skip: Int, after: String, before: String, first: Int, last: Int): [VideoUnit!]
   supportFiles(where: SupportFileWhereInput, orderBy: SupportFileOrderByInput, skip: Int, after: String, before: String, first: Int, last: Int): [SupportFile!]
   thumbnails(where: ImageFileWhereInput, orderBy: ImageFileOrderByInput, skip: Int, after: String, before: String, first: Int, last: Int): [ImageFile!]
@@ -3399,6 +3400,7 @@ input VideoProjectCreateInput {
   team: TeamCreateOneInput
   status: ProjectPublishStatus
   visibility: ProjectVisibility
+  protectImages: Boolean
   units: VideoUnitCreateManyInput
   supportFiles: SupportFileCreateManyInput
   thumbnails: ImageFileCreateManyInput
@@ -3432,6 +3434,8 @@ enum VideoProjectOrderByInput {
   status_DESC
   visibility_ASC
   visibility_DESC
+  protectImages_ASC
+  protectImages_DESC
 }
 
 type VideoProjectPreviousValues {
@@ -3445,6 +3449,7 @@ type VideoProjectPreviousValues {
   author: String
   status: ProjectPublishStatus
   visibility: ProjectVisibility
+  protectImages: Boolean
 }
 
 type VideoProjectSubscriptionPayload {
@@ -3474,6 +3479,7 @@ input VideoProjectUpdateInput {
   team: TeamUpdateOneInput
   status: ProjectPublishStatus
   visibility: ProjectVisibility
+  protectImages: Boolean
   units: VideoUnitUpdateManyInput
   supportFiles: SupportFileUpdateManyInput
   thumbnails: ImageFileUpdateManyInput
@@ -3489,6 +3495,7 @@ input VideoProjectUpdateManyMutationInput {
   author: String
   status: ProjectPublishStatus
   visibility: ProjectVisibility
+  protectImages: Boolean
 }
 
 input VideoProjectWhereInput {
@@ -3601,6 +3608,8 @@ input VideoProjectWhereInput {
   visibility_not: ProjectVisibility
   visibility_in: [ProjectVisibility!]
   visibility_not_in: [ProjectVisibility!]
+  protectImages: Boolean
+  protectImages_not: Boolean
   units_every: VideoUnitWhereInput
   units_some: VideoUnitWhereInput
   units_none: VideoUnitWhereInput

--- a/src/schema/generated/prisma-client/prisma-schema.js
+++ b/src/schema/generated/prisma-client/prisma-schema.js
@@ -27,6 +27,10 @@ type AggregateSupportFile {
   count: Int!
 }
 
+type AggregateSupportFileUse {
+  count: Int!
+}
+
 type AggregateTag {
   count: Int!
 }
@@ -353,6 +357,7 @@ type ImageFile {
   caption: String
   filename: String
   filetype: String
+  use: ImageUse
   md5: String
   url: String
 }
@@ -371,6 +376,7 @@ input ImageFileCreateInput {
   caption: String
   filename: String
   filetype: String
+  use: ImageUseCreateOneInput
   md5: String
   url: String
 }
@@ -586,6 +592,7 @@ input ImageFileUpdateDataInput {
   caption: String
   filename: String
   filetype: String
+  use: ImageUseUpdateOneInput
   md5: String
   url: String
 }
@@ -598,6 +605,7 @@ input ImageFileUpdateInput {
   caption: String
   filename: String
   filetype: String
+  use: ImageUseUpdateOneInput
   md5: String
   url: String
 }
@@ -766,6 +774,7 @@ input ImageFileWhereInput {
   filetype_not_starts_with: String
   filetype_ends_with: String
   filetype_not_ends_with: String
+  use: ImageUseWhereInput
   md5: String
   md5_not: String
   md5_in: [String!]
@@ -818,6 +827,11 @@ input ImageUseCreateInput {
   name: String!
 }
 
+input ImageUseCreateOneInput {
+  create: ImageUseCreateInput
+  connect: ImageUseWhereUniqueInput
+}
+
 type ImageUseEdge {
   node: ImageUse!
   cursor: String!
@@ -857,12 +871,30 @@ input ImageUseSubscriptionWhereInput {
   NOT: [ImageUseSubscriptionWhereInput!]
 }
 
+input ImageUseUpdateDataInput {
+  name: String
+}
+
 input ImageUseUpdateInput {
   name: String
 }
 
 input ImageUseUpdateManyMutationInput {
   name: String
+}
+
+input ImageUseUpdateOneInput {
+  create: ImageUseCreateInput
+  update: ImageUseUpdateDataInput
+  upsert: ImageUseUpsertNestedInput
+  delete: Boolean
+  disconnect: Boolean
+  connect: ImageUseWhereUniqueInput
+}
+
+input ImageUseUpsertNestedInput {
+  update: ImageUseUpdateDataInput!
+  create: ImageUseCreateInput!
 }
 
 input ImageUseWhereInput {
@@ -901,6 +933,7 @@ input ImageUseWhereInput {
 
 input ImageUseWhereUniqueInput {
   id: ID
+  name: String
 }
 
 type Language {
@@ -1345,6 +1378,12 @@ type Mutation {
   upsertSupportFile(where: SupportFileWhereUniqueInput!, create: SupportFileCreateInput!, update: SupportFileUpdateInput!): SupportFile!
   deleteSupportFile(where: SupportFileWhereUniqueInput!): SupportFile
   deleteManySupportFiles(where: SupportFileWhereInput): BatchPayload!
+  createSupportFileUse(data: SupportFileUseCreateInput!): SupportFileUse!
+  updateSupportFileUse(data: SupportFileUseUpdateInput!, where: SupportFileUseWhereUniqueInput!): SupportFileUse
+  updateManySupportFileUses(data: SupportFileUseUpdateManyMutationInput!, where: SupportFileUseWhereInput): BatchPayload!
+  upsertSupportFileUse(where: SupportFileUseWhereUniqueInput!, create: SupportFileUseCreateInput!, update: SupportFileUseUpdateInput!): SupportFileUse!
+  deleteSupportFileUse(where: SupportFileUseWhereUniqueInput!): SupportFileUse
+  deleteManySupportFileUses(where: SupportFileUseWhereInput): BatchPayload!
   createTag(data: TagCreateInput!): Tag!
   updateTag(data: TagUpdateInput!, where: TagWhereUniqueInput!): Tag
   upsertTag(where: TagWhereUniqueInput!, create: TagCreateInput!, update: TagUpdateInput!): Tag!
@@ -1458,6 +1497,9 @@ type Query {
   supportFile(where: SupportFileWhereUniqueInput!): SupportFile
   supportFiles(where: SupportFileWhereInput, orderBy: SupportFileOrderByInput, skip: Int, after: String, before: String, first: Int, last: Int): [SupportFile]!
   supportFilesConnection(where: SupportFileWhereInput, orderBy: SupportFileOrderByInput, skip: Int, after: String, before: String, first: Int, last: Int): SupportFileConnection!
+  supportFileUse(where: SupportFileUseWhereUniqueInput!): SupportFileUse
+  supportFileUses(where: SupportFileUseWhereInput, orderBy: SupportFileUseOrderByInput, skip: Int, after: String, before: String, first: Int, last: Int): [SupportFileUse]!
+  supportFileUsesConnection(where: SupportFileUseWhereInput, orderBy: SupportFileUseOrderByInput, skip: Int, after: String, before: String, first: Int, last: Int): SupportFileUseConnection!
   tag(where: TagWhereUniqueInput!): Tag
   tags(where: TagWhereInput, orderBy: TagOrderByInput, skip: Int, after: String, before: String, first: Int, last: Int): [Tag]!
   tagsConnection(where: TagWhereInput, orderBy: TagOrderByInput, skip: Int, after: String, before: String, first: Int, last: Int): TagConnection!
@@ -1496,6 +1538,7 @@ type Subscription {
   language(where: LanguageSubscriptionWhereInput): LanguageSubscriptionPayload
   languageTranslation(where: LanguageTranslationSubscriptionWhereInput): LanguageTranslationSubscriptionPayload
   supportFile(where: SupportFileSubscriptionWhereInput): SupportFileSubscriptionPayload
+  supportFileUse(where: SupportFileUseSubscriptionWhereInput): SupportFileUseSubscriptionPayload
   tag(where: TagSubscriptionWhereInput): TagSubscriptionPayload
   team(where: TeamSubscriptionWhereInput): TeamSubscriptionPayload
   thumbnail(where: ThumbnailSubscriptionWhereInput): ThumbnailSubscriptionPayload
@@ -1517,6 +1560,7 @@ type SupportFile {
   filename: String
   filetype: String
   filesize: Float
+  use: SupportFileUse
 }
 
 type SupportFileConnection {
@@ -1532,6 +1576,7 @@ input SupportFileCreateInput {
   filename: String
   filetype: String
   filesize: Float
+  use: SupportFileUseCreateOneInput
 }
 
 input SupportFileCreateManyInput {
@@ -1699,6 +1744,7 @@ input SupportFileUpdateDataInput {
   filename: String
   filetype: String
   filesize: Float
+  use: SupportFileUseUpdateOneInput
 }
 
 input SupportFileUpdateInput {
@@ -1708,6 +1754,7 @@ input SupportFileUpdateInput {
   filename: String
   filetype: String
   filesize: Float
+  use: SupportFileUseUpdateOneInput
 }
 
 input SupportFileUpdateManyDataInput {
@@ -1751,6 +1798,130 @@ input SupportFileUpsertWithWhereUniqueNestedInput {
   where: SupportFileWhereUniqueInput!
   update: SupportFileUpdateDataInput!
   create: SupportFileCreateInput!
+}
+
+type SupportFileUse {
+  id: ID!
+  name: String!
+}
+
+type SupportFileUseConnection {
+  pageInfo: PageInfo!
+  edges: [SupportFileUseEdge]!
+  aggregate: AggregateSupportFileUse!
+}
+
+input SupportFileUseCreateInput {
+  name: String!
+}
+
+input SupportFileUseCreateOneInput {
+  create: SupportFileUseCreateInput
+  connect: SupportFileUseWhereUniqueInput
+}
+
+type SupportFileUseEdge {
+  node: SupportFileUse!
+  cursor: String!
+}
+
+enum SupportFileUseOrderByInput {
+  id_ASC
+  id_DESC
+  name_ASC
+  name_DESC
+  createdAt_ASC
+  createdAt_DESC
+  updatedAt_ASC
+  updatedAt_DESC
+}
+
+type SupportFileUsePreviousValues {
+  id: ID!
+  name: String!
+}
+
+type SupportFileUseSubscriptionPayload {
+  mutation: MutationType!
+  node: SupportFileUse
+  updatedFields: [String!]
+  previousValues: SupportFileUsePreviousValues
+}
+
+input SupportFileUseSubscriptionWhereInput {
+  mutation_in: [MutationType!]
+  updatedFields_contains: String
+  updatedFields_contains_every: [String!]
+  updatedFields_contains_some: [String!]
+  node: SupportFileUseWhereInput
+  AND: [SupportFileUseSubscriptionWhereInput!]
+  OR: [SupportFileUseSubscriptionWhereInput!]
+  NOT: [SupportFileUseSubscriptionWhereInput!]
+}
+
+input SupportFileUseUpdateDataInput {
+  name: String
+}
+
+input SupportFileUseUpdateInput {
+  name: String
+}
+
+input SupportFileUseUpdateManyMutationInput {
+  name: String
+}
+
+input SupportFileUseUpdateOneInput {
+  create: SupportFileUseCreateInput
+  update: SupportFileUseUpdateDataInput
+  upsert: SupportFileUseUpsertNestedInput
+  delete: Boolean
+  disconnect: Boolean
+  connect: SupportFileUseWhereUniqueInput
+}
+
+input SupportFileUseUpsertNestedInput {
+  update: SupportFileUseUpdateDataInput!
+  create: SupportFileUseCreateInput!
+}
+
+input SupportFileUseWhereInput {
+  id: ID
+  id_not: ID
+  id_in: [ID!]
+  id_not_in: [ID!]
+  id_lt: ID
+  id_lte: ID
+  id_gt: ID
+  id_gte: ID
+  id_contains: ID
+  id_not_contains: ID
+  id_starts_with: ID
+  id_not_starts_with: ID
+  id_ends_with: ID
+  id_not_ends_with: ID
+  name: String
+  name_not: String
+  name_in: [String!]
+  name_not_in: [String!]
+  name_lt: String
+  name_lte: String
+  name_gt: String
+  name_gte: String
+  name_contains: String
+  name_not_contains: String
+  name_starts_with: String
+  name_not_starts_with: String
+  name_ends_with: String
+  name_not_ends_with: String
+  AND: [SupportFileUseWhereInput!]
+  OR: [SupportFileUseWhereInput!]
+  NOT: [SupportFileUseWhereInput!]
+}
+
+input SupportFileUseWhereUniqueInput {
+  id: ID
+  name: String
 }
 
 input SupportFileWhereInput {
@@ -1849,6 +2020,7 @@ input SupportFileWhereInput {
   filesize_lte: Float
   filesize_gt: Float
   filesize_gte: Float
+  use: SupportFileUseWhereInput
   AND: [SupportFileWhereInput!]
   OR: [SupportFileWhereInput!]
   NOT: [SupportFileWhereInput!]
@@ -2931,7 +3103,7 @@ type VideoFile {
   bitrate: Float
   filesize: Float
   dimensions: Dimensions
-  stream: VideoStream
+  stream(where: VideoStreamWhereInput, orderBy: VideoStreamOrderByInput, skip: Int, after: String, before: String, first: Int, last: Int): [VideoStream!]
 }
 
 type VideoFileConnection {
@@ -2953,7 +3125,7 @@ input VideoFileCreateInput {
   bitrate: Float
   filesize: Float
   dimensions: DimensionsCreateOneInput
-  stream: VideoStreamCreateOneInput
+  stream: VideoStreamCreateManyInput
 }
 
 input VideoFileCreateManyInput {
@@ -3163,7 +3335,7 @@ input VideoFileUpdateDataInput {
   bitrate: Float
   filesize: Float
   dimensions: DimensionsUpdateOneInput
-  stream: VideoStreamUpdateOneInput
+  stream: VideoStreamUpdateManyInput
 }
 
 input VideoFileUpdateInput {
@@ -3179,7 +3351,7 @@ input VideoFileUpdateInput {
   bitrate: Float
   filesize: Float
   dimensions: DimensionsUpdateOneInput
-  stream: VideoStreamUpdateOneInput
+  stream: VideoStreamUpdateManyInput
 }
 
 input VideoFileUpdateManyDataInput {
@@ -3355,7 +3527,9 @@ input VideoFileWhereInput {
   filesize_gt: Float
   filesize_gte: Float
   dimensions: DimensionsWhereInput
-  stream: VideoStreamWhereInput
+  stream_every: VideoStreamWhereInput
+  stream_some: VideoStreamWhereInput
+  stream_none: VideoStreamWhereInput
   AND: [VideoFileWhereInput!]
   OR: [VideoFileWhereInput!]
   NOT: [VideoFileWhereInput!]
@@ -3658,9 +3832,9 @@ input VideoStreamCreateInput {
   embedUrl: String
 }
 
-input VideoStreamCreateOneInput {
-  create: VideoStreamCreateInput
-  connect: VideoStreamWhereUniqueInput
+input VideoStreamCreateManyInput {
+  create: [VideoStreamCreateInput!]
+  connect: [VideoStreamWhereUniqueInput!]
 }
 
 type VideoStreamEdge {
@@ -3688,6 +3862,68 @@ type VideoStreamPreviousValues {
   site: String
   url: String
   embedUrl: String
+}
+
+input VideoStreamScalarWhereInput {
+  id: ID
+  id_not: ID
+  id_in: [ID!]
+  id_not_in: [ID!]
+  id_lt: ID
+  id_lte: ID
+  id_gt: ID
+  id_gte: ID
+  id_contains: ID
+  id_not_contains: ID
+  id_starts_with: ID
+  id_not_starts_with: ID
+  id_ends_with: ID
+  id_not_ends_with: ID
+  site: String
+  site_not: String
+  site_in: [String!]
+  site_not_in: [String!]
+  site_lt: String
+  site_lte: String
+  site_gt: String
+  site_gte: String
+  site_contains: String
+  site_not_contains: String
+  site_starts_with: String
+  site_not_starts_with: String
+  site_ends_with: String
+  site_not_ends_with: String
+  url: String
+  url_not: String
+  url_in: [String!]
+  url_not_in: [String!]
+  url_lt: String
+  url_lte: String
+  url_gt: String
+  url_gte: String
+  url_contains: String
+  url_not_contains: String
+  url_starts_with: String
+  url_not_starts_with: String
+  url_ends_with: String
+  url_not_ends_with: String
+  embedUrl: String
+  embedUrl_not: String
+  embedUrl_in: [String!]
+  embedUrl_not_in: [String!]
+  embedUrl_lt: String
+  embedUrl_lte: String
+  embedUrl_gt: String
+  embedUrl_gte: String
+  embedUrl_contains: String
+  embedUrl_not_contains: String
+  embedUrl_starts_with: String
+  embedUrl_not_starts_with: String
+  embedUrl_ends_with: String
+  embedUrl_not_ends_with: String
+  AND: [VideoStreamScalarWhereInput!]
+  OR: [VideoStreamScalarWhereInput!]
+  NOT: [VideoStreamScalarWhereInput!]
 }
 
 type VideoStreamSubscriptionPayload {
@@ -3720,22 +3956,41 @@ input VideoStreamUpdateInput {
   embedUrl: String
 }
 
+input VideoStreamUpdateManyDataInput {
+  site: String
+  url: String
+  embedUrl: String
+}
+
+input VideoStreamUpdateManyInput {
+  create: [VideoStreamCreateInput!]
+  update: [VideoStreamUpdateWithWhereUniqueNestedInput!]
+  upsert: [VideoStreamUpsertWithWhereUniqueNestedInput!]
+  delete: [VideoStreamWhereUniqueInput!]
+  connect: [VideoStreamWhereUniqueInput!]
+  disconnect: [VideoStreamWhereUniqueInput!]
+  deleteMany: [VideoStreamScalarWhereInput!]
+  updateMany: [VideoStreamUpdateManyWithWhereNestedInput!]
+}
+
 input VideoStreamUpdateManyMutationInput {
   site: String
   url: String
   embedUrl: String
 }
 
-input VideoStreamUpdateOneInput {
-  create: VideoStreamCreateInput
-  update: VideoStreamUpdateDataInput
-  upsert: VideoStreamUpsertNestedInput
-  delete: Boolean
-  disconnect: Boolean
-  connect: VideoStreamWhereUniqueInput
+input VideoStreamUpdateManyWithWhereNestedInput {
+  where: VideoStreamScalarWhereInput!
+  data: VideoStreamUpdateManyDataInput!
 }
 
-input VideoStreamUpsertNestedInput {
+input VideoStreamUpdateWithWhereUniqueNestedInput {
+  where: VideoStreamWhereUniqueInput!
+  data: VideoStreamUpdateDataInput!
+}
+
+input VideoStreamUpsertWithWhereUniqueNestedInput {
+  where: VideoStreamWhereUniqueInput!
   update: VideoStreamUpdateDataInput!
   create: VideoStreamCreateInput!
 }
@@ -3808,6 +4063,8 @@ input VideoStreamWhereUniqueInput {
 
 type VideoUnit {
   id: ID!
+  createdAt: DateTime!
+  updatedAt: DateTime!
   language: Language
   title: String!
   descPublic: String
@@ -3846,18 +4103,20 @@ type VideoUnitEdge {
 enum VideoUnitOrderByInput {
   id_ASC
   id_DESC
-  title_ASC
-  title_DESC
-  descPublic_ASC
-  descPublic_DESC
   createdAt_ASC
   createdAt_DESC
   updatedAt_ASC
   updatedAt_DESC
+  title_ASC
+  title_DESC
+  descPublic_ASC
+  descPublic_DESC
 }
 
 type VideoUnitPreviousValues {
   id: ID!
+  createdAt: DateTime!
+  updatedAt: DateTime!
   title: String!
   descPublic: String
 }
@@ -3877,6 +4136,22 @@ input VideoUnitScalarWhereInput {
   id_not_starts_with: ID
   id_ends_with: ID
   id_not_ends_with: ID
+  createdAt: DateTime
+  createdAt_not: DateTime
+  createdAt_in: [DateTime!]
+  createdAt_not_in: [DateTime!]
+  createdAt_lt: DateTime
+  createdAt_lte: DateTime
+  createdAt_gt: DateTime
+  createdAt_gte: DateTime
+  updatedAt: DateTime
+  updatedAt_not: DateTime
+  updatedAt_in: [DateTime!]
+  updatedAt_not_in: [DateTime!]
+  updatedAt_lt: DateTime
+  updatedAt_lte: DateTime
+  updatedAt_gt: DateTime
+  updatedAt_gte: DateTime
   title: String
   title_not: String
   title_in: [String!]
@@ -4000,6 +4275,22 @@ input VideoUnitWhereInput {
   id_not_starts_with: ID
   id_ends_with: ID
   id_not_ends_with: ID
+  createdAt: DateTime
+  createdAt_not: DateTime
+  createdAt_in: [DateTime!]
+  createdAt_not_in: [DateTime!]
+  createdAt_lt: DateTime
+  createdAt_lte: DateTime
+  createdAt_gt: DateTime
+  createdAt_gte: DateTime
+  updatedAt: DateTime
+  updatedAt_not: DateTime
+  updatedAt_in: [DateTime!]
+  updatedAt_not_in: [DateTime!]
+  updatedAt_lt: DateTime
+  updatedAt_lte: DateTime
+  updatedAt_gt: DateTime
+  updatedAt_gte: DateTime
   language: LanguageWhereInput
   title: String
   title_not: String
@@ -4171,6 +4462,7 @@ input VideoUseWhereInput {
 
 input VideoUseWhereUniqueInput {
   id: ID
+  name: String
 }
 `
       }

--- a/src/schema/generated/prisma-client/prisma.graphql
+++ b/src/schema/generated/prisma-client/prisma.graphql
@@ -206,6 +206,8 @@ enum ContentType {
   TEACHING_MATERIAL
 }
 
+scalar DateTime
+
 type Dimensions {
   id: ID!
   width: Int
@@ -341,6 +343,8 @@ input DimensionsWhereUniqueInput {
 
 type ImageFile {
   id: ID!
+  createdAt: DateTime!
+  updatedAt: DateTime!
   language: Language
   dimensions: Dimensions
   alt: String
@@ -388,6 +392,10 @@ type ImageFileEdge {
 enum ImageFileOrderByInput {
   id_ASC
   id_DESC
+  createdAt_ASC
+  createdAt_DESC
+  updatedAt_ASC
+  updatedAt_DESC
   alt_ASC
   alt_DESC
   longdesc_ASC
@@ -402,14 +410,12 @@ enum ImageFileOrderByInput {
   md5_DESC
   url_ASC
   url_DESC
-  createdAt_ASC
-  createdAt_DESC
-  updatedAt_ASC
-  updatedAt_DESC
 }
 
 type ImageFilePreviousValues {
   id: ID!
+  createdAt: DateTime!
+  updatedAt: DateTime!
   alt: String
   longdesc: String
   caption: String
@@ -434,6 +440,22 @@ input ImageFileScalarWhereInput {
   id_not_starts_with: ID
   id_ends_with: ID
   id_not_ends_with: ID
+  createdAt: DateTime
+  createdAt_not: DateTime
+  createdAt_in: [DateTime!]
+  createdAt_not_in: [DateTime!]
+  createdAt_lt: DateTime
+  createdAt_lte: DateTime
+  createdAt_gt: DateTime
+  createdAt_gte: DateTime
+  updatedAt: DateTime
+  updatedAt_not: DateTime
+  updatedAt_in: [DateTime!]
+  updatedAt_not_in: [DateTime!]
+  updatedAt_lt: DateTime
+  updatedAt_lte: DateTime
+  updatedAt_gt: DateTime
+  updatedAt_gte: DateTime
   alt: String
   alt_not: String
   alt_in: [String!]
@@ -655,6 +677,22 @@ input ImageFileWhereInput {
   id_not_starts_with: ID
   id_ends_with: ID
   id_not_ends_with: ID
+  createdAt: DateTime
+  createdAt_not: DateTime
+  createdAt_in: [DateTime!]
+  createdAt_not_in: [DateTime!]
+  createdAt_lt: DateTime
+  createdAt_lte: DateTime
+  createdAt_gt: DateTime
+  createdAt_gte: DateTime
+  updatedAt: DateTime
+  updatedAt_not: DateTime
+  updatedAt_in: [DateTime!]
+  updatedAt_not_in: [DateTime!]
+  updatedAt_lt: DateTime
+  updatedAt_lte: DateTime
+  updatedAt_gt: DateTime
+  updatedAt_gte: DateTime
   language: LanguageWhereInput
   dimensions: DimensionsWhereInput
   alt: String
@@ -1470,6 +1508,8 @@ type Subscription {
 
 type SupportFile {
   id: ID!
+  createdAt: DateTime!
+  updatedAt: DateTime!
   language: Language!
   url: String
   md5: String
@@ -1506,6 +1546,10 @@ type SupportFileEdge {
 enum SupportFileOrderByInput {
   id_ASC
   id_DESC
+  createdAt_ASC
+  createdAt_DESC
+  updatedAt_ASC
+  updatedAt_DESC
   url_ASC
   url_DESC
   md5_ASC
@@ -1516,14 +1560,12 @@ enum SupportFileOrderByInput {
   filetype_DESC
   filesize_ASC
   filesize_DESC
-  createdAt_ASC
-  createdAt_DESC
-  updatedAt_ASC
-  updatedAt_DESC
 }
 
 type SupportFilePreviousValues {
   id: ID!
+  createdAt: DateTime!
+  updatedAt: DateTime!
   url: String
   md5: String
   filename: String
@@ -1546,6 +1588,22 @@ input SupportFileScalarWhereInput {
   id_not_starts_with: ID
   id_ends_with: ID
   id_not_ends_with: ID
+  createdAt: DateTime
+  createdAt_not: DateTime
+  createdAt_in: [DateTime!]
+  createdAt_not_in: [DateTime!]
+  createdAt_lt: DateTime
+  createdAt_lte: DateTime
+  createdAt_gt: DateTime
+  createdAt_gte: DateTime
+  updatedAt: DateTime
+  updatedAt_not: DateTime
+  updatedAt_in: [DateTime!]
+  updatedAt_not_in: [DateTime!]
+  updatedAt_lt: DateTime
+  updatedAt_lte: DateTime
+  updatedAt_gt: DateTime
+  updatedAt_gte: DateTime
   url: String
   url_not: String
   url_in: [String!]
@@ -1709,6 +1767,22 @@ input SupportFileWhereInput {
   id_not_starts_with: ID
   id_ends_with: ID
   id_not_ends_with: ID
+  createdAt: DateTime
+  createdAt_not: DateTime
+  createdAt_in: [DateTime!]
+  createdAt_not_in: [DateTime!]
+  createdAt_lt: DateTime
+  createdAt_lte: DateTime
+  createdAt_gt: DateTime
+  createdAt_gte: DateTime
+  updatedAt: DateTime
+  updatedAt_not: DateTime
+  updatedAt_in: [DateTime!]
+  updatedAt_not_in: [DateTime!]
+  updatedAt_lt: DateTime
+  updatedAt_lte: DateTime
+  updatedAt_gt: DateTime
+  updatedAt_gte: DateTime
   language: LanguageWhereInput
   url: String
   url_not: String
@@ -2842,6 +2916,8 @@ enum VideoBurnedInStatus {
 
 type VideoFile {
   id: ID!
+  createdAt: DateTime!
+  updatedAt: DateTime!
   language: Language
   filetype: String
   filename: String
@@ -2892,6 +2968,10 @@ type VideoFileEdge {
 enum VideoFileOrderByInput {
   id_ASC
   id_DESC
+  createdAt_ASC
+  createdAt_DESC
+  updatedAt_ASC
+  updatedAt_DESC
   filetype_ASC
   filetype_DESC
   filename_ASC
@@ -2910,14 +2990,12 @@ enum VideoFileOrderByInput {
   bitrate_DESC
   filesize_ASC
   filesize_DESC
-  createdAt_ASC
-  createdAt_DESC
-  updatedAt_ASC
-  updatedAt_DESC
 }
 
 type VideoFilePreviousValues {
   id: ID!
+  createdAt: DateTime!
+  updatedAt: DateTime!
   filetype: String
   filename: String
   quality: VideoQuality
@@ -2944,6 +3022,22 @@ input VideoFileScalarWhereInput {
   id_not_starts_with: ID
   id_ends_with: ID
   id_not_ends_with: ID
+  createdAt: DateTime
+  createdAt_not: DateTime
+  createdAt_in: [DateTime!]
+  createdAt_not_in: [DateTime!]
+  createdAt_lt: DateTime
+  createdAt_lte: DateTime
+  createdAt_gt: DateTime
+  createdAt_gte: DateTime
+  updatedAt: DateTime
+  updatedAt_not: DateTime
+  updatedAt_in: [DateTime!]
+  updatedAt_not_in: [DateTime!]
+  updatedAt_lt: DateTime
+  updatedAt_lte: DateTime
+  updatedAt_gt: DateTime
+  updatedAt_gte: DateTime
   filetype: String
   filetype_not: String
   filetype_in: [String!]
@@ -3153,6 +3247,22 @@ input VideoFileWhereInput {
   id_not_starts_with: ID
   id_ends_with: ID
   id_not_ends_with: ID
+  createdAt: DateTime
+  createdAt_not: DateTime
+  createdAt_in: [DateTime!]
+  createdAt_not_in: [DateTime!]
+  createdAt_lt: DateTime
+  createdAt_lte: DateTime
+  createdAt_gt: DateTime
+  createdAt_gte: DateTime
+  updatedAt: DateTime
+  updatedAt_not: DateTime
+  updatedAt_in: [DateTime!]
+  updatedAt_not_in: [DateTime!]
+  updatedAt_lt: DateTime
+  updatedAt_lte: DateTime
+  updatedAt_gt: DateTime
+  updatedAt_gte: DateTime
   language: LanguageWhereInput
   filetype: String
   filetype_not: String
@@ -3256,6 +3366,8 @@ input VideoFileWhereUniqueInput {
 
 type VideoProject {
   id: ID!
+  createdAt: DateTime!
+  updatedAt: DateTime!
   projectType: String!
   projectTitle: String!
   descPublic: String
@@ -3301,6 +3413,10 @@ type VideoProjectEdge {
 enum VideoProjectOrderByInput {
   id_ASC
   id_DESC
+  createdAt_ASC
+  createdAt_DESC
+  updatedAt_ASC
+  updatedAt_DESC
   projectType_ASC
   projectType_DESC
   projectTitle_ASC
@@ -3315,14 +3431,12 @@ enum VideoProjectOrderByInput {
   status_DESC
   visibility_ASC
   visibility_DESC
-  createdAt_ASC
-  createdAt_DESC
-  updatedAt_ASC
-  updatedAt_DESC
 }
 
 type VideoProjectPreviousValues {
   id: ID!
+  createdAt: DateTime!
+  updatedAt: DateTime!
   projectType: String!
   projectTitle: String!
   descPublic: String
@@ -3391,6 +3505,22 @@ input VideoProjectWhereInput {
   id_not_starts_with: ID
   id_ends_with: ID
   id_not_ends_with: ID
+  createdAt: DateTime
+  createdAt_not: DateTime
+  createdAt_in: [DateTime!]
+  createdAt_not_in: [DateTime!]
+  createdAt_lt: DateTime
+  createdAt_lte: DateTime
+  createdAt_gt: DateTime
+  createdAt_gte: DateTime
+  updatedAt: DateTime
+  updatedAt_not: DateTime
+  updatedAt_in: [DateTime!]
+  updatedAt_not_in: [DateTime!]
+  updatedAt_lt: DateTime
+  updatedAt_lte: DateTime
+  updatedAt_gt: DateTime
+  updatedAt_gte: DateTime
   projectType: String
   projectType_not: String
   projectType_in: [String!]

--- a/src/schema/generated/prisma-client/prisma.graphql
+++ b/src/schema/generated/prisma-client/prisma.graphql
@@ -3376,6 +3376,7 @@ type VideoProject {
   team: Team
   status: ProjectPublishStatus
   visibility: ProjectVisibility
+  protectImages: Boolean
   units(where: VideoUnitWhereInput, orderBy: VideoUnitOrderByInput, skip: Int, after: String, before: String, first: Int, last: Int): [VideoUnit!]
   supportFiles(where: SupportFileWhereInput, orderBy: SupportFileOrderByInput, skip: Int, after: String, before: String, first: Int, last: Int): [SupportFile!]
   thumbnails(where: ImageFileWhereInput, orderBy: ImageFileOrderByInput, skip: Int, after: String, before: String, first: Int, last: Int): [ImageFile!]
@@ -3398,6 +3399,7 @@ input VideoProjectCreateInput {
   team: TeamCreateOneInput
   status: ProjectPublishStatus
   visibility: ProjectVisibility
+  protectImages: Boolean
   units: VideoUnitCreateManyInput
   supportFiles: SupportFileCreateManyInput
   thumbnails: ImageFileCreateManyInput
@@ -3431,6 +3433,8 @@ enum VideoProjectOrderByInput {
   status_DESC
   visibility_ASC
   visibility_DESC
+  protectImages_ASC
+  protectImages_DESC
 }
 
 type VideoProjectPreviousValues {
@@ -3444,6 +3448,7 @@ type VideoProjectPreviousValues {
   author: String
   status: ProjectPublishStatus
   visibility: ProjectVisibility
+  protectImages: Boolean
 }
 
 type VideoProjectSubscriptionPayload {
@@ -3473,6 +3478,7 @@ input VideoProjectUpdateInput {
   team: TeamUpdateOneInput
   status: ProjectPublishStatus
   visibility: ProjectVisibility
+  protectImages: Boolean
   units: VideoUnitUpdateManyInput
   supportFiles: SupportFileUpdateManyInput
   thumbnails: ImageFileUpdateManyInput
@@ -3488,6 +3494,7 @@ input VideoProjectUpdateManyMutationInput {
   author: String
   status: ProjectPublishStatus
   visibility: ProjectVisibility
+  protectImages: Boolean
 }
 
 input VideoProjectWhereInput {
@@ -3600,6 +3607,8 @@ input VideoProjectWhereInput {
   visibility_not: ProjectVisibility
   visibility_in: [ProjectVisibility!]
   visibility_not_in: [ProjectVisibility!]
+  protectImages: Boolean
+  protectImages_not: Boolean
   units_every: VideoUnitWhereInput
   units_some: VideoUnitWhereInput
   units_none: VideoUnitWhereInput

--- a/src/schema/generated/prisma-client/prisma.graphql
+++ b/src/schema/generated/prisma-client/prisma.graphql
@@ -26,6 +26,10 @@ type AggregateSupportFile {
   count: Int!
 }
 
+type AggregateSupportFileUse {
+  count: Int!
+}
+
 type AggregateTag {
   count: Int!
 }
@@ -352,6 +356,7 @@ type ImageFile {
   caption: String
   filename: String
   filetype: String
+  use: ImageUse
   md5: String
   url: String
 }
@@ -370,6 +375,7 @@ input ImageFileCreateInput {
   caption: String
   filename: String
   filetype: String
+  use: ImageUseCreateOneInput
   md5: String
   url: String
 }
@@ -585,6 +591,7 @@ input ImageFileUpdateDataInput {
   caption: String
   filename: String
   filetype: String
+  use: ImageUseUpdateOneInput
   md5: String
   url: String
 }
@@ -597,6 +604,7 @@ input ImageFileUpdateInput {
   caption: String
   filename: String
   filetype: String
+  use: ImageUseUpdateOneInput
   md5: String
   url: String
 }
@@ -765,6 +773,7 @@ input ImageFileWhereInput {
   filetype_not_starts_with: String
   filetype_ends_with: String
   filetype_not_ends_with: String
+  use: ImageUseWhereInput
   md5: String
   md5_not: String
   md5_in: [String!]
@@ -817,6 +826,11 @@ input ImageUseCreateInput {
   name: String!
 }
 
+input ImageUseCreateOneInput {
+  create: ImageUseCreateInput
+  connect: ImageUseWhereUniqueInput
+}
+
 type ImageUseEdge {
   node: ImageUse!
   cursor: String!
@@ -856,12 +870,30 @@ input ImageUseSubscriptionWhereInput {
   NOT: [ImageUseSubscriptionWhereInput!]
 }
 
+input ImageUseUpdateDataInput {
+  name: String
+}
+
 input ImageUseUpdateInput {
   name: String
 }
 
 input ImageUseUpdateManyMutationInput {
   name: String
+}
+
+input ImageUseUpdateOneInput {
+  create: ImageUseCreateInput
+  update: ImageUseUpdateDataInput
+  upsert: ImageUseUpsertNestedInput
+  delete: Boolean
+  disconnect: Boolean
+  connect: ImageUseWhereUniqueInput
+}
+
+input ImageUseUpsertNestedInput {
+  update: ImageUseUpdateDataInput!
+  create: ImageUseCreateInput!
 }
 
 input ImageUseWhereInput {
@@ -900,6 +932,7 @@ input ImageUseWhereInput {
 
 input ImageUseWhereUniqueInput {
   id: ID
+  name: String
 }
 
 type Language {
@@ -1344,6 +1377,12 @@ type Mutation {
   upsertSupportFile(where: SupportFileWhereUniqueInput!, create: SupportFileCreateInput!, update: SupportFileUpdateInput!): SupportFile!
   deleteSupportFile(where: SupportFileWhereUniqueInput!): SupportFile
   deleteManySupportFiles(where: SupportFileWhereInput): BatchPayload!
+  createSupportFileUse(data: SupportFileUseCreateInput!): SupportFileUse!
+  updateSupportFileUse(data: SupportFileUseUpdateInput!, where: SupportFileUseWhereUniqueInput!): SupportFileUse
+  updateManySupportFileUses(data: SupportFileUseUpdateManyMutationInput!, where: SupportFileUseWhereInput): BatchPayload!
+  upsertSupportFileUse(where: SupportFileUseWhereUniqueInput!, create: SupportFileUseCreateInput!, update: SupportFileUseUpdateInput!): SupportFileUse!
+  deleteSupportFileUse(where: SupportFileUseWhereUniqueInput!): SupportFileUse
+  deleteManySupportFileUses(where: SupportFileUseWhereInput): BatchPayload!
   createTag(data: TagCreateInput!): Tag!
   updateTag(data: TagUpdateInput!, where: TagWhereUniqueInput!): Tag
   upsertTag(where: TagWhereUniqueInput!, create: TagCreateInput!, update: TagUpdateInput!): Tag!
@@ -1457,6 +1496,9 @@ type Query {
   supportFile(where: SupportFileWhereUniqueInput!): SupportFile
   supportFiles(where: SupportFileWhereInput, orderBy: SupportFileOrderByInput, skip: Int, after: String, before: String, first: Int, last: Int): [SupportFile]!
   supportFilesConnection(where: SupportFileWhereInput, orderBy: SupportFileOrderByInput, skip: Int, after: String, before: String, first: Int, last: Int): SupportFileConnection!
+  supportFileUse(where: SupportFileUseWhereUniqueInput!): SupportFileUse
+  supportFileUses(where: SupportFileUseWhereInput, orderBy: SupportFileUseOrderByInput, skip: Int, after: String, before: String, first: Int, last: Int): [SupportFileUse]!
+  supportFileUsesConnection(where: SupportFileUseWhereInput, orderBy: SupportFileUseOrderByInput, skip: Int, after: String, before: String, first: Int, last: Int): SupportFileUseConnection!
   tag(where: TagWhereUniqueInput!): Tag
   tags(where: TagWhereInput, orderBy: TagOrderByInput, skip: Int, after: String, before: String, first: Int, last: Int): [Tag]!
   tagsConnection(where: TagWhereInput, orderBy: TagOrderByInput, skip: Int, after: String, before: String, first: Int, last: Int): TagConnection!
@@ -1495,6 +1537,7 @@ type Subscription {
   language(where: LanguageSubscriptionWhereInput): LanguageSubscriptionPayload
   languageTranslation(where: LanguageTranslationSubscriptionWhereInput): LanguageTranslationSubscriptionPayload
   supportFile(where: SupportFileSubscriptionWhereInput): SupportFileSubscriptionPayload
+  supportFileUse(where: SupportFileUseSubscriptionWhereInput): SupportFileUseSubscriptionPayload
   tag(where: TagSubscriptionWhereInput): TagSubscriptionPayload
   team(where: TeamSubscriptionWhereInput): TeamSubscriptionPayload
   thumbnail(where: ThumbnailSubscriptionWhereInput): ThumbnailSubscriptionPayload
@@ -1516,6 +1559,7 @@ type SupportFile {
   filename: String
   filetype: String
   filesize: Float
+  use: SupportFileUse
 }
 
 type SupportFileConnection {
@@ -1531,6 +1575,7 @@ input SupportFileCreateInput {
   filename: String
   filetype: String
   filesize: Float
+  use: SupportFileUseCreateOneInput
 }
 
 input SupportFileCreateManyInput {
@@ -1698,6 +1743,7 @@ input SupportFileUpdateDataInput {
   filename: String
   filetype: String
   filesize: Float
+  use: SupportFileUseUpdateOneInput
 }
 
 input SupportFileUpdateInput {
@@ -1707,6 +1753,7 @@ input SupportFileUpdateInput {
   filename: String
   filetype: String
   filesize: Float
+  use: SupportFileUseUpdateOneInput
 }
 
 input SupportFileUpdateManyDataInput {
@@ -1750,6 +1797,130 @@ input SupportFileUpsertWithWhereUniqueNestedInput {
   where: SupportFileWhereUniqueInput!
   update: SupportFileUpdateDataInput!
   create: SupportFileCreateInput!
+}
+
+type SupportFileUse {
+  id: ID!
+  name: String!
+}
+
+type SupportFileUseConnection {
+  pageInfo: PageInfo!
+  edges: [SupportFileUseEdge]!
+  aggregate: AggregateSupportFileUse!
+}
+
+input SupportFileUseCreateInput {
+  name: String!
+}
+
+input SupportFileUseCreateOneInput {
+  create: SupportFileUseCreateInput
+  connect: SupportFileUseWhereUniqueInput
+}
+
+type SupportFileUseEdge {
+  node: SupportFileUse!
+  cursor: String!
+}
+
+enum SupportFileUseOrderByInput {
+  id_ASC
+  id_DESC
+  name_ASC
+  name_DESC
+  createdAt_ASC
+  createdAt_DESC
+  updatedAt_ASC
+  updatedAt_DESC
+}
+
+type SupportFileUsePreviousValues {
+  id: ID!
+  name: String!
+}
+
+type SupportFileUseSubscriptionPayload {
+  mutation: MutationType!
+  node: SupportFileUse
+  updatedFields: [String!]
+  previousValues: SupportFileUsePreviousValues
+}
+
+input SupportFileUseSubscriptionWhereInput {
+  mutation_in: [MutationType!]
+  updatedFields_contains: String
+  updatedFields_contains_every: [String!]
+  updatedFields_contains_some: [String!]
+  node: SupportFileUseWhereInput
+  AND: [SupportFileUseSubscriptionWhereInput!]
+  OR: [SupportFileUseSubscriptionWhereInput!]
+  NOT: [SupportFileUseSubscriptionWhereInput!]
+}
+
+input SupportFileUseUpdateDataInput {
+  name: String
+}
+
+input SupportFileUseUpdateInput {
+  name: String
+}
+
+input SupportFileUseUpdateManyMutationInput {
+  name: String
+}
+
+input SupportFileUseUpdateOneInput {
+  create: SupportFileUseCreateInput
+  update: SupportFileUseUpdateDataInput
+  upsert: SupportFileUseUpsertNestedInput
+  delete: Boolean
+  disconnect: Boolean
+  connect: SupportFileUseWhereUniqueInput
+}
+
+input SupportFileUseUpsertNestedInput {
+  update: SupportFileUseUpdateDataInput!
+  create: SupportFileUseCreateInput!
+}
+
+input SupportFileUseWhereInput {
+  id: ID
+  id_not: ID
+  id_in: [ID!]
+  id_not_in: [ID!]
+  id_lt: ID
+  id_lte: ID
+  id_gt: ID
+  id_gte: ID
+  id_contains: ID
+  id_not_contains: ID
+  id_starts_with: ID
+  id_not_starts_with: ID
+  id_ends_with: ID
+  id_not_ends_with: ID
+  name: String
+  name_not: String
+  name_in: [String!]
+  name_not_in: [String!]
+  name_lt: String
+  name_lte: String
+  name_gt: String
+  name_gte: String
+  name_contains: String
+  name_not_contains: String
+  name_starts_with: String
+  name_not_starts_with: String
+  name_ends_with: String
+  name_not_ends_with: String
+  AND: [SupportFileUseWhereInput!]
+  OR: [SupportFileUseWhereInput!]
+  NOT: [SupportFileUseWhereInput!]
+}
+
+input SupportFileUseWhereUniqueInput {
+  id: ID
+  name: String
 }
 
 input SupportFileWhereInput {
@@ -1848,6 +2019,7 @@ input SupportFileWhereInput {
   filesize_lte: Float
   filesize_gt: Float
   filesize_gte: Float
+  use: SupportFileUseWhereInput
   AND: [SupportFileWhereInput!]
   OR: [SupportFileWhereInput!]
   NOT: [SupportFileWhereInput!]
@@ -2930,7 +3102,7 @@ type VideoFile {
   bitrate: Float
   filesize: Float
   dimensions: Dimensions
-  stream: VideoStream
+  stream(where: VideoStreamWhereInput, orderBy: VideoStreamOrderByInput, skip: Int, after: String, before: String, first: Int, last: Int): [VideoStream!]
 }
 
 type VideoFileConnection {
@@ -2952,7 +3124,7 @@ input VideoFileCreateInput {
   bitrate: Float
   filesize: Float
   dimensions: DimensionsCreateOneInput
-  stream: VideoStreamCreateOneInput
+  stream: VideoStreamCreateManyInput
 }
 
 input VideoFileCreateManyInput {
@@ -3162,7 +3334,7 @@ input VideoFileUpdateDataInput {
   bitrate: Float
   filesize: Float
   dimensions: DimensionsUpdateOneInput
-  stream: VideoStreamUpdateOneInput
+  stream: VideoStreamUpdateManyInput
 }
 
 input VideoFileUpdateInput {
@@ -3178,7 +3350,7 @@ input VideoFileUpdateInput {
   bitrate: Float
   filesize: Float
   dimensions: DimensionsUpdateOneInput
-  stream: VideoStreamUpdateOneInput
+  stream: VideoStreamUpdateManyInput
 }
 
 input VideoFileUpdateManyDataInput {
@@ -3354,7 +3526,9 @@ input VideoFileWhereInput {
   filesize_gt: Float
   filesize_gte: Float
   dimensions: DimensionsWhereInput
-  stream: VideoStreamWhereInput
+  stream_every: VideoStreamWhereInput
+  stream_some: VideoStreamWhereInput
+  stream_none: VideoStreamWhereInput
   AND: [VideoFileWhereInput!]
   OR: [VideoFileWhereInput!]
   NOT: [VideoFileWhereInput!]
@@ -3657,9 +3831,9 @@ input VideoStreamCreateInput {
   embedUrl: String
 }
 
-input VideoStreamCreateOneInput {
-  create: VideoStreamCreateInput
-  connect: VideoStreamWhereUniqueInput
+input VideoStreamCreateManyInput {
+  create: [VideoStreamCreateInput!]
+  connect: [VideoStreamWhereUniqueInput!]
 }
 
 type VideoStreamEdge {
@@ -3687,6 +3861,68 @@ type VideoStreamPreviousValues {
   site: String
   url: String
   embedUrl: String
+}
+
+input VideoStreamScalarWhereInput {
+  id: ID
+  id_not: ID
+  id_in: [ID!]
+  id_not_in: [ID!]
+  id_lt: ID
+  id_lte: ID
+  id_gt: ID
+  id_gte: ID
+  id_contains: ID
+  id_not_contains: ID
+  id_starts_with: ID
+  id_not_starts_with: ID
+  id_ends_with: ID
+  id_not_ends_with: ID
+  site: String
+  site_not: String
+  site_in: [String!]
+  site_not_in: [String!]
+  site_lt: String
+  site_lte: String
+  site_gt: String
+  site_gte: String
+  site_contains: String
+  site_not_contains: String
+  site_starts_with: String
+  site_not_starts_with: String
+  site_ends_with: String
+  site_not_ends_with: String
+  url: String
+  url_not: String
+  url_in: [String!]
+  url_not_in: [String!]
+  url_lt: String
+  url_lte: String
+  url_gt: String
+  url_gte: String
+  url_contains: String
+  url_not_contains: String
+  url_starts_with: String
+  url_not_starts_with: String
+  url_ends_with: String
+  url_not_ends_with: String
+  embedUrl: String
+  embedUrl_not: String
+  embedUrl_in: [String!]
+  embedUrl_not_in: [String!]
+  embedUrl_lt: String
+  embedUrl_lte: String
+  embedUrl_gt: String
+  embedUrl_gte: String
+  embedUrl_contains: String
+  embedUrl_not_contains: String
+  embedUrl_starts_with: String
+  embedUrl_not_starts_with: String
+  embedUrl_ends_with: String
+  embedUrl_not_ends_with: String
+  AND: [VideoStreamScalarWhereInput!]
+  OR: [VideoStreamScalarWhereInput!]
+  NOT: [VideoStreamScalarWhereInput!]
 }
 
 type VideoStreamSubscriptionPayload {
@@ -3719,22 +3955,41 @@ input VideoStreamUpdateInput {
   embedUrl: String
 }
 
+input VideoStreamUpdateManyDataInput {
+  site: String
+  url: String
+  embedUrl: String
+}
+
+input VideoStreamUpdateManyInput {
+  create: [VideoStreamCreateInput!]
+  update: [VideoStreamUpdateWithWhereUniqueNestedInput!]
+  upsert: [VideoStreamUpsertWithWhereUniqueNestedInput!]
+  delete: [VideoStreamWhereUniqueInput!]
+  connect: [VideoStreamWhereUniqueInput!]
+  disconnect: [VideoStreamWhereUniqueInput!]
+  deleteMany: [VideoStreamScalarWhereInput!]
+  updateMany: [VideoStreamUpdateManyWithWhereNestedInput!]
+}
+
 input VideoStreamUpdateManyMutationInput {
   site: String
   url: String
   embedUrl: String
 }
 
-input VideoStreamUpdateOneInput {
-  create: VideoStreamCreateInput
-  update: VideoStreamUpdateDataInput
-  upsert: VideoStreamUpsertNestedInput
-  delete: Boolean
-  disconnect: Boolean
-  connect: VideoStreamWhereUniqueInput
+input VideoStreamUpdateManyWithWhereNestedInput {
+  where: VideoStreamScalarWhereInput!
+  data: VideoStreamUpdateManyDataInput!
 }
 
-input VideoStreamUpsertNestedInput {
+input VideoStreamUpdateWithWhereUniqueNestedInput {
+  where: VideoStreamWhereUniqueInput!
+  data: VideoStreamUpdateDataInput!
+}
+
+input VideoStreamUpsertWithWhereUniqueNestedInput {
+  where: VideoStreamWhereUniqueInput!
   update: VideoStreamUpdateDataInput!
   create: VideoStreamCreateInput!
 }
@@ -3807,6 +4062,8 @@ input VideoStreamWhereUniqueInput {
 
 type VideoUnit {
   id: ID!
+  createdAt: DateTime!
+  updatedAt: DateTime!
   language: Language
   title: String!
   descPublic: String
@@ -3845,18 +4102,20 @@ type VideoUnitEdge {
 enum VideoUnitOrderByInput {
   id_ASC
   id_DESC
-  title_ASC
-  title_DESC
-  descPublic_ASC
-  descPublic_DESC
   createdAt_ASC
   createdAt_DESC
   updatedAt_ASC
   updatedAt_DESC
+  title_ASC
+  title_DESC
+  descPublic_ASC
+  descPublic_DESC
 }
 
 type VideoUnitPreviousValues {
   id: ID!
+  createdAt: DateTime!
+  updatedAt: DateTime!
   title: String!
   descPublic: String
 }
@@ -3876,6 +4135,22 @@ input VideoUnitScalarWhereInput {
   id_not_starts_with: ID
   id_ends_with: ID
   id_not_ends_with: ID
+  createdAt: DateTime
+  createdAt_not: DateTime
+  createdAt_in: [DateTime!]
+  createdAt_not_in: [DateTime!]
+  createdAt_lt: DateTime
+  createdAt_lte: DateTime
+  createdAt_gt: DateTime
+  createdAt_gte: DateTime
+  updatedAt: DateTime
+  updatedAt_not: DateTime
+  updatedAt_in: [DateTime!]
+  updatedAt_not_in: [DateTime!]
+  updatedAt_lt: DateTime
+  updatedAt_lte: DateTime
+  updatedAt_gt: DateTime
+  updatedAt_gte: DateTime
   title: String
   title_not: String
   title_in: [String!]
@@ -3999,6 +4274,22 @@ input VideoUnitWhereInput {
   id_not_starts_with: ID
   id_ends_with: ID
   id_not_ends_with: ID
+  createdAt: DateTime
+  createdAt_not: DateTime
+  createdAt_in: [DateTime!]
+  createdAt_not_in: [DateTime!]
+  createdAt_lt: DateTime
+  createdAt_lte: DateTime
+  createdAt_gt: DateTime
+  createdAt_gte: DateTime
+  updatedAt: DateTime
+  updatedAt_not: DateTime
+  updatedAt_in: [DateTime!]
+  updatedAt_not_in: [DateTime!]
+  updatedAt_lt: DateTime
+  updatedAt_lte: DateTime
+  updatedAt_gt: DateTime
+  updatedAt_gte: DateTime
   language: LanguageWhereInput
   title: String
   title_not: String
@@ -4170,4 +4461,5 @@ input VideoUseWhereInput {
 
 input VideoUseWhereUniqueInput {
   id: ID
+  name: String
 }


### PR DESCRIPTION
1247 - Update GraphQL type resolvers to accept args
1249 - Add createdAt and updatedAt fields to GraphQL types

Also includes:
- Making `VideoFile` `stream` field accept an array of `VideoStream`s
- Adding `use` field to the `ImageFile` type
- Creating `SupportFileUse` type & adding it as `use` field to `SupportFile`
- Adding `createdAt` & `updatedAt` to `VideoUnit`
- Making `name` field `@unique` for `VideoUse`, `ImageUse`, & `SupportFileUse` (`Language` `locale` was already `@unique`)