### PR TITLE
CDP-2394: Delete support files from S3 when removing from Playbook

### DIFF
--- a/src/fragments/common.js
+++ b/src/fragments/common.js
@@ -1,0 +1,27 @@
+export const SUPPORT_FILE_FULL = `
+  fragment SUPPORT_FILE_FULL on SupportFile {
+    id
+    createdAt
+    updatedAt
+    language { 
+      id 
+      languageCode 
+      locale 
+      textDirection 
+      displayName 
+      nativeName 
+    }
+    url
+    signedUrl
+    md5
+    filename
+    filetype
+    filesize
+    visibility
+    editable
+    use {
+      id
+      name
+    }
+  }
+`;

--- a/src/resolvers/Package/controller.js
+++ b/src/resolvers/Package/controller.js
@@ -6,7 +6,7 @@ const PUBLISHER_BUCKET = process.env.AWS_S3_AUTHORING_BUCKET;
 
 /**
  * Removes both the document and its associated thumbnail image
- * @param {object} ctx graphQL context ohject
+ * @param {object} ctx graphQL context object
  * @param {string} id id of document fetch
  * @returns promises array
  */
@@ -38,7 +38,7 @@ export const deleteAsset = async ( ctx, id ) => {
 
 /**
  *
- * @param {object} ctx graphQL context ohject
+ * @param {object} ctx graphQL context object
  * @param {array} assetsToDelete documents to delete
  * @returns Promise
  */

--- a/src/resolvers/Playbook/controller.js
+++ b/src/resolvers/Playbook/controller.js
@@ -1,0 +1,37 @@
+import { deleteS3Asset } from '../../services/aws/s3';
+import { SUPPORT_FILE_FULL } from '../../fragments/common';
+import { hasValidValue } from '../../lib/projectParser';
+
+const PUBLISHER_BUCKET = process.env.AWS_S3_AUTHORING_BUCKET;
+
+/**
+ * Removes an individual file from the S3 authoring bucket.
+ * @param {Object} ctx GraphQL context object.
+ * @param {string} id The id of the file to be deleted.
+ * @returns {Promise}
+ */
+export const deleteAsset = async ( ctx, id ) => {
+  const file = await ctx.prisma
+    .supportFile( { id } )
+    .$fragment( SUPPORT_FILE_FULL );
+
+  if ( file ) {
+    const { url } = file;
+
+    if ( url && hasValidValue( url ) ) {
+      return deleteS3Asset( url, PUBLISHER_BUCKET );
+    }
+  }
+};
+
+/**
+ * Iterates through an array of support files deleting each one.
+ * @param {Object} ctx GraphQL context object.
+ * @param {Object[]} assetsToDelete Files to delete.
+ * @returns {Promise}
+ */
+export const deleteAssets = async ( ctx, assetsToDelete ) => {
+  if ( Array.isArray( assetsToDelete ) ) {
+    return Promise.all( assetsToDelete.map( file => deleteAsset( ctx, file.id ) ) );
+  }
+};


### PR DESCRIPTION
Creates a support file fragment that can be reused in multiple places.

Related to, but not dependent on client [PR #307](https://github.com/IIP-Design/content-commons-client/pull/307).