### PR TITLE
CDP-2136: Public/Internal Description is not updating on Commons when you edit with an empty value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ _This sections lists changes committed since most recent release_
 
 **Changed:**
 - Pass pagination arguments to package resolver
+- Adjust conditional check for public and internal description content in the `transformGraphic` function to accept all string values
 
 # [4.1.1](2020-05-22)
 **Added:**

--- a/src/services/es/graphic/transform.js
+++ b/src/services/es/graphic/transform.js
@@ -134,11 +134,11 @@ const transformGraphic = graphicProject => {
     tags: transformTaxonomy( tags, 'en-us' ),
   };
 
-  if ( descPublic && descPublic.content ) {
+  if ( descPublic && typeof descPublic.content === 'string' ) {
     esData.descPublic = transformDesc( descPublic );
   }
 
-  if ( descInternal && descInternal.content ) {
+  if ( descInternal && typeof descInternal.content === 'string' ) {
     esData.descInternal = transformDesc( descInternal );
   }
 


### PR DESCRIPTION
Adjusts the conditional check for public and internal description content in the `transformGraphic` function to accept all string values. Previously, the condition checked for a falsy value for `descPublic.content` and `descInternal.content`, which resulted in `descPublic` and `descInternal` being omitted from the `esData` object for empty string values.