### PR TITLE
CDP-2469: Return filesize property to on playbook support files

### DIFF
--- a/src/fragments/playbook.js
+++ b/src/fragments/playbook.js
@@ -74,8 +74,8 @@ export const PLAYBOOK_FULL = `
       }
       url 
       filename
+      filesize
       filetype
-      filename
       visibility 
       editable
     }

--- a/src/services/es/common/transform.js
+++ b/src/services/es/common/transform.js
@@ -55,22 +55,22 @@ export const transformTaxonomy = ( taxonomyTerms, locale ) => {
   return terms;
 };
 
-export const transformSupportFile = file => {
-  const {
-    title,
-    language,
-    filename,
-    filetype,
-    visibility,
-    editable,
-    url,
-  } = file;
-
+export const transformSupportFile = ( {
+  title,
+  language,
+  filename,
+  filesize,
+  filetype,
+  visibility,
+  editable,
+  url,
+} ) => {
   const supportFile = {
     title,
     visibility,
     editable: editable || false,
     filename,
+    filesize,
     filetype,
     url: getUrlToProdS3( url ),
     language: transformLanguage( language ),

--- a/src/services/es/playbook/transform.js
+++ b/src/services/es/playbook/transform.js
@@ -9,8 +9,8 @@ import {
  * Transforms data from a GraphQL Playbook into a Playbook format
  * accepted by the Public API for Elastic Search.
  *
- * @param playbook
- * @returns object
+ * @param {Object} playbook
+ * @returns {Object}
  */
 const transformPlaybook = playbook => {
   const now = new Date().toISOString();
@@ -66,6 +66,5 @@ const transformPlaybook = playbook => {
 
   return esData;
 };
-
 
 export default transformPlaybook;


### PR DESCRIPTION
Rather than returning the filesize for a playbook support file, the `PLAYBOOK_FULL` fragment lists filename twice. This PR corrects that error and then adds the filesize to normalized support files sent to Elasticsearch.