### PR TITLE
CDP-2304: Add the playbook and toolkit data models

### DIFF
--- a/prisma/datamodel.prisma
+++ b/prisma/datamodel.prisma
@@ -158,6 +158,7 @@ type Language {
 type PolicyPriority {
   id: ID! @id
   name: String! @unique
+  theme: String
 }
 
 # translations prop required as we need at least the English translation to create a category

--- a/prisma/datamodel.prisma
+++ b/prisma/datamodel.prisma
@@ -22,6 +22,8 @@ enum ProjectType {
 
 enum PackageType {
   DAILY_GUIDANCE
+  TOOLKIT
+  PLAYBOOK
 }
 
 enum VideoBurnedInStatus {
@@ -153,6 +155,11 @@ type Language {
   nativeName: String!
 }
 
+type PolicyPriority {
+  id: ID! @id
+  name: String! @unique
+}
+
 # translations prop required as we need at least the English translation to create a category
 type Category {
   id: ID! @id
@@ -164,6 +171,7 @@ type Tag {
   id: ID! @id
   translations: [LanguageTranslation!]!
 }
+
 
 type LanguageTranslation {
   id: ID! @id
@@ -202,6 +210,46 @@ type Package {
   categories: [Category]
   tags: [Tag]
   documents: [DocumentFile] 
+}
+
+type Playbook {
+  id: ID! @id
+  createdAt: DateTime! @createdAt
+  updatedAt: DateTime! @updatedAt
+  publishedAt: DateTime
+  type: PackageType!
+  title: String!
+  assetPath: String
+  author: User
+  team: Team
+  desc:  String
+  content: DocumentConversionFormat
+  status: PublishStatus @default(value: DRAFT)
+  visibility: Visibility @default(value: INTERNAL)
+  policy: PolicyPriority
+  categories: [Category]
+  tags: [Tag]
+  supportFiles: [SupportFile] 
+}
+
+type Toolkit {
+  id: ID! @id
+  createdAt: DateTime! @createdAt
+  updatedAt: DateTime! @updatedAt
+  publishedAt: DateTime
+  type: PackageType!
+  title: String!
+  assetPath: String
+  author: User
+  team: Team
+  desc:  String
+  content: DocumentConversionFormat
+  status: PublishStatus @default(value: DRAFT)
+  visibility: Visibility @default(value: INTERNAL)
+  policy: PolicyPriority
+  categories: [Category]
+  tags: [Tag]
+  supportFiles: [SupportFile] 
 }
 
 type GraphicProject {


### PR DESCRIPTION
Created the `Playbook` and `Toolkit` data structures as well as the `PolicyPriority` data structure.

Since the Playbook/Toolkit types are so similar to the Package data type, I do have some concerns with this approach. The alternative solution would be to add additional fields to the Package type to support both Playbooks/Toolkits:
```
type Package {
  id: ID! @id
  createdAt: DateTime! @createdAt
  updatedAt: DateTime! @updatedAt
  publishedAt: DateTime
  type: PackageType!
  title: String!
  assetPath: String
  author: User
  team: Team
  desc:  String
  content: DocumentConversionFormat
  status: PublishStatus @default(value: DRAFT)
  visibility: Visibility @default(value: INTERNAL)
  categories: [Category]
  tags: [Tag]
  policy: PolicyPriority
  documents: [DocumentFile]
  supportFiles: [SupportFile]  
}
```

NOTE: we could also create a single data type to support both Playbooks and Toolkits since they are essential the same 

Pros/Cons for creating separate data types

Pros

- easier to customize data type w/o adding unused fields to Packages
- easier to use data type extensions if available
- will not interfere with Package functionality
- will not have to check the Package `type` field for permissions as opposed to simply checking the base type, check for Package only as opposed to check for Package and then for Package type, e.g. Playbook
- keeps package types separate and thus offers more flexibility

Cons

- is not DRY, lots of code duplication
- will need to write additional resolvers for Playbooks and Toolkits as opposed to simply extending the current functions
- will need to write additional api publish handlers as opposed to simply extending the current functions
- will need to create elastic indices for Playbooks and Toolkits
- simply more code to manage


