### PR TITLE
CDP 2379 - Add playbook publish and unpublish functionality

### DIFF
--- a/src/fragments/playbook.js
+++ b/src/fragments/playbook.js
@@ -1,0 +1,82 @@
+export const PLAYBOOK_FULL = `
+  fragment PLAYBOOK_FULL on Playbook {
+    id
+    createdAt
+    updatedAt
+    publishedAt
+    type
+    title
+    desc
+    status
+    visibility
+    assetPath
+    author {
+      id
+      firstName
+      lastName
+      email
+      permissions
+    }
+    team {
+      id
+      name
+      organization
+    } 
+    content {
+      id
+      rawText
+      html
+      markdown
+    }
+    policy {
+      id
+      name
+      theme
+    }
+    categories {
+      id 
+      translations {
+        name
+        language { 
+          id 
+          languageCode 
+          locale 
+          textDirection 
+          displayName 
+          nativeName 
+        }
+      }
+    }
+    tags {
+      id 
+      translations {
+        name
+        language { 
+          id 
+          languageCode 
+          locale 
+          textDirection 
+          displayName 
+          nativeName 
+        }
+      }
+    }
+    supportFiles {
+      id
+      language { 
+        id 
+        languageCode 
+        locale 
+        textDirection 
+        displayName 
+        nativeName 
+      }
+      url 
+      filename
+      filetype
+      filename
+      visibility 
+      editable
+    }
+  }
+`;

--- a/src/schema/package.graphql
+++ b/src/schema/package.graphql
@@ -35,4 +35,7 @@ type Mutation {
   createPlaybook(data: PlaybookCreateInput!): Playbook!
   deletePlaybook(id: ID!): Playbook!
   updatePlaybook(data: PlaybookUpdateInput!, where: PlaybookWhereUniqueInput!): Playbook
+  playbookExists(where: PlaybookWhereInput): Boolean!
+  publishPlaybook(id: ID!): Playbook
+  unpublishPlaybook(id: ID!): Playbook
 }

--- a/src/services/es/common/transform.js
+++ b/src/services/es/common/transform.js
@@ -1,0 +1,80 @@
+import { getUrlToProdS3 } from '..';
+
+export const english = {
+  language_code: 'en',
+  locale: 'en-us',
+  text_direction: 'ltr',
+  display_name: 'English',
+  native_name: 'English',
+};
+
+export const transformContent = content => {
+  const tree = {};
+
+  if ( content.rawText ) {
+    tree.rawText = content.rawText;
+  }
+  if ( content.html ) {
+    tree.html = content.html;
+  }
+  if ( content.markdown ) {
+    tree.markdown = content.markdown;
+  }
+
+  return tree;
+};
+
+export const transformLanguage = language => ( {
+  language_code: language.languageCode,
+  locale: language.locale,
+  text_direction: language.textDirection.toLowerCase(),
+  display_name: language.displayName,
+  native_name: language.nativeName,
+} );
+
+/**
+ * Convert a taxonomy field (categories/tags) into translated ES terms
+ * based on the provided language local.
+ *
+ * @param  {Array} taxonomyTerms
+ * @param {String} locale
+ * @returns {Array}
+ */
+export const transformTaxonomy = ( taxonomyTerms, locale ) => {
+  if ( !taxonomyTerms || !taxonomyTerms.length ) return [];
+  const terms = [];
+
+  taxonomyTerms.forEach( ( { translations = [] } ) => {
+    const translation = translations.find( trans => trans.language.locale === locale );
+
+    if ( translation ) {
+      terms.push( translation.name );
+    }
+  } );
+
+  return terms;
+};
+
+export const transformSupportFile = file => {
+  const {
+    title,
+    language,
+    filename,
+    filetype,
+    visibility,
+    editable,
+    url,
+  } = file;
+
+  const supportFile = {
+    title,
+    visibility,
+    editable: editable || false,
+    filename,
+    filetype,
+    url: getUrlToProdS3( url ),
+    language: transformLanguage( language ),
+  };
+
+  return supportFile;
+};

--- a/src/services/es/graphic/transform.js
+++ b/src/services/es/graphic/transform.js
@@ -1,37 +1,9 @@
+import {
+  transformLanguage,
+  transformSupportFile,
+  transformTaxonomy,
+} from '../common/transform';
 import { getUrlToProdS3 } from '..';
-
-const transformLanguage = language => ( {
-  language_code: language.languageCode,
-  locale: language.locale,
-  text_direction: language.textDirection.toLowerCase(),
-  display_name: language.displayName,
-  native_name: language.nativeName,
-} );
-
-
-const transformSupportFile = file => {
-  const {
-    title,
-    language,
-    filename,
-    filetype,
-    visibility,
-    editable,
-    url,
-  } = file;
-
-  const supportFile = {
-    title,
-    visibility,
-    editable: editable || false,
-    filename,
-    filetype,
-    url: getUrlToProdS3( url ),
-    language: transformLanguage( language ),
-  };
-
-  return supportFile;
-};
 
 const transformImage = ( file, alt ) => {
   const { title,
@@ -63,28 +35,6 @@ const transformImage = ( file, alt ) => {
   return image;
 };
 
-
-/**
- * Convert a taxonomy field (categories/tags) into translated ES terms based on the provided language.
- *
- * @param taxonomyTerms
- * @param language
- * @returns {Array}
- */
-const transformTaxonomy = ( taxonomyTerms, locale ) => {
-  if ( !taxonomyTerms || !taxonomyTerms.length ) return [];
-  const terms = [];
-
-  taxonomyTerms.forEach( ( { translations = [] } ) => {
-    const translation = translations.find( trans => trans.language.locale === locale );
-
-    if ( translation ) {
-      terms.push( translation.name );
-    }
-  } );
-
-  return terms;
-};
 
 const transformDesc = desc => {
   const { content, visibility } = desc;

--- a/src/services/es/package/transform.js
+++ b/src/services/es/package/transform.js
@@ -1,43 +1,6 @@
+import { english, transformTaxonomy, transformLanguage } from '../common/transform';
 import { getUrlToProdS3 } from '..';
 
-const english = {
-  language_code: 'en',
-  locale: 'en-us',
-  text_direction: 'ltr',
-  display_name: 'English',
-  native_name: 'English',
-};
-
-
-/**
- * Convert a taxonomy field (categories/tags) into translated ES terms based on the provided language.
- *
- * @param taxonomyTerms
- * @param language
- * @returns {Array}
- */
-const transformTaxonomy = ( taxonomyTerms, language ) => {
-  if ( !taxonomyTerms || !taxonomyTerms.length ) return [];
-  const terms = [];
-
-  taxonomyTerms.forEach( ( { translations = [] } ) => {
-    const translation = translations.find( trans => trans.language.id === language.id );
-
-    if ( translation ) {
-      terms.push( translation.name );
-    }
-  } );
-
-  return terms;
-};
-
-const transformLanguage = language => ( {
-  language_code: language.languageCode,
-  locale: language.locale,
-  text_direction: language.textDirection.toLowerCase(),
-  display_name: language.displayName,
-  native_name: language.nativeName,
-} );
 
 const transformDocument = ( document, team ) => {
   const now = new Date().toISOString();

--- a/src/services/es/playbook/transform.js
+++ b/src/services/es/playbook/transform.js
@@ -1,0 +1,60 @@
+import {
+  english,
+  transformContent,
+  transformSupportFile,
+  transformTaxonomy,
+} from '../common/transform';
+
+/**
+ * Transforms data from a GraphQL Playbook into a Playbook format
+ * accepted by the Public API for Elastic Search.
+ *
+ * @param playbook
+ * @returns object
+ */
+const transformPlaybook = playbook => {
+  const now = new Date().toISOString();
+  const {
+    id, createdAt, title, visibility, team, desc, policy, content, categories, tags,
+  } = playbook;
+
+  const esData = {
+    id,
+    site: process.env.INDEXING_DOMAIN,
+    title: title || '',
+    type: 'playbook',
+    published: now,
+    modified: now,
+    created: createdAt,
+    visibility,
+    language: english,
+    desc,
+    owner: team && team.name ? team.name : '',
+    categories: transformTaxonomy( categories, 'en-us' ),
+    tags: transformTaxonomy( tags, 'en-us' ),
+    supportFiles: [],
+  };
+
+  if ( policy ) {
+    esData.policy = {
+      name: policy.name,
+      theme: policy.theme,
+    };
+  }
+
+  if ( content ) {
+    esData.content = transformContent( content );
+  }
+
+  if ( playbook.supportFiles && playbook.supportFiles.length ) {
+    esData.supportFiles = playbook.supportFiles.map( file => transformSupportFile( file ) );
+  }
+
+  console.log( 'playbook', JSON.stringify( playbook, null, 2 ) );
+  console.log( 'esdata', JSON.stringify( esData, null, 2 ) );
+
+  return esData;
+};
+
+
+export default transformPlaybook;

--- a/src/services/es/video/transform.js
+++ b/src/services/es/video/transform.js
@@ -1,4 +1,5 @@
 import { getVimeoId, getYouTubeId } from '../../../lib/projectParser';
+import { transformLanguage } from '../common/transform';
 import { maybeGetUrlToProdS3 } from '..';
 
 const ENGLISH_LOCALE = 'en-us';
@@ -17,14 +18,6 @@ function getEmbedUrl( url ) {
 
   return url;
 }
-
-const transformLanguage = language => ( {
-  language_code: language.languageCode,
-  locale: language.locale,
-  text_direction: language.textDirection.toLowerCase(),
-  display_name: language.displayName,
-  native_name: language.nativeName,
-} );
 
 const transformThumbnail = image => ( {
   url: maybeGetUrlToProdS3( image.url ),

--- a/src/services/rabbitmq/index.js
+++ b/src/services/rabbitmq/index.js
@@ -2,6 +2,7 @@ import initialize, { getConsumerChannel } from './initialize';
 import video from './video';
 import graphic from './graphic';
 import pkg from './package';
+import playbook from './playbook';
 
 const consumePublishSuccess = async () => {
   const channel = await getConsumerChannel();
@@ -19,6 +20,8 @@ const consumePublishSuccess = async () => {
           pkg.consumePublishSuccess( channel, msg );
         } else if ( routingKey.includes( 'graphic' ) ) {
           graphic.consumeSuccess( channel, msg );
+        } else if ( routingKey.includes( 'playbook' ) ) {
+          playbook.consumeSuccess( channel, msg );
         }
         // TODO handle not having handler for routing keu
       }
@@ -65,7 +68,10 @@ const consumeErrors = async () => {
           pkg.consumeError( channel, msg );
         } else if ( routingKey.includes( 'graphic' ) ) {
           graphic.consumeError( channel, msg );
+        } else if ( routingKey.includes( 'playbook' ) ) {
+          playbook.consumeError( channel, msg );
         }
+
         // TODO handle not having error handler for routing key
       }
       // TODO handle no routing key

--- a/src/services/rabbitmq/package.js
+++ b/src/services/rabbitmq/package.js
@@ -10,7 +10,7 @@ const updateDatabase = async ( id, data ) => {
  *
  * @param {string} id project id
  * @param {object} data project data
- * @param {object} status project stastus
+ * @param {object} status project status
  * @param {object} projectDirectory path to S3 dir
  *
  * NOTE: function name follows [exchange][routing key] convention

--- a/src/services/rabbitmq/playbook.js
+++ b/src/services/rabbitmq/playbook.js
@@ -1,0 +1,112 @@
+import { publishToChannel, parseMessage } from './util';
+import { prisma } from '../../schema/generated/prisma-client';
+
+
+const updateDatabase = async ( id, data ) => prisma.updatePlaybook( { data, where: { id } } )
+  .catch( err => console.error( err ) );
+
+
+/**
+ * Put publish creation request on publish.create queue
+ *
+ * @param {string} id project id
+ * @param {object} data project data
+ * @param {object} status project status
+ * @param {object} projectDirectory path to S3 dir
+ *
+ * NOTE: function name follows [exchange][routing key] convention
+ */
+export const publishCreate = async ( id, data, status, projectDirectory ) => {
+  console.log( '[x] PUBLISHING a publish PLAYBOOK create request' );
+
+  await publishToChannel( {
+    exchangeName: 'publish',
+    routingKey: 'create.playbook',
+    data: {
+      projectId: id,
+      projectStatus: status,
+      projectJson: JSON.stringify( data ),
+      projectDirectory,
+    },
+  } );
+};
+
+
+/**
+ * Put publish deletion request on publish.delete queue
+ *
+ * @param {string} id project id to delete
+ * @param {object} projectDirectory path to S3 dir
+ *
+ */
+export const publishDelete = async ( id, projectDirectory ) => {
+  console.log( '[x] PUBLISHING a publish PLAYBOOK delete request' );
+
+  await publishToChannel( {
+    exchangeName: 'publish',
+    routingKey: 'delete.playbook',
+    data: {
+      projectId: id,
+      projectDirectory,
+    },
+  } );
+};
+
+
+export const publishUpdate = async ( id, data, status, projectDirectory ) => {
+  console.log( '[x] PUBLISHING a publish PLAYBOOK update request' );
+
+  await publishToChannel( {
+    exchangeName: 'publish',
+    routingKey: 'update.playbook',
+    data: {
+      projectId: id,
+      projectStatus: status,
+      projectJson: JSON.stringify( data ),
+      projectDirectory,
+    },
+  } );
+};
+
+
+const consumeSuccess = async ( channel, msg ) => {
+  // 1. parse message
+  const { routingKey, data: { projectId } } = parseMessage( msg );
+  const status = routingKey.includes( '.delete' ) ? 'UNPUBLISH_SUCCESS' : 'PUBLISH_SUCCESS';
+
+  console.log( `[√] RECEIVED a publish ${routingKey} result for project ${projectId}` );
+
+  // 2. on successful result, update db with applicable status using the returned projectId
+  try {
+    updateDatabase( projectId, { status } );
+  } catch ( err ) {
+    console.log( `Error: ${err.message}` );
+  }
+
+  // 3. acknowledge message as received
+  channel.ack( msg );
+};
+
+const consumeError = async ( channel, msg ) => {
+  // 1. parse message
+  const { routingKey, data: { projectId, projectStatus } } = parseMessage( msg );
+
+  // 2. Update db with failed status to alert the client (client polls for status changes)
+  try {
+    updateDatabase( projectId, { status: projectStatus } );
+  } catch ( err ) {
+    console.log( `Error: ${err.message}` );
+  }
+
+  // 3. log error
+  const errorMessage = `Unable to process queue ${routingKey} request for project : ${projectId} `;
+
+  console.log( errorMessage );
+};
+
+const consumer = {
+  consumeSuccess,
+  consumeError,
+};
+
+export default consumer;


### PR DESCRIPTION
This PR is dependent on PR [CDP-2379](https://github.com/IIP-Design/cdp-public-api/pull/99) in the cdp-public-api repository

This PR adds publish and unpublish functionality. Specifically:

- Creates publish and unpublish resolvers
- Writes transform to put graphQL playbook data into format that adheres to elastic search playbook data structure
- Writes consumers to process publish/unpublish success and failures

In addition, puts common content type transform functions in a separate file to reduce repetitiveness