### PR TITLE
CDP 2445 - Wrap remaining resolvers in authentication

### DIFF
--- a/src/resolvers/Bureau/index.js
+++ b/src/resolvers/Bureau/index.js
@@ -1,5 +1,7 @@
+import { requiresLogin } from '../../lib/authentication';
+
 const BureauResolvers = {
-  Query: {
+  Query: requiresLogin( {
     bureaus( parent, args, ctx ) {
       return ctx.prisma.bureaus( { ...args } );
     },
@@ -7,16 +9,16 @@ const BureauResolvers = {
     bureau( parent, args, ctx ) {
       return ctx.prisma.bureau( { ...args } );
     },
-  },
+  } ),
 
-  Mutation: {
+  Mutation: requiresLogin( {
     async createBureau( parent, args, ctx ) {
       const { data } = args;
       const bureau = await ctx.prisma.createBureau( { ...data } );
 
       return bureau;
     },
-  },
+  } ),
 
   Bureau: {
     offices( parent, args, ctx ) {

--- a/src/resolvers/Language/index.js
+++ b/src/resolvers/Language/index.js
@@ -1,5 +1,7 @@
+import { requiresLogin } from '../../lib/authentication';
+
 const LanguageResolvers = {
-  Query: {
+  Query: requiresLogin( {
     languages( parent, args, ctx ) {
       return ctx.prisma.languages( { ...args } );
     },
@@ -15,9 +17,9 @@ const LanguageResolvers = {
     languageTranslation( parent, args, ctx ) {
       return ctx.prisma.languageTranslation( { ...args } );
     },
-  },
+  } ),
 
-  Mutation: {
+  Mutation: requiresLogin( {
     async createLanguage( parent, args, ctx ) {
       const { data } = args;
       const language = await ctx.prisma.createLanguage( {
@@ -36,7 +38,7 @@ const LanguageResolvers = {
         where: { id },
       } );
     },
-  },
+  } ),
 
   LanguageTranslation: {
     language( parent, args, ctx ) {

--- a/src/resolvers/PolicyPriority/index.js
+++ b/src/resolvers/PolicyPriority/index.js
@@ -1,5 +1,7 @@
+import { requiresLogin } from '../../lib/authentication';
+
 const PolicyPriorityResolvers = {
-  Query: {
+  Query: requiresLogin( {
     policyPriorities( parent, args, ctx ) {
       return ctx.prisma.policyPriorities( { ...args } );
     },
@@ -7,9 +9,9 @@ const PolicyPriorityResolvers = {
     policyPriority( parent, args, ctx ) {
       return ctx.prisma.policyPriority( { ...args } );
     },
-  },
+  } ),
 
-  Mutation: {
+  Mutation: requiresLogin( {
     async createPolicyPriority( parent, args, ctx ) {
       const { data } = args;
       const policyPriority = await ctx.prisma.createPolicyPriority( { ...data } );
@@ -26,7 +28,7 @@ const PolicyPriorityResolvers = {
 
       return ctx.prisma.deletePolicyPriority( { id, name } );
     },
-  },
+  } ),
 };
 
 export default PolicyPriorityResolvers;

--- a/src/resolvers/Region/index.js
+++ b/src/resolvers/Region/index.js
@@ -1,7 +1,7 @@
 import { requiresLogin } from '../../lib/authentication';
 
 const RegionResolvers = {
-  Query: requiresLogin( {
+  Query: {
     regions( parent, args, ctx ) {
       return ctx.prisma.regions( { ...args } );
     },
@@ -17,7 +17,7 @@ const RegionResolvers = {
     country( parent, args, ctx ) {
       return ctx.prisma.country( { ...args } );
     },
-  } ),
+  },
 
   Mutation: requiresLogin( {
     async createRegion( parent, args, ctx ) {

--- a/src/resolvers/Region/index.js
+++ b/src/resolvers/Region/index.js
@@ -1,5 +1,7 @@
+import { requiresLogin } from '../../lib/authentication';
+
 const RegionResolvers = {
-  Query: {
+  Query: requiresLogin( {
     regions( parent, args, ctx ) {
       return ctx.prisma.regions( { ...args } );
     },
@@ -15,16 +17,16 @@ const RegionResolvers = {
     country( parent, args, ctx ) {
       return ctx.prisma.country( { ...args } );
     },
-  },
+  } ),
 
-  Mutation: {
+  Mutation: requiresLogin( {
     async createRegion( parent, args, ctx ) {
       const { data } = args;
       const region = await ctx.prisma.createRegion( { ...data } );
 
       return region;
     },
-  },
+  } ),
 
   Region: {
     countries( parent, args, ctx ) {

--- a/src/resolvers/Taxonomy/index.js
+++ b/src/resolvers/Taxonomy/index.js
@@ -1,5 +1,7 @@
+import { requiresLogin } from '../../lib/authentication';
+
 const TaxonomyResolvers = {
-  Query: {
+  Query: requiresLogin( {
     categories( parent, args, ctx ) {
       return ctx.prisma.categories( { ...args } );
     },
@@ -15,9 +17,9 @@ const TaxonomyResolvers = {
     tag( parent, args, ctx ) {
       return ctx.prisma.tag( { ...args } );
     },
-  },
+  } ),
 
-  Mutation: {
+  Mutation: requiresLogin( {
     async createCategory( parent, args, ctx ) {
       const { data } = args;
       const category = await ctx.prisma.createCategory( {
@@ -43,7 +45,7 @@ const TaxonomyResolvers = {
     updateTag( parent, args, ctx ) {
       return ctx.prisma.updateTag( { ...args } );
     },
-  },
+  } ),
 
   Category: {
     translations( parent, args, ctx ) {

--- a/src/resolvers/Team/index.js
+++ b/src/resolvers/Team/index.js
@@ -1,7 +1,7 @@
 import { requiresLogin } from '../../lib/authentication';
 
 const TeamResolvers = {
-  Query: {
+  Query: requiresLogin( {
     teams( parent, args, ctx ) {
       return ctx.prisma.teams( { ...args } );
     },
@@ -9,7 +9,7 @@ const TeamResolvers = {
     team( parent, args, ctx ) {
       return ctx.prisma.team( { id: args.id } );
     },
-  },
+  } ),
 
   Mutation: requiresLogin( {
     async createTeam( parent, args, ctx ) {

--- a/src/resolvers/User/index.js
+++ b/src/resolvers/User/index.js
@@ -1,12 +1,12 @@
 import { requiresLogin } from '../../lib/authentication';
 
 const UserResolvers = {
-  Query: requiresLogin( {
-    users( parent, args, ctx ) {
-      return ctx.prisma.users();
-    },
+  Query: {
+    authenticatedUser: ( parent, args, ctx ) => ctx.user,
 
-    permissionEnum( parent, args, ctx ) {
+    users: requiresLogin( ( parent, args, ctx ) => ctx.prisma.users() ),
+
+    permissionEnum: requiresLogin( ( parent, args, ctx ) => {
       const query = `
        query {
           __type(name: "Permission") {
@@ -18,8 +18,8 @@ const UserResolvers = {
       `;
 
       return ctx.prisma.$graphql( query );
-    },
-  } ),
+    } ),
+  },
 
   Mutation: requiresLogin( {
     async updateUser( parent, args, ctx ) {
@@ -37,14 +37,6 @@ const UserResolvers = {
   User: {
     team( parent, args, ctx ) {
       return ctx.prisma.user( { id: parent.id } ).team( { ...args } );
-    },
-  },
-};
-
-export const CurrentUserResolvers = {
-  Query: {
-    authenticatedUser( parent, args, ctx ) {
-      return ctx.user;
     },
   },
 };

--- a/src/resolvers/index.js
+++ b/src/resolvers/index.js
@@ -7,7 +7,7 @@ import BureauResolvers from './Bureau';
 import TaxonomyResolvers from './Taxonomy';
 import TeamResolvers from './Team';
 import PolicyPriorityResolvers from './PolicyPriority';
-import UserResolvers, { CurrentUserResolvers } from './User';
+import UserResolvers from './User';
 import UtilResolvers from './Util';
 import DocumentResolvers from './Document';
 import VideoResolvers from './Video';
@@ -18,7 +18,6 @@ import GraphicResolvers from './Graphic';
 const resolvers = merge(
   AuthResolvers,
   UtilResolvers,
-  CurrentUserResolvers,
   // SharedResolvers,
   LanguageResolvers,
   TaxonomyResolvers,


### PR DESCRIPTION
This PR wraps the Bureau, Language, PolicyPriority, Region, Taxonomy and Team queries and mutations in the `requiresLogin` authentication method. All could be wrapped as they are accessed from the authoring side only.  The frontend pulls all needed data from elasticsearch via the public API. The only exception is the Region queries.  The frontend country/region filter menu pulls countries from GraphQL but this filter is only present for Press Guidance packages which require a valid user.

In addition, I moved the `authenticatedUser` resolver back to the `UserResolvers` object and individually wrapped the `users` and `permissionEnum` in `requiresLogin`.