### PR TITLE
CDP-2146: Do not display English in video preview download modal if all of the English unit's videos are Clean

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ _This sections lists changes committed since most recent release_
 
 **Added:**
 - Clean video to uses.csv
+- The use field to the `transformVideoFile` function
 
 # [5.0.0](https://github.com/IIP-Design/content-commons-server/compare/v4.1.1...v5.0.0) (2020-07-10)
  

--- a/src/services/es/video/transform.js
+++ b/src/services/es/video/transform.js
@@ -117,6 +117,7 @@ const transformTaxonomy = ( taxonomyTerms, unitLanguage ) => {
 const transformVideoFile = file => {
   const source = {
     burnedInCaptions: file.videoBurnedInStatus !== 'CLEAN',
+    use: file.use.name,
     downloadUrl: maybeGetUrlToProdS3( file.url ),
     streamUrl: [],
     stream: null,


### PR DESCRIPTION
* Addresses CDP-2145, which also needs the use field for the new "For Translation" tab in the video preview download modal
* Adds a `use` field to the `transformVideoFile` function
* see also: [PR #87 cdp-public-api](https://github.com/IIP-Design/cdp-public-api/pull/87)